### PR TITLE
[crt-011] Design: Confidence Signal Integrity

### DIFF
--- a/product/features/crt-011/ACCEPTANCE-MAP.md
+++ b/product/features/crt-011/ACCEPTANCE-MAP.md
@@ -1,0 +1,54 @@
+# crt-011: Acceptance Map — Confidence Signal Integrity
+
+## AC-to-Test Traceability
+
+| AC | Description | FR | Test(s) | Status |
+|----|-------------|----|---------|----- --|
+| AC-01 | success_session_count dedup per (session_id, entry_id) | FR-01 | T-CON-01, T-CON-02 | Pending |
+| AC-02 | rework_session_count dedup per (session_id, entry_id) | FR-02 | T-CON-03 | Pending |
+| AC-03 | helpful_count dedup preserved (no regression) | FR-03 | Existing tests | Pending |
+| AC-04 | Unit test reproduces over-counting and verifies fix | FR-01, FR-02 | T-CON-01, T-CON-03 | Pending |
+| AC-05 | rework_flag_count NOT deduped, documented | FR-02 | T-CON-04, ADR-002 | Pending |
+| AC-06 | Integration test: context_search handler path | FR-04 | T-INT-01 or T-INT-03 | Pending |
+| AC-07 | Integration test: context_get handler path | FR-04 | T-INT-01 or T-INT-03 | Pending |
+| AC-08 | Integration test: UsageDedup prevents double access | FR-04 | T-INT-02 or T-INT-04 | Pending |
+| AC-09 | All existing tests pass | FR-03 | cargo test --workspace | Pending |
+| AC-10 | Multi-session overlapping entry_ids handled correctly | FR-01 | T-CON-02 | Pending |
+
+## Test-to-File Mapping
+
+| Test ID | File | Test Function |
+|---------|------|---------------|
+| T-CON-01 | crates/unimatrix-server/src/uds/listener.rs | test_confidence_consumer_dedup_same_session |
+| T-CON-02 | crates/unimatrix-server/src/uds/listener.rs | test_confidence_consumer_different_sessions_count_separately |
+| T-CON-03 | crates/unimatrix-server/src/uds/listener.rs | test_retrospective_consumer_rework_session_dedup |
+| T-CON-04 | crates/unimatrix-server/src/uds/listener.rs | test_retrospective_consumer_flag_count_not_deduped |
+| T-INT-01 | crates/unimatrix-server/src/services/usage.rs | test_mcp_usage_confidence_recomputed |
+| T-INT-02 | crates/unimatrix-server/src/services/usage.rs | test_mcp_usage_dedup_prevents_double_access |
+| T-INT-03 | crates/unimatrix-server/src/server.rs | test_confidence_path_search_to_store (or existing test_confidence_updated_on_retrieval) |
+| T-INT-04 | crates/unimatrix-server/src/server.rs | test_confidence_path_dedup_across_calls (or existing test_record_usage_for_entries_access_dedup) |
+
+## ADR Coverage
+
+| ADR | AC | Verified By |
+|-----|-----|-------------|
+| ADR-001: Per-session dedup | AC-01, AC-02, AC-10 | T-CON-01, T-CON-02, T-CON-03 |
+| ADR-002: rework_flag_count no dedup | AC-05 | T-CON-04 |
+| ADR-003: UsageService-level tests | AC-06, AC-07, AC-08 | T-INT-01..04 |
+
+## Risk Coverage
+
+| Risk | Test Coverage |
+|------|---------------|
+| R-01: Three-pass race | T-CON-01, T-CON-02 |
+| R-02: Integration test gap | T-INT-01..04 |
+| R-03: Semantic confusion | T-CON-04, code comments |
+| R-04: Queue backlog | T-CON-02 |
+
+## Completion Gate
+
+All ACs marked "Pending" above must be verified during implementation. The implementation is complete when:
+- [ ] All T-CON-* tests pass
+- [ ] All T-INT-* tests pass (or mapped to existing passing tests)
+- [ ] `cargo test --workspace` passes with no regressions
+- [ ] Code comments document rework_flag_count vs rework_session_count distinction

--- a/product/features/crt-011/ALIGNMENT-REPORT.md
+++ b/product/features/crt-011/ALIGNMENT-REPORT.md
@@ -1,0 +1,61 @@
+# crt-011: Vision Alignment Report
+
+## Feature: Confidence Signal Integrity
+
+## Vision Checkpoints
+
+### 1. Core Value Proposition Alignment
+
+**Status: PASS**
+
+The product vision states: "Unimatrix ensures what agents remember is **trustworthy, correctable, and auditable** — and gets better with every feature delivered."
+
+crt-011 directly fixes a data integrity bug that corrupts the trustworthiness of confidence signals. Over-counted session counts produce incorrect observation metrics, which distort hotspot detection and entry health assessment. This fix is a prerequisite for the confidence system to deliver on its value proposition.
+
+### 2. Milestone Alignment
+
+**Status: PASS**
+
+crt-011 is the first feature in the Intelligence Sharpening milestone, Wave 1 (Critical fixes). The product vision explicitly lists it as P0. Wave 3 (crt-013: Retrieval Calibration) depends on correct confidence data from crt-011. The feature is correctly sequenced.
+
+### 3. Architecture Alignment
+
+**Status: PASS**
+
+- **No schema changes:** Consistent with the SQLite schema v6 baseline. No migration needed.
+- **Service layer pattern:** Integration tests follow the established service layer architecture (vnc-006 through vnc-009). Tests at UsageService and UnimatrixServer level, not bypassing service abstractions.
+- **Signal queue design:** No changes to SignalRecord, SignalType, or the queue mechanism. The fix is purely in the consumer logic.
+- **f64 scoring pipeline:** No changes to the confidence formula or scoring constants. The compute_confidence function in unimatrix-engine is untouched.
+
+### 4. Security Alignment
+
+**Status: PASS**
+
+No new attack surfaces. The fix adds in-memory deduplication (HashSet operations) with no external I/O, no new tool parameters, and no changes to agent identity or trust verification. The existing SecurityGateway is unaffected.
+
+### 5. Confidence System Integrity
+
+**Status: PASS**
+
+The six-factor additive formula (base, usage, freshness, helpfulness, correction, trust — weights summing to 0.92) is unchanged. The co-access affinity (W_COAC = 0.08) at query time is unchanged. The fix ensures that the *inputs* to this formula (specifically, the observation metrics that feed retrospective analysis) are accurate.
+
+### 6. Test Infrastructure Alignment
+
+**Status: PASS**
+
+New tests extend existing test modules using existing helpers (`make_server()`, `insert_test_entry()`). This follows the CLAUDE.md directive: "Test infrastructure is cumulative — extend existing fixtures and helpers, never create isolated scaffolding."
+
+## Variance Summary
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Core value proposition | PASS | Fixes data integrity bug in confidence pipeline |
+| Milestone alignment | PASS | Wave 1 P0, correctly sequenced |
+| Architecture alignment | PASS | No schema/formula/API changes |
+| Security alignment | PASS | No new attack surfaces |
+| Confidence system integrity | PASS | Formula untouched, inputs corrected |
+| Test infrastructure | PASS | Extends existing patterns |
+
+**Variances requiring approval:** None.
+
+**Overall assessment:** Full alignment with product vision and architecture. This is a focused correctness fix in the right place at the right time.

