### PR TITLE
docs: remove last shell script hook from settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,10 +42,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/observe-pre-tool.sh"
-          },
-          {
-            "type": "command",
             "command": "unimatrix-server hook PreToolUse"
           }
         ]


### PR DESCRIPTION
## Summary
- Remove `observe-pre-tool.sh` shell hook from PreToolUse in `.claude/settings.json`
- All hooks now route through `unimatrix-server hook` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)