### PR TITLE
[col-014] Design: Feature attribution fix

### DIFF
--- a/product/features/col-014/ACCEPTANCE-MAP.md
+++ b/product/features/col-014/ACCEPTANCE-MAP.md
@@ -1,0 +1,32 @@
+# col-014: Acceptance Map
+
+## Acceptance Criteria -> Test Mapping
+
+| AC# | Criterion | Test Function | Status |
+|-----|-----------|---------------|--------|
+| 1 | `col-010b` accepted | `test_is_valid_feature_id_suffixed` | Pending |
+| 2 | `col-002b` accepted | `test_is_valid_feature_id_suffixed` | Pending |
+| 3 | `nxs-001` accepted (regression) | `test_is_valid_feature_id_positive` (existing) | Pending |
+| 4 | `PROJ-123` accepted | `test_is_valid_feature_id_domain_agnostic` | Pending |
+| 5 | `sprint-7-auth` accepted | `test_is_valid_feature_id_domain_agnostic` | Pending |
+| 6 | `v2.1-migration` accepted | `test_is_valid_feature_id_domain_agnostic` | Pending |
+| 7 | `my_project-feat_1` accepted | `test_is_valid_feature_id_domain_agnostic` | Pending |
+| 8 | Empty string rejected | `test_is_valid_feature_id_negative` (existing, updated) | Pending |
+| 9 | `nohyphen` rejected | `test_is_valid_feature_id_no_hyphen` | Pending |
+| 10 | `a]b-c` rejected | `test_is_valid_feature_id_special_chars` | Pending |
+| 11 | `a b-c` rejected | `test_is_valid_feature_id_whitespace` | Pending |
+| 12 | 128/129 length boundary | `test_is_valid_feature_id_length_boundary` | Pending |
+| 13 | Existing IDs remain valid | Existing tests (regression suite) | Pending |
+| 14 | E2E attribution with `col-010b` | `test_attribute_sessions_suffixed_feature` | Pending |
+
+## Risk -> Test Mapping
+
+| Risk | Test Coverage |
+|------|---------------|
+| R-01: False positives | `test_is_valid_feature_id_domain_agnostic` + existing attribution tests |
+| R-02: Regression | `test_is_valid_feature_id_positive` + all existing tests |
+| R-03: Injection | `test_is_valid_feature_id_special_chars` |
+
+## Completion Gate
+
+All 14 AC tests pass + all existing `attribution.rs` tests pass + `cargo test -p unimatrix-observe` clean.

--- a/product/features/col-014/ALIGNMENT-REPORT.md
+++ b/product/features/col-014/ALIGNMENT-REPORT.md
@@ -1,0 +1,36 @@
+# col-014: Vision Alignment Report
+
+## Alignment Assessment
+
+### Domain Agnosticism (ASS-009) -- PASS
+
+The product vision states: "The core engine is domain-agnostic. Domain-specific behavior is confined to four server-level configuration items."
+
+The current `is_valid_feature_id` encodes a project-specific convention (`{alpha}-{digits}`) at the engine level, violating this principle. The fix removes this structural assumption and replaces it with permissive safety gating, fully aligned with domain agnosticism.
+
+### Intelligence Sharpening Milestone -- PASS
+
+col-014 is listed in Wave 1 (Critical fixes) of the Intelligence Sharpening milestone. The fix directly addresses the stated goal: "Fix `is_valid_feature_id()` (#79) to accept suffixed feature IDs." The revised scope (permissive validation) is a superset of the original requirement.
+
+### Retrospective Pipeline Integrity -- PASS
+
+The retrospective pipeline (`context_retrospective`) depends on attribution to link observation data to feature cycles. Fixing `is_valid_feature_id` restores correct feature_cycle linking for `col-010b`, `col-002b`, and any future features with non-digit suffixes.
+
+### Security Cross-Cutting -- PASS
+
+The character allowlist (ASCII alphanumeric, hyphen, underscore, dot) aligns with the product vision's input validation approach: "Content scanning (~50 injection patterns + PII), input validation (max lengths, pattern matching, no control chars)." The fix maintains safety boundaries while removing unnecessary structural constraints.
+
+## Variance Summary
+
+| Dimension | Status |
+|-----------|--------|
+| Domain agnosticism | PASS |
+| Milestone alignment | PASS |
+| Pipeline integrity | PASS |
+| Security | PASS |
+
+**Variances requiring approval**: None.
+
+## Notes
+
+The revised scope (Option 3 -- permissive gating) is more aligned with the product vision than the original Option 1 (fix suffix only). Option 1 would have replaced one project-specific convention with another (`{alpha}-{digits}{optional-alpha}`), which still violates domain agnosticism.