--- a/product/features/crt-011/IMPLEMENTATION-BRIEF.md
+++ b/product/features/crt-011/IMPLEMENTATION-BRIEF.md
@@ -1,0 +1,104 @@
+# crt-011: Implementation Brief — Confidence Signal Integrity
+
+## Summary
+
+Fix session count over-counting in signal consumers and add handler-level integration tests. Two bug fixes + new tests, all within `unimatrix-server`.
+
+## GitHub Issue
+
+#136 (https://github.com/dug-21/unimatrix/issues/136)
+Related: #75 (session over-counting), #32 (handler integration tests)
+
+## Implementation Tasks
+
+### Task 1: Fix run_confidence_consumer (AC-01, AC-03, AC-04, AC-10)
+
+**File:** `crates/unimatrix-server/src/uds/listener.rs`
+**Function:** `run_confidence_consumer` (line ~1364)
+
+**Changes:**
+1. Add `let mut session_counted: HashSet<(String, u64)> = HashSet::new();` before the three-pass structure.
+2. In Pass 1 (lines 1418-1427), wrap the `success_session_count += 1` increment:
+   ```rust
+   if session_counted.insert((signal.session_id.clone(), entry_id)) {
+       existing.success_session_count += 1;
+   }
+   ```
+3. In Pass 3 (lines 1440-1460), apply the same check:
+   - Line 1446 ("Added between passes"): check `session_counted.insert(...)` before incrementing.
+   - Line 1454 (new entry): the initial value of 1 is correct only if the pair is new in the HashSet (it will be, since this is a new entry).
+
+**Do NOT modify:** Steps 2-3 (helpful_count dedup via HashSet<u64>). These are already correct.
+
+### Task 2: Fix run_retrospective_consumer (AC-02, AC-05)
+
+**File:** `crates/unimatrix-server/src/uds/listener.rs`
+**Function:** `run_retrospective_consumer` (line ~1464)
+
+**Changes:**
+1. Add `let mut session_counted: HashSet<(String, u64)> = HashSet::new();` before the update loop.
+2. In Step 4 (lines 1507-1528), split the increment:
+   ```rust
+   // Always increment rework_flag_count (event counter, no dedup)
+   existing.rework_flag_count += 1;
+   // Only increment rework_session_count once per (session_id, entry_id)
+   if session_counted.insert((signal.session_id.clone(), entry_id)) {
+       existing.rework_session_count += 1;
+   }
+   ```
+3. For new entries (line 1521), set `rework_session_count: 1` only if the pair is new (it will be for new entries, but check for consistency).
+
+**Add code comments** explaining the semantic distinction between `rework_flag_count` (event counter) and `rework_session_count` (session counter).
+
+### Task 3: Consumer Dedup Unit Tests (AC-04)
+
+**File:** `crates/unimatrix-server/src/uds/listener.rs` (extend existing test module)
+
+**Tests to add:**
+- `test_confidence_consumer_dedup_same_session` (T-CON-01)
+- `test_confidence_consumer_different_sessions_count_separately` (T-CON-02)
+- `test_retrospective_consumer_rework_session_dedup` (T-CON-03)
+- `test_retrospective_consumer_flag_count_not_deduped` (T-CON-04)
+
+**Setup pattern:** Use the existing test helper in listener.rs tests. Create a test Store, insert signals with overlapping entry_ids, call the consumer function, inspect PendingEntriesAnalysis.
+
+### Task 4: Handler-Level Integration Tests (AC-06, AC-07, AC-08)
+
+**Files:**
+- `crates/unimatrix-server/src/services/usage.rs` (extend test module)
+- `crates/unimatrix-server/src/server.rs` (extend test module)
+
+**Tests to add:**
+- `test_mcp_usage_confidence_recomputed` (T-INT-01)
+- `test_mcp_usage_dedup_prevents_double_access` (T-INT-02)
+- `test_confidence_path_search_to_store` (T-INT-03) — may already exist as `test_confidence_updated_on_retrieval`
+- `test_confidence_path_dedup_across_calls` (T-INT-04) — may already exist as `test_record_usage_for_entries_access_dedup`
+
+**Note:** Review existing tests before adding duplicates. Some of T-INT-03 and T-INT-04 may already be covered by existing tests in server.rs (e.g., `test_confidence_updated_on_retrieval`, `test_record_usage_for_entries_access_dedup`). If so, document the mapping and add only the missing coverage.
+
+### Task 5: Verify No Regressions (AC-09)
+
+Run full test suite: `cargo test --workspace`
+
+## ADRs
+
+- **ADR-001:** Per-session dedup using (session_id, entry_id) HashSet
+- **ADR-002:** rework_flag_count remains un-deduplicated
+- **ADR-003:** Integration tests at UsageService level
+
+ADRs are documented in `product/features/crt-011/architecture/ARCHITECTURE.md`. Unimatrix storage was attempted but MCP server was unavailable; store when server is available.
+
+## Estimated Scope
+
+- **Modified files:** 1 (`uds/listener.rs`)
+- **New test code:** ~150-200 lines across `listener.rs`, `usage.rs`, and `server.rs` test modules
+- **Risk:** LOW — focused bug fix with clear before/after behavior
+- **Dependencies:** None (no new crate deps, no schema changes)
+
+## Implementation Order
+
+1. Task 1 (confidence consumer fix) — highest priority, fixes #75
+2. Task 2 (retrospective consumer fix) — same pattern
+3. Task 3 (consumer dedup tests) — verify fixes
+4. Task 4 (integration tests) — closes #32
+5. Task 5 (regression check) — final gate