--- a/product/features/col-014/IMPLEMENTATION-BRIEF.md
+++ b/product/features/col-014/IMPLEMENTATION-BRIEF.md
@@ -1,0 +1,61 @@
+# col-014: Implementation Brief
+
+## Summary
+
+Replace rigid `{alpha}-{digits}` validation in `is_valid_feature_id()` with permissive character/length safety gating. Single file change in `crates/unimatrix-observe/src/attribution.rs`.
+
+## Change Specification
+
+### File: `crates/unimatrix-observe/src/attribution.rs`
+
+**Replace** lines 5-15 (`is_valid_feature_id` function):
+
+```rust
+const MAX_FEATURE_ID_LEN: usize = 128;
+
+/// Check if a string is a plausible feature ID.
+///
+/// Permissive safety gating: non-empty, reasonable length, contains a hyphen,
+/// only safe characters (ASCII alphanumeric, hyphen, underscore, dot).
+/// No leading/trailing hyphens.
+///
+/// Unimatrix is domain-agnostic (ASS-009) -- feature ID format is a
+/// project-level concern, not an engine-level concern.
+fn is_valid_feature_id(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= MAX_FEATURE_ID_LEN
+        && s.contains('-')
+        && !s.starts_with('-')
+        && !s.ends_with('-')
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
+```
+
+### Test Updates
+
+**Update** `test_is_valid_feature_id_negative`:
+- Remove `assert!(!is_valid_feature_id("col-abc"))` -- now valid under permissive rules
+- Keep: empty, `col-`, `-002` assertions
+- Add: `assert!(!is_valid_feature_id("nohyphen"))`
+
+**Add** new test functions as specified in SPECIFICATION.md (see AC traceability table).
+
+## Implementation Order
+
+1. Add `MAX_FEATURE_ID_LEN` constant
+2. Replace `is_valid_feature_id` function body
+3. Update `test_is_valid_feature_id_negative`
+4. Add new test functions
+5. Run `cargo test -p unimatrix-observe` to verify
+
+## Estimated Effort
+
+~30 minutes. Single function replacement + test updates. No cross-crate coordination needed.
+
+## Dependencies
+
+None. No schema changes, no API changes, no configuration changes.
+
+## GH Issue
+
+#79

--- a/product/features/col-014/RISK-TEST-STRATEGY.md
+++ b/product/features/col-014/RISK-TEST-STRATEGY.md
@@ -1,0 +1,60 @@
+# col-014: Risk-Test Strategy
+
+## Risk Register
+
+### R-01: False Positive Feature Extraction (from SR-01)
+
+**Severity**: Medium | **Likelihood**: Low | **Overall**: Low
+
+Broader validation accepts more tokens as feature IDs from free text. Hyphenated English words (e.g., "well-known") could be extracted.
+
+**Test coverage**:
+- Unit: Verify common hyphenated English words are technically accepted (expected -- they pass safety gating)
+- Integration: Verify attribution partitioning tolerates occasional false signals (existing `test_attribute_two_feature_session` pattern)
+- Acceptance: End-to-end attribution with suffixed feature IDs produces correct results
+
+**Mitigation**: Attribution's partition-based approach means false positives only matter if they dominate a session. Single-record noise does not create feature switches.
+
+### R-02: Regression on Existing Feature IDs (from implementation)
+
+**Severity**: High | **Likelihood**: Very Low | **Overall**: Low
+
+All existing feature IDs (`col-002`, `nxs-001`, `eng-001`, `spike-042`, `api-100`) must remain valid after the change.
+
+**Test coverage**:
+- `test_is_valid_feature_id_positive` (existing, unchanged)
+- `test_extract_feature_id_pattern_accepts_arbitrary_prefixes` (existing, unchanged)
+- `test_attribute_sessions_with_arbitrary_prefix_feature` (existing, unchanged)
+
+### R-03: Injection via Feature ID Tokens (from SR-01, safety)
+
+**Severity**: High | **Likelihood**: Very Low | **Overall**: Low
+
+Feature IDs extracted from observation data could contain malicious content if validation is too permissive.
+
+**Test coverage**:
+- `test_is_valid_feature_id_special_chars`: Verify `a]b-c`, `feat<script>-1`, `col-001;drop` are rejected
+- Character allowlist (alphanumeric + hyphen + underscore + dot) blocks injection characters
+
+## Scope Risk Traceability
+
+| Scope Risk | Architecture Response | Test Coverage |
+|------------|----------------------|---------------|
+| SR-01: False positive increase | Hyphen requirement, partition tolerance | R-01 tests |
+| SR-02: Dot in paths | Path segment extraction isolates dots | R-01 integration tests + existing path tests |
+| SR-03: Underscore ambiguity | Hyphen requirement blocks pure-underscore | Covered by `test_is_valid_feature_id_no_hyphen` |
+
+## Test Strategy Summary
+
+| Category | Count | Coverage Target |
+|----------|-------|-----------------|
+| Unit: validation rules | 8 tests (6 new, 2 updated) | All 5 validation rules |
+| Unit: existing regression | 5 tests (unchanged) | Existing positive/negative cases |
+| Integration: E2E attribution | 1 test (new) | Suffixed feature in full pipeline |
+| **Total** | 14 tests | |
+
+## Top 3 Risks by Severity
+
+1. **R-03**: Injection via feature ID tokens (High severity, Very Low likelihood)
+2. **R-02**: Regression on existing feature IDs (High severity, Very Low likelihood)
+3. **R-01**: False positive feature extraction (Medium severity, Low likelihood)

--- a/product/features/col-014/SCOPE-RISK-ASSESSMENT.md
+++ b/product/features/col-014/SCOPE-RISK-ASSESSMENT.md
@@ -1,0 +1,40 @@
+# col-014: Scope Risk Assessment
+
+## SR-01: False Positive Increase in Text Extraction
+
+**Severity**: Medium
+**Likelihood**: Low
+
+Relaxing validation from `{alpha}-{digits}` to "any safe string with a hyphen" increases the set of strings that `extract_feature_id_pattern` will match from free text. Hyphenated English words (e.g., "well-known", "re-use") could be extracted as feature IDs.
+
+**Mitigation**: The `extract_feature_id_pattern` function splits on whitespace and delimiter characters, then calls `is_valid_feature_id` on each token. Hyphenated English words would match, but attribution requires the *same* token to appear consistently across records to establish a feature context. A one-off false positive in a single record does not create a partition -- it would need to appear as the dominant signal across a session. The `trim_matches` in `extract_feature_id_pattern` strips non-alphanumeric/non-hyphen characters, which further constrains candidates.
+
+**Residual risk**: Acceptable. Attribution already tolerates noise -- the partition-based approach (FR-04.3 priority ordering: path > text pattern > git checkout) means path-based signals dominate.
+
+## SR-02: Dot Character in Feature IDs
+
+**Severity**: Low
+**Likelihood**: Low
+
+Allowing dots (e.g., `v2.1-migration`) means file extensions could partially match. A path like `test-file.rs` contains a hyphen and safe characters.
+
+**Mitigation**: Path extraction (`extract_from_path`) looks for `product/features/` prefix and extracts the next path segment. The segment `test-file.rs` would pass `is_valid_feature_id` but would only match if that exact string appeared as a feature_cycle target in an `attribute_sessions` call. Since callers pass real feature IDs, this is a theoretical concern only.
+
+**Residual risk**: Negligible. The function is private and only called from well-defined extraction pipelines.
+
+## SR-03: Underscore Ambiguity
+
+**Severity**: Low
+**Likelihood**: Low
+
+Allowing underscores means tokens like `my_variable` could match if they also contain a hyphen somewhere in context. Since hyphens are required, `my_variable` alone would not match.
+
+**Mitigation**: Hyphen requirement eliminates pure-underscore identifiers. Only `underscore-hyphen` combinations match, which are plausible feature IDs.
+
+**Residual risk**: Acceptable.
+
+## Top 3 Risks for Architecture Attention
+
+1. **SR-01**: False positive increase -- architect should confirm that attribution's partition-based approach tolerates the broader match set
+2. **SR-02**: Dot character interaction with file paths -- architect should verify `extract_from_path` isolates path segments correctly
+3. **SR-03**: Underscore ambiguity -- minor, no architect action needed