--- a/product/features/crt-011/RISK-TEST-STRATEGY.md
+++ b/product/features/crt-011/RISK-TEST-STRATEGY.md
@@ -1,0 +1,96 @@
+# crt-011: Risk-Test Strategy — Confidence Signal Integrity
+
+## Risk Register
+
+### R-01: Three-Pass Race in run_confidence_consumer (SR-02)
+
+**Severity:** MEDIUM
+**Likelihood:** LOW (single-threaded consumer calls)
+**Impact:** Double-counted success_session_count for entries added between passes
+
+**Description:** The three-pass structure (lock → unlock for fetch → lock) in `run_confidence_consumer` means `PendingEntriesAnalysis` can be modified between Pass 1 and Pass 3. If another consumer or handler adds an entry for the same `(session_id, entry_id)` between passes, the third pass could increment again.
+
+**Mitigation:** The dedup HashSet persists across all three passes. Pass 1 inserts all `(session_id, entry_id)` pairs it processes. Pass 3 checks the same HashSet before incrementing. Even if the entry was added between passes, the HashSet prevents double-counting.
+
+**Test:** T-CON-01 (same session, overlapping entries), T-CON-02 (different sessions).
+
+### R-02: Integration Test Insufficiency (SR-03)
+
+**Severity:** MEDIUM
+**Likelihood:** LOW
+**Impact:** Handler wiring bugs undetected
+
+**Description:** Tests at `UsageService` and `UnimatrixServer` level do not exercise MCP transport-layer dispatch. A bug in tool parameter routing or JSON-RPC deserialization would not be caught.
+
+**Mitigation:** Accepted risk. Existing param deserialization tests cover JSON → struct mapping. The service layer is where business logic lives. MCP transport tests are disproportionately expensive for the risk level.
+
+**Test:** T-INT-01 through T-INT-04.
+
+### R-03: Semantic Confusion Between rework Counters (SR-04)
+
+**Severity:** LOW
+**Likelihood:** MEDIUM (future contributors)
+**Impact:** Future code changes might incorrectly dedup rework_flag_count or fail to dedup rework_session_count
+
+**Description:** Both counters are incremented in the same loop with different dedup behavior. Without clear documentation, a future contributor might "fix" rework_flag_count by adding dedup, or remove dedup from rework_session_count.
+
+**Mitigation:** ADR-002 documents the decision. Code comments at the increment site explain the distinction. Test T-CON-04 explicitly verifies that rework_flag_count is NOT deduped.
+
+**Test:** T-CON-04.
+
+### R-04: Signal Queue Backlog Amplifies Bug Impact
+
+**Severity:** LOW
+**Likelihood:** LOW (requires server downtime + busy sessions)
+**Impact:** Larger over-counting if many signals accumulate before drain
+
+**Description:** If the signal queue accumulates many records (up to the 10,000 cap) before a drain cycle runs, the over-counting bug would be amplified. After the fix, this scenario is handled correctly, but it's worth testing.
+
+**Test:** T-CON-02 (tests multiple sessions with overlapping entries).
+
+## Scope Risk Traceability
+
+| Scope Risk | Architecture Response | Test Coverage |
+|-----------|----------------------|---------------|
+| SR-01 (String cloning) | Accepted — bounded by 10K cap | No dedicated test needed |
+| SR-02 (Three-pass race) | HashSet persists across passes (ADR-001) | T-CON-01, T-CON-02 |
+| SR-03 (Test setup complexity) | Use existing make_server() + UsageService (ADR-003) | T-INT-01..04 |
+| SR-04 (Semantic ambiguity) | ADR-002 + code comments | T-CON-04 |
+
+## Test Strategy Summary
+
+### Unit Tests (Consumer Dedup)
+
+| ID | Target | Scenario | Assertion |
+|----|--------|----------|-----------|
+| T-CON-01 | run_confidence_consumer | 2 signals, same session_id, overlapping entry_ids | success_session_count = 1 per entry |
+| T-CON-02 | run_confidence_consumer | 2 signals, different session_ids, overlapping entry_ids | success_session_count = 2 per entry |
+| T-CON-03 | run_retrospective_consumer | 2 signals, same session_id, overlapping entry_ids | rework_session_count = 1 per entry |
+| T-CON-04 | run_retrospective_consumer | 2 signals, same session_id, same entry_id | rework_flag_count = 2 (no dedup) |
+
+### Integration Tests (Handler-Service-Store)
+
+| ID | Target | Scenario | Assertion |
+|----|--------|----------|-----------|
+| T-INT-01 | UsageService::record_usage_for_entries_mcp | Insert entry, record usage | confidence > 0, access_count = 1 |
+| T-INT-02 | UsageService::record_usage_for_entries_mcp | Same agent+entry twice | access_count = 1 (dedup) |
+| T-INT-03 | UnimatrixServer::record_usage_for_entries | Insert entry, record usage | access_count + confidence updated |
+| T-INT-04 | UnimatrixServer::record_usage_for_entries | Two calls same agent+entry | access_count stays 1 |
+
+### Regression
+
+All existing tests in unimatrix-server, unimatrix-store, unimatrix-engine, unimatrix-observe must pass unchanged.
+
+## Risk Summary
+
+| ID | Risk | Severity | Covered By |
+|----|------|----------|------------|
+| R-01 | Three-pass race | MEDIUM | T-CON-01, T-CON-02, ADR-001 |
+| R-02 | Integration test gap | MEDIUM | T-INT-01..04, ADR-003 |
+| R-03 | Semantic confusion | LOW | T-CON-04, ADR-002, code comments |
+| R-04 | Queue backlog | LOW | T-CON-02 |
+
+**Top 3 by severity:**
+1. R-01: Three-pass race (MEDIUM) — mitigated by HashSet lifecycle
+2. R-02: Integration test gap (MEDIUM) — accepted, covered at service level
+3. R-03: Semantic confusion (LOW) — mitigated by ADR + tests