--- a/product/features/col-014/SCOPE.md
+++ b/product/features/col-014/SCOPE.md
@@ -1,0 +1,82 @@
+# col-014: Feature Attribution Fix
+
+## Problem Statement
+
+`is_valid_feature_id()` in `crates/unimatrix-observe/src/attribution.rs:6-15` enforces a rigid `{alpha}-{digits}` format, silently rejecting feature IDs with letter suffixes like `col-010b` and `col-002b`. This causes `context_retrospective(feature_cycle: "col-010b")` to return "No observation data found" even though JSONL files contain col-010b references.
+
+More fundamentally, Unimatrix is domain-agnostic (ASS-009). Enforcing a specific feature ID convention at the engine level is architecturally wrong. Feature ID format is a project-level concern, not an engine-level concern.
+
+## Root Cause
+
+```rust
+fn is_valid_feature_id(s: &str) -> bool {
+    let parts: Vec<&str> = s.splitn(2, '-').collect();
+    if parts.len() != 2 { return false; }
+    !parts[0].is_empty()
+        && parts[0].chars().all(|c| c.is_ascii_alphabetic())
+        && !parts[1].is_empty()
+        && parts[1].chars().all(|c| c.is_ascii_digit())  // rejects "010b"
+}
+```
+
+The function imposes structural constraints (`{alpha}-{digits}`) that belong to project convention, not to a domain-agnostic engine. This rejects valid feature IDs like `col-010b`, `PROJ-123`, `sprint-7-auth`, `v2.1-migration`.
+
+## Scope
+
+### In Scope
+
+1. **Replace rigid format validation with permissive character/length gating** in `is_valid_feature_id()`
+2. **Update existing tests** to reflect new permissive validation
+3. **Add new tests** for the safety boundary (empty, too long, control chars, whitespace)
+
+### Out of Scope
+
+- Canonical validator in unimatrix-core (no cross-crate coupling needed)
+- Server-side `validate_retrospective_params` changes (already permissive)
+- Changes to any other crate
+
+## Decision: Option 3 (revised) -- Permissive safety gating
+
+Per issue #79 and human review, the revised direction is:
+
+- **Remove structural format validation** (`{alpha}-{digits}` pattern)
+- **Replace with permissive safety guards**:
+  - Non-empty
+  - Reasonable max length (128 chars, consistent with `MAX_FEATURE_CYCLE_LEN` in server validation)
+  - Contains at least one hyphen (distinguishes feature IDs from plain words in free text extraction)
+  - Only safe characters: ASCII alphanumeric, hyphens, underscores, dots
+  - No control characters, no whitespace, no special characters
+
+The hyphen requirement is the minimal structural constraint needed for attribution's text extraction: without it, `extract_feature_id_pattern` would match arbitrary single words from free text, producing excessive false positives.
+
+**Why not Option 1 (fix suffix only)**: Still encodes project-specific convention. Breaks for `sprint-7-auth`, `v2.1-migration`, etc.
+
+**Why not Option 2 (canonical validator)**: Cross-crate coupling for a private function is overengineering.
+
+## Acceptance Criteria
+
+1. `is_valid_feature_id("col-010b")` returns `true`
+2. `is_valid_feature_id("col-002b")` returns `true`
+3. `is_valid_feature_id("nxs-001")` returns `true` (regression)
+4. `is_valid_feature_id("PROJ-123")` returns `true` (domain-agnostic)
+5. `is_valid_feature_id("sprint-7-auth")` returns `true` (multi-hyphen)
+6. `is_valid_feature_id("v2.1-migration")` returns `true` (dots allowed)
+7. `is_valid_feature_id("my_project-feat_1")` returns `true` (underscores allowed)
+8. `is_valid_feature_id("")` returns `false` (empty)
+9. `is_valid_feature_id("nohyphen")` returns `false` (no hyphen)
+10. `is_valid_feature_id("a]b-c")` returns `false` (special chars)
+11. `is_valid_feature_id("a b-c")` returns `false` (whitespace)
+12. 128-char ID accepted, 129-char ID rejected
+13. All existing attribution integration tests continue to pass (existing IDs like `col-002`, `nxs-001`, `eng-001` remain valid)
+14. End-to-end: `attribute_sessions` correctly attributes records referencing `col-010b`
+
+## Affected Files
+
+- `crates/unimatrix-observe/src/attribution.rs` (fix + tests)
+
+## Risk Assessment
+
+- **Low risk**: Single private function, comprehensive existing test suite
+- **False positive risk**: Mitigated by retaining hyphen requirement -- plain English words won't match
+- **Regression risk**: All previously-valid IDs remain valid (relaxing validation only adds matches)
+- **Consistency**: Aligns with server's `MAX_FEATURE_CYCLE_LEN = 128` and permissive `validate_retrospective_params`

--- a/product/features/col-014/architecture/ARCHITECTURE.md
+++ b/product/features/col-014/architecture/ARCHITECTURE.md
@@ -1,0 +1,50 @@
+# col-014: Architecture
+
+## Overview
+
+Single-function fix in `crates/unimatrix-observe/src/attribution.rs`. No new modules, no cross-crate changes, no schema changes.
+
+## Current State
+
+```
+is_valid_feature_id(s) -> bool
+  Split on first hyphen
+  Validate: prefix is all-alpha, suffix is all-digits
+  Used by: extract_from_path, extract_feature_id_pattern, extract_from_git_checkout
+```
+
+## Target State
+
+```
+is_valid_feature_id(s) -> bool
+  Check: non-empty
+  Check: length <= 128
+  Check: contains at least one hyphen
+  Check: all chars are ASCII alphanumeric, hyphen, underscore, or dot
+  Used by: extract_from_path, extract_feature_id_pattern, extract_from_git_checkout (unchanged)
+```
+
+## ADR-001: Permissive Feature ID Validation
+
+**Context**: `is_valid_feature_id` enforces `{alpha}-{digits}` format. Unimatrix is domain-agnostic (ASS-009). The function is private to `attribution.rs` and used only for extracting feature signals from free text and file paths.
+
+**Decision**: Replace structural format validation with permissive character/length gating. Retain hyphen requirement as the minimal structural constraint to distinguish feature-ID-like tokens from plain words in free text extraction.
+
+**Allowed characters**: ASCII alphanumeric (`a-z`, `A-Z`, `0-9`), hyphen (`-`), underscore (`_`), dot (`.`).
+
+**Max length**: 128 characters, consistent with `MAX_FEATURE_CYCLE_LEN` in `crates/unimatrix-server/src/infra/validation.rs`.
+
+**Consequences**:
+- Broader set of strings accepted as feature IDs
+- False positive risk in text extraction mitigated by attribution's partition-based approach (SR-01)
+- All previously-valid IDs remain valid
+- Domain-agnostic: no project-specific conventions encoded
+
+## Integration Surface
+
+No integration changes. The function is private (`fn`, not `pub fn`). All callers are within `attribution.rs`. No API changes, no schema changes, no configuration changes.
+
+## Interaction with SR Risks
+
+- **SR-01 (false positives)**: The hyphen requirement is the key mitigation. Without it, every single word in free text would match. With it, only hyphenated tokens match, which is a reasonable proxy for structured identifiers.
+- **SR-02 (dots in paths)**: `extract_from_path` extracts the path segment after `product/features/` up to the next `/`. File extensions like `.rs` won't appear in that segment since they're in deeper path components. The dot allowance is safe here.