--- a/product/features/crt-011/SCOPE-RISK-ASSESSMENT.md
+++ b/product/features/crt-011/SCOPE-RISK-ASSESSMENT.md
@@ -1,0 +1,64 @@
+# crt-011: Scope Risk Assessment
+
+## Feature Context
+
+**Feature:** crt-011 — Confidence Signal Integrity
+**Scope:** Fix session count over-counting in signal consumers (#75), add handler-level integration tests (#32)
+**Crates:** unimatrix-server (primary), unimatrix-observe (type definitions), unimatrix-store (signal queue), unimatrix-engine (confidence formula — read-only)
+
+---
+
+## Identified Scope Risks
+
+### SR-01: Per-Session Dedup Key Requires String Cloning
+
+**Risk Level:** LOW
+**Category:** Performance
+
+The per-session dedup uses `HashSet<(String, u64)>` keyed on `(session_id, entry_id)`. Each signal's `session_id` is a `String` that must be cloned into the HashSet key. In typical operation, `drain_signals` returns a small number of signals (1-5), so the cloning cost is negligible. However, if a large backlog accumulates (e.g., server restart with many stale sessions), the number of signals could be larger.
+
+**Mitigation:** The signal queue has a 10,000-record cap (signal.rs:120). Even in the worst case, the HashSet contains at most 10,000 entries with short session_id strings. This is well within acceptable memory bounds.
+
+### SR-02: Race Condition Between First Pass and Second Pass in run_confidence_consumer
+
+**Risk Level:** MEDIUM
+**Category:** Correctness
+
+The current `run_confidence_consumer` Step 4 has a three-pass structure (lines 1415-1460): first pass under lock, fetch outside lock, third pass under lock. Between the first and third passes, another thread could modify `PendingEntriesAnalysis`. The existing code handles this with "Added between our first pass and now" logic (line 1446), but the dedup fix must account for this: the dedup HashSet must be maintained across all three passes to prevent the "already added" case from double-counting.
+
+**Mitigation:** The dedup HashSet is populated during the first pass (entries already counted) and checked during the third pass (new entries). Since the HashSet tracks `(session_id, entry_id)` pairs seen across ALL passes, the race is handled correctly. Architecture should specify this clearly.
+
+### SR-03: Integration Test Setup Complexity
+
+**Risk Level:** MEDIUM
+**Category:** Feasibility
+
+Handler-level integration tests require constructing a `UnimatrixServer` with all its dependencies (Store, VectorIndex, EmbedPipeline, services, UsageDedup, SessionRegistry). If existing test infrastructure does not support this, significant scaffolding may be needed, conflicting with the "extend existing test infrastructure" constraint.
+
+**Mitigation:** Review existing test patterns in `crates/unimatrix-server/src/server.rs` (which has 1900+ lines including tests). The `server.rs` tests already construct `UnimatrixServer` instances. The integration tests should follow the same pattern. If handler-level tests (at the MCP transport layer) are too complex, testing at the `UsageService` level may satisfy the intent of #32 while staying practical.
+
+### SR-04: Semantic Ambiguity Between rework_flag_count and rework_session_count
+
+**Risk Level:** LOW
+**Category:** Documentation / Future Maintenance
+
+The decision to NOT dedup `rework_flag_count` while deduping `rework_session_count` creates a subtle semantic distinction that future contributors may not understand. Both fields are incremented in the same loop (listener.rs:1510-1511), but with different dedup behavior.
+
+**Mitigation:** ADR documenting the distinction. Code comments at the increment site. Both the architecture doc and code should make clear that `rework_flag_count` is an event counter (how many times flagged) while `rework_session_count` is a session counter (how many unique sessions flagged this entry).
+
+---
+
+## Risk Summary
+
+| ID | Risk | Level | Architect Action |
+|----|------|-------|-----------------|
+| SR-01 | String cloning in dedup HashSet | LOW | Accept — bounded by signal queue cap |
+| SR-02 | Three-pass race in confidence consumer | MEDIUM | Specify dedup HashSet lifecycle across all passes |
+| SR-03 | Integration test setup complexity | MEDIUM | Identify existing test patterns; consider UsageService-level as fallback |
+| SR-04 | Semantic ambiguity in rework counters | LOW | ADR + code comments |
+
+## Top 3 Risks for Architect Attention
+
+1. **SR-02:** The three-pass structure in `run_confidence_consumer` must maintain dedup state correctly across lock/unlock boundaries.
+2. **SR-03:** Integration test feasibility depends on existing test infrastructure; architect should specify the test boundary.
+3. **SR-04:** The rework_flag_count vs rework_session_count distinction needs explicit documentation to prevent future confusion.

--- a/product/features/crt-011/SCOPE.md
+++ b/product/features/crt-011/SCOPE.md
@@ -1,0 +1,124 @@
+# crt-011: Confidence Signal Integrity
+
+## Problem Statement
+
+The `success_session_count` field in `PendingEntriesAnalysis` is over-counted when multiple signals drain for the same entry in a single consumer run. In `run_confidence_consumer` (listener.rs:1413-1460), Step 4 iterates over ALL drained signals and increments `success_session_count` once per signal per entry_id, rather than once per unique entry_id across all signals. The same bug exists in `run_retrospective_consumer` (listener.rs:1504-1530) for `rework_session_count`.
+
+Since `success_session_count` feeds into the retrospective entries analysis (which flows into observation metrics and ultimately impacts confidence-driven ranking decisions), this corruption silently inflates session counts, making entries appear more heavily used than they are.
+
+Additionally, the handler-to-service-to-store confidence path (#32) lacks integration tests. The existing tests call `Store` methods directly, bypassing the MCP tool handler layer. This means regressions in the handler wiring (parameter parsing, dedup integration, service delegation) would go undetected.
+
+**Who is affected?** Every agent that relies on confidence-ranked search results or briefing content selection. Corrupted session counts distort the observation pipeline that feeds retrospective analysis and ultimately confidence scoring.
+
+**Why now?** This is the first feature in the Intelligence Sharpening milestone. Wave 3 (crt-013: Retrieval Calibration) depends on correct confidence data. Fixing this first is a prerequisite.
+
+## Goals
+
+1. Fix `success_session_count` over-counting in `run_confidence_consumer` so each (session_id, entry_id) pair is counted at most once per consumer drain cycle.
+2. Fix `rework_session_count` over-counting in `run_retrospective_consumer` using the same per-session deduplication approach.
+3. Add integration tests covering the handler-to-service-to-store confidence path through MCP tool handlers.
+4. Verify that `helpful_count` increments (Step 3 of `run_confidence_consumer`) are already correctly deduplicated (they use `HashSet<u64>` in Step 2).
+
+## Non-Goals
+
+- **Not changing the 6-factor confidence formula.** The formula itself (`compute_confidence` in `unimatrix-engine/src/confidence.rs`) is correct. Only the signal ingestion path is broken.
+- **Not adding new confidence factors.** No changes to weights, Wilson score parameters, or co-access affinity.
+- **Not fixing `UsageDedup` (in-memory MCP-level dedup).** `UsageDedup` handles per-agent-per-entry access/vote dedup for MCP tool calls. It is correct and unrelated to the signal queue consumer bug.
+- **Not modifying the `SIGNAL_QUEUE` schema or `SignalRecord` format.** The queue structure is fine; the bug is in the consumer logic.
+- **Not addressing observation metrics normalization (#103 / nxs-009).** That is a separate feature.
+- **Not changing `SessionRegistry` or session lifecycle persistence.** The session infrastructure works correctly; the bug is downstream in signal consumption.
+
+## Background Research
+
+### The Over-Counting Bug (#75)
+
+**Root cause:** In `run_confidence_consumer` (listener.rs:1364-1461), `drain_signals(SignalType::Helpful)` can return multiple `SignalRecord`s — one per session that closed since the last drain. Each `SignalRecord` contains an `entry_ids: Vec<u64>` list. Step 4 iterates `for signal in &signals { for &entry_id in &signal.entry_ids { ... } }`, incrementing `success_session_count` for each occurrence. If the same entry_id appears in signals from different sessions, this is correct (one count per session). But the first pass/second pass structure (lines 1415-1428 and 1440-1460) has a subtlety: entries fetched in the second pass that were already added between passes get double-counted (line 1446: `existing.success_session_count += 1` in the "Added between our first pass and now" case).
+
+However, the **primary** over-counting path is: if the same entry appears in multiple signals from the SAME session (e.g., stale session sweep + normal close, or multiple stale sweeps), `success_session_count` increments multiple times for what should be a single session.
+
+**Impact:** The `PendingEntriesAnalysis.entries` HashMap flows into `EntryAnalysis` records that are merged via `server.rs:57-63` and then consumed by the retrospective pipeline for observation metrics. Over-counted session counts distort the metrics used for hotspot detection and entry health assessment.
+
+### The rework_session_count Bug (same pattern)
+
+In `run_retrospective_consumer` (listener.rs:1504-1530), the same pattern exists: iterating over signals and entry_ids without deduplication. `rework_session_count` and `rework_flag_count` increment for every signal/entry combination.
+
+### Existing Dedup for helpful_count
+
+Step 2-3 of `run_confidence_consumer` (lines 1382-1411) correctly deduplicate `helpful_count` increments: a `HashSet<u64>` collects unique entry_ids across all signals, then `record_usage_with_confidence` is called once with the unique set. This path is correct.
+
+### Handler-Level Test Gap (#32)
+
+Current confidence integration tests (`crates/unimatrix-store/tests/sqlite_parity.rs`) call `store.record_usage_with_confidence()` directly. No tests exercise the full path:
+1. MCP tool handler receives `context_search`/`context_get` request
+2. Handler calls `UsageService::record_usage_for_entries_mcp()`
+3. `UsageService` applies `UsageDedup` filtering
+4. `UsageService` calls `store.record_usage_with_confidence()`
+5. Confidence is recomputed and stored
+
+The handler→service→store chain has no integration coverage, meaning broken wiring between layers would not be caught.
+
+### Crate Boundaries
+
+| Crate | Role in Confidence Path |
+|-------|------------------------|
+| `unimatrix-observe` | Defines `EntryAnalysis` struct with `success_session_count` / `rework_session_count` |
+| `unimatrix-store` | Signal queue persistence (`insert_signal`, `drain_signals`), usage recording (`record_usage_with_confidence`) |
+| `unimatrix-engine` | Confidence formula (`compute_confidence`), scoring constants |
+| `unimatrix-server` | Signal consumers (`run_confidence_consumer`, `run_retrospective_consumer`), `UsageService`, `UsageDedup`, MCP tool handlers |
+
+## Proposed Approach
+
+### Fix 1: Deduplicate session counts in `run_confidence_consumer`
+
+In Step 4, track which `(session_id, entry_id)` pairs have already been counted using a `HashSet<(String, u64)>`. Only increment `success_session_count` for pairs not yet seen in this drain cycle. Each `SignalRecord` carries a `session_id`, so the key is available. This preserves the correct semantic: if entry X appeared in sessions A and B, it counts twice (once per session). But if entry X appears in two signals from the SAME session, it counts once.
+
+### Fix 2: Deduplicate session counts in `run_retrospective_consumer`
+
+Same approach: use a `HashSet<(String, u64)>` to track which `(session_id, entry_id)` pairs have had `rework_session_count` incremented. Only increment once per unique pair per drain cycle.
+
+`rework_flag_count` is intentionally NOT deduplicated. It counts individual rework flagging events (not sessions) and serves as a severity/priority signal for `PendingEntriesAnalysis` cap eviction. Higher values mean "keep this entry for analysis." This semantic distinction between `rework_flag_count` (event counter) and `rework_session_count` (session counter) will be documented in an ADR.
+
+### Fix 3: Handler-level integration tests
+
+Write integration tests in `crates/unimatrix-server/` that exercise the MCP tool handler → `UsageService` → `Store` confidence path. Tests should:
+- Call `context_search` or `context_get` via the MCP handler
+- Verify that `access_count`, `helpful_count`, `confidence` are updated correctly
+- Verify that `UsageDedup` prevents double-counting within a session
+- Verify confidence recomputation occurs after counter updates
+
+Use the existing test infrastructure (`TestServiceContext` or equivalent) to avoid creating isolated test scaffolding.
+
+## Acceptance Criteria
+
+- AC-01: `success_session_count` increments at most once per unique `(session_id, entry_id)` pair per `run_confidence_consumer` drain cycle. Two different sessions containing the same entry correctly increment by 2.
+- AC-02: `rework_session_count` increments at most once per unique `(session_id, entry_id)` pair per `run_retrospective_consumer` drain cycle.
+- AC-03: `helpful_count` dedup in `run_confidence_consumer` Step 2-3 remains correct and is not regressed by changes.
+- AC-04: A unit test reproduces the over-counting bug (multiple signals with overlapping entry_ids) and verifies the fix.
+- AC-05: `rework_flag_count` is NOT deduplicated (it counts flagging events, not sessions). The semantic distinction between `rework_flag_count` and `rework_session_count` is documented in an ADR and in code comments.
+- AC-06: At least one integration test exercises the full `context_search` handler → `UsageService` → `Store` → confidence recomputation path.
+- AC-07: At least one integration test exercises the `context_get` handler → `UsageService` → `Store` → confidence recomputation path.
+- AC-08: Integration tests verify `UsageDedup` prevents double access_count increment for the same agent+entry within a session.
+- AC-09: All existing tests pass with no regressions.
+- AC-10: The fix handles the edge case where `drain_signals` returns signals from multiple sessions with overlapping entry_ids (each unique `(session_id, entry_id)` pair increments once; different sessions correctly count separately).
+
+## Constraints
+
+- **No schema changes.** The `SIGNAL_QUEUE`, `entries`, and `sessions` tables remain unchanged.
+- **No crate boundary changes.** The fix is contained within `unimatrix-server` (consumer functions) and new tests.
+- **Extend existing test infrastructure.** Per CLAUDE.md: "Test infrastructure is cumulative — extend existing fixtures and helpers, never create isolated scaffolding."
+- **No changes to `compute_confidence` formula.** The formula in `unimatrix-engine` is correct; only the signal ingestion is broken.
+- **Backward-compatible.** Already-corrupted session counts in existing databases are not retroactively fixed (no migration needed; the counts only exist in-memory `PendingEntriesAnalysis`).
+
+## Resolved Questions
+
+1. **`rework_flag_count` should NOT be deduplicated.** Research confirmed it counts individual rework flagging events, not unique sessions. It is named "rework **flag** count" (distinct from `rework_session_count`). It serves as a severity/priority signal in `PendingEntriesAnalysis` cap eviction (server.rs:66-70): entries with the lowest `rework_flag_count` are dropped first. Higher values = more problematic = keep for analysis. Deduplicating would lose signal.
+2. **Per-session dedup for session counts (DECIDED).** Each unique `(session_id, entry_id)` pair should count once. If entry X appears in signals from sessions A and B, `success_session_count` increments by 2 (once per session). Global dedup would be wrong -- we want to know how many sessions used the entry.
+
+## Open Questions
+
+None remaining.
+
+## Tracking
+
+- GitHub Issue: #136 (https://github.com/dug-21/unimatrix/issues/136)
+- Related: #75 (session over-counting bug), #32 (missing handler-level integration tests)

--- a/product/features/crt-011/architecture/ARCHITECTURE.md
+++ b/product/features/crt-011/architecture/ARCHITECTURE.md
@@ -1,0 +1,125 @@
+# crt-011: Architecture — Confidence Signal Integrity
+
+## Overview
+
+This feature fixes session count over-counting in the signal consumer pipeline and adds handler-level integration tests for the confidence path. The changes are confined to `unimatrix-server` (consumer functions + new tests). No schema changes, no new crates, no changes to the confidence formula.
+
+## Architecture Decisions
+
+### ADR-001: Per-Session Dedup Using (session_id, entry_id) HashSet
+
+**Context:** `run_confidence_consumer` and `run_retrospective_consumer` iterate over all drained signals and increment session counts without deduplication. The same entry can appear in multiple signals from the same session (e.g., stale sweep + normal close).
+
+**Decision:** Introduce a `HashSet<(String, u64)>` keyed on `(session_id, entry_id)` in both consumer functions. Before incrementing `success_session_count` or `rework_session_count`, check if the pair has already been counted. If so, skip the increment.
+
+**Rationale:**
+- Per-session (not global) dedup preserves the correct semantic: entry X used in sessions A and B counts as 2 sessions.
+- `SignalRecord` already carries `session_id`, so no new data is needed.
+- The signal queue cap (10,000 records) bounds the worst-case HashSet size.
+- This mirrors the existing `HashSet<u64>` dedup for `helpful_count` in Step 2 of `run_confidence_consumer`.
+
+**Consequences:**
+- String cloning for session_id keys — acceptable given small drain batch sizes.
+- The dedup HashSet must persist across the three-pass structure in `run_confidence_consumer` (first pass under lock, fetch outside lock, third pass under lock).
+
+### ADR-002: rework_flag_count Remains Un-Deduplicated
+
+**Context:** `rework_flag_count` and `rework_session_count` are both incremented in the same loop in `run_retrospective_consumer`. The fix deduplicates `rework_session_count` but must decide about `rework_flag_count`.
+
+**Decision:** Do NOT deduplicate `rework_flag_count`. It is an event counter (number of times an entry was flagged for rework), not a session counter. It is used as a severity/priority signal for `PendingEntriesAnalysis` cap eviction — entries with the lowest `rework_flag_count` are dropped first when the 1000-entry cap is reached.
+
+**Rationale:**
+- The field name distinguishes it from `rework_session_count`.
+- Its downstream consumer (cap eviction in `PendingEntriesAnalysis::upsert`) uses it as a priority signal. Higher values = more problematic = keep for analysis.
+- Deduplicating would lose information about how many times an entry was flagged within a drain cycle.
+
+**Consequences:**
+- Code comments must clearly document the semantic distinction at the increment site.
+- Both fields are incremented in the same loop but with different dedup behavior — clarity is critical.
+
+### ADR-003: Integration Tests at UsageService Level
+
+**Context:** #32 requests handler-level integration tests for the confidence path. The question is what "handler level" means: (a) MCP transport-level tool dispatch, or (b) service-level calls that the handlers delegate to.
+
+**Decision:** Write integration tests at the `UsageService` level, exercising `record_usage_for_entries_mcp()` and `record_access_fire_and_forget()`. These tests construct a `UsageService` with real `Store` and `UsageDedup` dependencies, then verify the full service-to-store chain including dedup and confidence recomputation.
+
+Additionally, write tests at the `UnimatrixServer` level using the existing `make_server()` helper to exercise `record_usage_for_entries()` through the server's public API, which is what the MCP tool handlers call.
+
+**Rationale:**
+- Existing test infrastructure (`make_server()`, `insert_test_entry()`) already supports `UnimatrixServer`-level testing.
+- `UsageService` is the service layer that encapsulates the handler's business logic. Testing here covers the handler-to-service-to-store chain without requiring MCP transport setup.
+- Pure MCP transport tests (stdin/stdout JSON-RPC) would require significant new scaffolding and are not proportionate to the risk.
+
+**Consequences:**
+- Tests do not exercise MCP JSON-RPC deserialization or tool dispatch routing. This is acceptable because those paths are covered by existing param deserialization tests.
+
+## Component Changes
+
+### Modified: `unimatrix-server/src/uds/listener.rs`
+
+#### `run_confidence_consumer`
+
+**Before:** Step 4 iterates `for signal in &signals { for &entry_id in &signal.entry_ids { ... } }` and unconditionally increments `success_session_count`.
+
+**After:** A `HashSet<(String, u64)>` tracks counted `(session_id, entry_id)` pairs. The HashSet is populated across all three passes:
+
+```
+Pass 1 (under lock): For each (session_id, entry_id), check/insert into HashSet.
+  If already seen → skip. If new AND entry exists in pending → increment.
+  Collect entry_ids needing fetch.
+
+Fetch (outside lock): Fetch metadata for unknown entry_ids.
+
+Pass 3 (under lock): For each fetched entry_id, check HashSet again.
+  If entry was added between passes → check HashSet, increment if pair is new.
+  If entry still missing → insert new EntryAnalysis, mark pair in HashSet.
+```
+
+#### `run_retrospective_consumer`
+
+**Before:** Step 4 iterates and unconditionally increments both `rework_flag_count` and `rework_session_count`.
+
+**After:** A `HashSet<(String, u64)>` tracks counted `(session_id, entry_id)` pairs for `rework_session_count` only. `rework_flag_count` continues to increment unconditionally.
+
+### New Tests: Integration Coverage
+
+Location: `crates/unimatrix-server/src/services/usage.rs` (extend existing test module) and `crates/unimatrix-server/src/server.rs` (extend existing test module).
+
+**UsageService tests:**
+1. `test_mcp_usage_confidence_recomputed` — call `record_usage_for_entries_mcp`, verify confidence changes.
+2. `test_mcp_usage_dedup_prevents_double_access` — same agent+entry, verify access_count stays at 1.
+
+**Server-level tests:**
+3. `test_confidence_path_search_to_store` — insert entry, call `record_usage_for_entries`, verify access_count + confidence.
+4. `test_confidence_path_dedup_across_calls` — two calls with same agent+entry, verify dedup.
+
+**Consumer tests (new):**
+5. `test_confidence_consumer_dedup_same_session` — insert two signals with overlapping entry_ids and same session_id, run consumer, verify `success_session_count` increments once per unique entry.
+6. `test_confidence_consumer_different_sessions` — insert signals from two different sessions with overlapping entry_ids, verify `success_session_count` increments twice (once per session).
+7. `test_retrospective_consumer_rework_dedup` — same pattern for `rework_session_count`.
+8. `test_retrospective_consumer_flag_count_not_deduped` — verify `rework_flag_count` increments for each signal regardless of dedup.
+
+## Integration Surface
+
+No changes to public API, MCP tool signatures, or inter-crate interfaces. The changes are internal to `unimatrix-server`:
+- `run_confidence_consumer` — internal function in `uds/listener.rs`
+- `run_retrospective_consumer` — internal function in `uds/listener.rs`
+- New tests extend existing test modules
+
+## Data Flow (After Fix)
+
+```
+Session Close
+  → write_signals_to_queue (1 SignalRecord per session)
+  → SIGNAL_QUEUE (SQLite)
+  → drain_signals (batch of SignalRecords)
+  → run_confidence_consumer:
+      Step 2: HashSet<u64> for helpful_count dedup (existing, correct)
+      Step 3: record_usage_with_confidence (existing, correct)
+      Step 4: HashSet<(session_id, entry_id)> for success_session_count dedup (NEW)
+  → run_retrospective_consumer:
+      HashSet<(session_id, entry_id)> for rework_session_count dedup (NEW)
+      rework_flag_count: no dedup (intentional)
+  → PendingEntriesAnalysis
+  → context_retrospective handler drains on call
+```

--- a/product/features/crt-011/specification/SPECIFICATION.md
+++ b/product/features/crt-011/specification/SPECIFICATION.md
@@ -1,0 +1,112 @@
+# crt-011: Specification — Confidence Signal Integrity
+
+## Feature Summary
+
+Fix session count over-counting in `run_confidence_consumer` and `run_retrospective_consumer` by introducing per-session deduplication. Add integration tests covering the handler-to-service-to-store confidence path.
+
+## Domain Model
+
+### Entities
+
+| Entity | Location | Description |
+|--------|----------|-------------|
+| `SignalRecord` | `unimatrix-store/src/signal.rs` | Queue record: session_id, entry_ids, signal_type, signal_source |
+| `EntryAnalysis` | `unimatrix-observe/src/types.rs` | Per-entry analysis: rework_flag_count, injection_count, success_session_count, rework_session_count |
+| `PendingEntriesAnalysis` | `unimatrix-server/src/server.rs` | HashMap<u64, EntryAnalysis> with 1000-entry cap, mutex-protected |
+| `UsageDedup` | `unimatrix-server/src/infra/usage_dedup.rs` | In-memory MCP-level dedup for access, votes, co-access |
+| `UsageService` | `unimatrix-server/src/services/usage.rs` | Service layer wrapping store + dedup for usage recording |
+
+### Counter Semantics
+
+| Counter | Dedup? | Semantic | Source |
+|---------|--------|----------|--------|
+| `success_session_count` | YES — per (session_id, entry_id) | Number of distinct sessions where entry was used successfully | run_confidence_consumer |
+| `rework_session_count` | YES — per (session_id, entry_id) | Number of distinct sessions where entry was flagged for rework | run_retrospective_consumer |
+| `rework_flag_count` | NO | Total number of rework flagging events (severity signal) | run_retrospective_consumer |
+| `helpful_count` | YES — per unique entry_id (existing) | Number of implicit helpful signals | run_confidence_consumer Step 2-3 |
+| `access_count` | YES — per (agent_id, entry_id) via UsageDedup | Number of distinct agent accesses | UsageService |
+
+## Functional Requirements
+
+### FR-01: success_session_count Dedup in run_confidence_consumer
+
+**Pre-condition:** `drain_signals(SignalType::Helpful)` returns N signals, possibly with overlapping entry_ids and/or duplicate session_ids.
+
+**Behavior:**
+1. Construct a `HashSet<(String, u64)>` to track counted `(session_id, entry_id)` pairs.
+2. In Pass 1 (under lock), for each signal and each entry_id:
+   - If `(signal.session_id, entry_id)` is already in the HashSet, skip.
+   - Otherwise, insert the pair into the HashSet and increment `success_session_count` if the entry exists in `PendingEntriesAnalysis`.
+3. In Pass 3 (under lock), for fetched entries:
+   - Check the HashSet before incrementing. Only increment if the `(session_id, entry_id)` pair is new.
+
+**Post-condition:** Each unique `(session_id, entry_id)` pair increments `success_session_count` exactly once per drain cycle.
+
+### FR-02: rework_session_count Dedup in run_retrospective_consumer
+
+**Pre-condition:** `drain_signals(SignalType::Flagged)` returns N signals.
+
+**Behavior:**
+1. Construct a `HashSet<(String, u64)>` to track counted `(session_id, entry_id)` pairs.
+2. For each signal and each entry_id:
+   - If `(signal.session_id, entry_id)` is already in the HashSet, skip the `rework_session_count` increment.
+   - Otherwise, insert the pair and increment `rework_session_count`.
+   - Always increment `rework_flag_count` regardless of dedup state.
+
+**Post-condition:** Each unique `(session_id, entry_id)` pair increments `rework_session_count` exactly once. `rework_flag_count` increments for every occurrence.
+
+### FR-03: Existing helpful_count Dedup Preserved
+
+**Constraint:** The existing `HashSet<u64>` dedup in Step 2-3 of `run_confidence_consumer` must not be modified or regressed. The fix only changes Step 4.
+
+### FR-04: Handler-Level Integration Tests
+
+**Requirement:** Add tests exercising the confidence path through service-level APIs:
+
+| Test ID | API Under Test | Verifies |
+|---------|---------------|----------|
+| T-INT-01 | `UsageService::record_usage_for_entries_mcp` | Confidence recomputed after usage |
+| T-INT-02 | `UsageService::record_usage_for_entries_mcp` | UsageDedup prevents double access_count |
+| T-INT-03 | `UnimatrixServer::record_usage_for_entries` | access_count + confidence updated |
+| T-INT-04 | `UnimatrixServer::record_usage_for_entries` | Dedup across repeated calls |
+
+### FR-05: Consumer Dedup Unit Tests
+
+| Test ID | Consumer | Verifies |
+|---------|----------|----------|
+| T-CON-01 | run_confidence_consumer | Same session, overlapping entry_ids → success_session_count = 1 per entry |
+| T-CON-02 | run_confidence_consumer | Different sessions, overlapping entry_ids → success_session_count = 2 per entry |
+| T-CON-03 | run_retrospective_consumer | Same session, overlapping entry_ids → rework_session_count = 1 per entry |
+| T-CON-04 | run_retrospective_consumer | rework_flag_count increments for every signal (no dedup) |
+
+## Acceptance Criteria Mapping
+
+| AC | FR | Test |
+|----|----|----- |
+| AC-01 | FR-01 | T-CON-01, T-CON-02 |
+| AC-02 | FR-02 | T-CON-03 |
+| AC-03 | FR-03 | Existing tests (no regression) |
+| AC-04 | FR-01, FR-02 | T-CON-01, T-CON-03 |
+| AC-05 | FR-02 | T-CON-04, code comments, ADR-002 |
+| AC-06 | FR-04 | T-INT-01 or T-INT-03 |
+| AC-07 | FR-04 | T-INT-01 or T-INT-03 (get path uses same service) |
+| AC-08 | FR-04 | T-INT-02 or T-INT-04 |
+| AC-09 | FR-03 | Full test suite pass |
+| AC-10 | FR-01 | T-CON-02 |
+
+## Constraints
+
+- No schema changes to any SQLite tables.
+- No modifications to `compute_confidence` in `unimatrix-engine`.
+- No changes to `SignalRecord`, `SignalType`, or `SignalSource`.
+- No changes to `UsageDedup` (MCP-level dedup is correct and separate).
+- All new tests extend existing test modules using existing helpers (`make_server`, `insert_test_entry`).
+- No new crate dependencies.
+
+## Error Handling
+
+No new error paths. The dedup HashSet operations (`insert`, `contains`) are infallible. The existing error handling in both consumers (drain failure → warn + return, spawn_blocking failure → warn + continue) is unchanged.
+
+## Performance Impact
+
+Negligible. The dedup HashSet adds O(n) time and O(n) space where n = total (signal, entry) pairs in a drain batch. Typical drain batches contain 1-5 signals with 5-20 entries each. The 10,000-record signal queue cap bounds worst-case.


### PR DESCRIPTION
## Summary

- Design artifacts for crt-011: Confidence Signal Integrity
- Fixes session count over-counting (#75) in `run_confidence_consumer` and `run_retrospective_consumer` via per-session `(session_id, entry_id)` dedup
- Adds handler-level integration tests (#32) at UsageService and UnimatrixServer level
- 3 ADRs: per-session dedup strategy, rework_flag_count semantics, test boundary

## Artifacts

- `SCOPE.md` — Problem statement, goals, acceptance criteria (10 ACs)
- `SCOPE-RISK-ASSESSMENT.md` — 4 scope risks (SR-01..04)
- `ARCHITECTURE.md` — 3 ADRs, component changes, data flow
- `SPECIFICATION.md` — 5 functional requirements, domain model, counter semantics
- `RISK-TEST-STRATEGY.md` — 4 risks, 8 tests mapped to risks
- `ALIGNMENT-REPORT.md` — 6 vision checks, all PASS
- `IMPLEMENTATION-BRIEF.md` — 5 implementation tasks with code locations
- `ACCEPTANCE-MAP.md` — AC-to-test traceability matrix

## Related Issues

Closes design phase for #136
Related: #75 (session over-counting bug), #32 (handler integration tests)

## Test plan

- [ ] Review SCOPE.md acceptance criteria (10 ACs)
- [ ] Review ARCHITECTURE.md ADRs for correctness
- [ ] Verify ACCEPTANCE-MAP.md traces all ACs to tests
- [ ] Approve to proceed to Session 2 (implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)