--- a/product/features/col-014/specification/SPECIFICATION.md
+++ b/product/features/col-014/specification/SPECIFICATION.md
@@ -1,0 +1,76 @@
+# col-014: Specification
+
+## Function Specification: `is_valid_feature_id`
+
+### Signature
+
+```rust
+fn is_valid_feature_id(s: &str) -> bool
+```
+
+### Behavior
+
+Returns `true` if `s` is a plausible feature identifier suitable for attribution extraction.
+
+### Validation Rules
+
+1. **Non-empty**: `s.is_empty()` => `false`
+2. **Max length**: `s.len() > 128` => `false`
+3. **Contains hyphen**: `!s.contains('-')` => `false`
+4. **Safe characters only**: Every character must be ASCII alphanumeric, hyphen (`-`), underscore (`_`), or dot (`.`). Any other character => `false`
+5. **No leading/trailing hyphen**: `s.starts_with('-') || s.ends_with('-')` => `false` (prevents matching partial tokens from text splitting)
+
+Rules are evaluated in short-circuit order for efficiency.
+
+### Constants
+
+```rust
+const MAX_FEATURE_ID_LEN: usize = 128;
+```
+
+Consistent with `MAX_FEATURE_CYCLE_LEN` in server validation.
+
+### Acceptance Criteria Traceability
+
+| AC | Rule | Test |
+|----|------|------|
+| AC-1: `col-010b` accepted | Rules 1-5 pass | `test_is_valid_feature_id_suffixed` |
+| AC-2: `col-002b` accepted | Rules 1-5 pass | `test_is_valid_feature_id_suffixed` |
+| AC-3: `nxs-001` accepted | Rules 1-5 pass (regression) | `test_is_valid_feature_id_positive` (existing) |
+| AC-4: `PROJ-123` accepted | Rules 1-5 pass | `test_is_valid_feature_id_domain_agnostic` |
+| AC-5: `sprint-7-auth` accepted | Rules 1-5 pass (multi-hyphen) | `test_is_valid_feature_id_domain_agnostic` |
+| AC-6: `v2.1-migration` accepted | Rules 1-5 pass (dot) | `test_is_valid_feature_id_domain_agnostic` |
+| AC-7: `my_project-feat_1` accepted | Rules 1-5 pass (underscore) | `test_is_valid_feature_id_domain_agnostic` |
+| AC-8: `""` rejected | Rule 1 | `test_is_valid_feature_id_negative` (existing) |
+| AC-9: `nohyphen` rejected | Rule 3 | `test_is_valid_feature_id_no_hyphen` |
+| AC-10: `a]b-c` rejected | Rule 4 | `test_is_valid_feature_id_special_chars` |
+| AC-11: `a b-c` rejected | Rule 4 | `test_is_valid_feature_id_whitespace` |
+| AC-12: 128/129 boundary | Rule 2 | `test_is_valid_feature_id_length_boundary` |
+| AC-13: Existing IDs valid | Rules 1-5 pass | Existing tests (regression) |
+| AC-14: E2E attribution | Full pipeline | `test_attribute_sessions_suffixed_feature` |
+
+### Test Updates Required
+
+**Existing tests to update**:
+- `test_is_valid_feature_id_negative`: Remove `col-abc` assertion (now valid -- it contains a hyphen and safe chars). Keep empty, no-hyphen, leading/trailing hyphen assertions.
+
+**New tests to add**:
+- `test_is_valid_feature_id_suffixed`: `col-010b`, `col-002b`
+- `test_is_valid_feature_id_domain_agnostic`: `PROJ-123`, `sprint-7-auth`, `v2.1-migration`, `my_project-feat_1`
+- `test_is_valid_feature_id_no_hyphen`: `nohyphen`, `justletters`, `12345`
+- `test_is_valid_feature_id_special_chars`: `a]b-c`, `feat<script>-1`, `col-001;drop`
+- `test_is_valid_feature_id_whitespace`: `a b-c`, `col -001`
+- `test_is_valid_feature_id_length_boundary`: 128-char (pass), 129-char (fail)
+- `test_is_valid_feature_id_leading_trailing_hyphen`: `-abc`, `abc-`, `-`
+- `test_attribute_sessions_suffixed_feature`: E2E with `col-010b` records
+
+### Domain Model
+
+No changes. `ObservationRecord`, `ParsedSession`, and `HookType` remain unchanged. The fix is purely in the validation predicate.
+
+### Constraints
+
+- Function remains private (`fn`, not `pub fn`)
+- No new dependencies
+- No changes to callers (`extract_from_path`, `extract_feature_id_pattern`, `extract_from_git_checkout`)
+- No changes outside `crates/unimatrix-observe/src/attribution.rs`


### PR DESCRIPTION
## Summary

- Replace rigid `{alpha}-{digits}` validation in `is_valid_feature_id()` with permissive character/length safety gating
- Aligns with domain-agnostic principle (ASS-009) — feature ID format is a project-level concern, not engine-level
- Fixes #79: `col-010b`, `col-002b` and arbitrary project ID formats now accepted
- Single file change: `crates/unimatrix-observe/src/attribution.rs`

## Artifacts

- SCOPE.md (revised after human checkpoint — Option 3 permissive gating)
- SCOPE-RISK-ASSESSMENT.md (3 risks: false positives, dot paths, underscore ambiguity)
- ARCHITECTURE.md + ADR-001 (permissive validation decision)
- SPECIFICATION.md (5 validation rules, 14 acceptance criteria, test traceability)
- RISK-TEST-STRATEGY.md (3 risks, test coverage mapping)
- ALIGNMENT-REPORT.md (4/4 PASS — domain agnosticism, milestone, pipeline, security)
- IMPLEMENTATION-BRIEF.md (change spec, ~30 min estimated effort)
- ACCEPTANCE-MAP.md (14 AC mapped to test functions)

## Vision Alignment

All dimensions PASS. No variances requiring approval.

## Test plan

- [ ] Review design artifacts for completeness
- [ ] Approve scope direction (Option 3 — permissive gating)
- [ ] Merge PR to approve design, then proceed to Session 2 (implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)