### PR TITLE
[vnc-010] Design artifacts: Quarantine State Restoration

### DIFF
--- a/product/features/vnc-010/ACCEPTANCE-MAP.md
+++ b/product/features/vnc-010/ACCEPTANCE-MAP.md
@@ -1,0 +1,36 @@
+# vnc-010: Acceptance Map
+
+## Acceptance Criteria to Implementation Mapping
+
+| AC | Description | Chunk | Files | Test Type |
+|----|-------------|-------|-------|-----------|
+| AC-1 | Quarantine from Deprecated | C2 | tools.rs, server.rs | Integration |
+| AC-2 | Quarantine from Proposed | C2 | tools.rs, server.rs | Integration |
+| AC-3 | Quarantine from Active (existing) | C2 | tools.rs, server.rs | Integration (existing + new) |
+| AC-4 | Restore to pre-quarantine status | C2 | server.rs | Integration |
+| AC-5 | Restore fallback (NULL pre_quarantine) | C2 | server.rs | Integration |
+| AC-6 | Idempotent quarantine | C2 | tools.rs | Integration (existing) |
+| AC-7 | Schema migration v7->v8 | C1, C3 | migration.rs, db.rs | Integration |
+| AC-8 | Status counter integrity | C2 | server.rs | Integration |
+| AC-9 | Audit trail | C2 | server.rs | Integration |
+| AC-10 | Invalid pre_quarantine fallback | C2 | server.rs | Unit + Integration |
+
+## Risk to Acceptance Criteria Mapping
+
+| Risk | AC Coverage | Confidence |
+|------|-------------|------------|
+| R-01: Migration failure | AC-7 | High |
+| R-02: Backfill correctness | AC-7 | High |
+| R-03: Counter drift | AC-8 | High |
+| R-04: Invalid restore target | AC-5, AC-10 | High |
+| R-05: Regression | AC-3, AC-6 | High |
+
+## Verification Checklist
+
+- [ ] All 10 acceptance criteria have at least one test
+- [ ] All 5 risks have test coverage
+- [ ] Existing quarantine/restore tests pass unchanged
+- [ ] Migration tested on v7 database
+- [ ] Counter integrity verified for Deprecated round-trip
+- [ ] Fallback behavior verified for NULL and invalid pre_quarantine_status
+- [ ] Audit log entries include pre_quarantine_status information

--- a/product/features/vnc-010/ALIGNMENT-REPORT.md
+++ b/product/features/vnc-010/ALIGNMENT-REPORT.md
@@ -1,0 +1,56 @@
+# vnc-010: Vision Alignment Report
+
+## Alignment Assessment
+
+### Vision Principle: Trustworthy, Correctable, Auditable Knowledge
+
+**Status: PASS**
+
+vnc-010 directly improves knowledge trustworthiness. Currently, deprecated entries with bad information cannot be fully hidden via quarantine — they leak through semantic search with only a confidence penalty. This feature closes that gap, allowing any entry in any status to be quarantined when discovered to be harmful.
+
+The restore-to-original-status behavior preserves the correctness of the knowledge lifecycle. An entry that was Deprecated before quarantine should not be promoted to Active by a quarantine/restore cycle.
+
+### Vision Principle: Auditable Knowledge Lifecycle
+
+**Status: PASS**
+
+Pre-quarantine status is tracked in the data model, creating an auditable record of the entry's lifecycle. The audit log records the operation including the pre_quarantine_status value. Hash-chained correction histories are unaffected.
+
+### Vision Principle: Security — Entry Quarantine (Integrity Layer)
+
+**Status: PASS**
+
+The PRODUCT-VISION.md explicitly lists "entry quarantine" as part of the integrity security layer. vnc-010 strengthens this by removing an artificial limitation (Active-only) that prevented quarantining entries discovered to be problematic after deprecation.
+
+### Vision Principle: Schema Evolution
+
+**Status: PASS**
+
+The v7->v8 migration follows the established pattern: ALTER TABLE ADD COLUMN with nullable default, backfill existing data, bump version. This is the same approach used for v5->v6 (nxs-008) and v6->v7 (col-012).
+
+### Milestone Alignment: Intelligence Sharpening
+
+**Status: PASS**
+
+vnc-010 is explicitly listed as Wave 1 (critical fixes) in the Intelligence Sharpening milestone. It addresses GitHub issue #43, which has been open since the crt-003 quarantine implementation.
+
+### Architecture Alignment: Service Layer Abstraction
+
+**Status: PASS**
+
+All changes go through the existing service layer (`change_status_with_audit`). No direct SQL from transport layers. No new tool parameters. The API surface is unchanged — only behavioral constraints are relaxed.
+
+## Variance Summary
+
+| Dimension | Status | Notes |
+|-----------|--------|-------|
+| Knowledge trustworthiness | PASS | Closes quarantine gap for deprecated entries |
+| Auditable lifecycle | PASS | Pre-quarantine status tracked and audited |
+| Security integrity | PASS | Strengthens quarantine capability |
+| Schema evolution | PASS | Follows established migration pattern |
+| Milestone alignment | PASS | Wave 1 critical fix, addresses #43 |
+| Architecture alignment | PASS | Service layer, no API surface changes |
+
+**Variances requiring approval: none**
+
+**Open questions: none**

--- a/product/features/vnc-010/IMPLEMENTATION-BRIEF.md
+++ b/product/features/vnc-010/IMPLEMENTATION-BRIEF.md
@@ -1,0 +1,68 @@
+# vnc-010: Implementation Brief
+
+## Summary
+
+Allow quarantine from any non-quarantined status (Active, Deprecated, Proposed) and restore entries to their pre-quarantine status instead of always Active. Schema migration v7->v8 adds `pre_quarantine_status` column.
+
+## Implementation Chunks
+
+### Chunk 1: Schema & Store (unimatrix-store)
+
+**Files**:
+- `crates/unimatrix-store/src/schema.rs` — Add `pre_quarantine_status: Option<u8>` to EntryRecord
+- `crates/unimatrix-store/src/migration.rs` — Add v7->v8 migration step, bump CURRENT_SCHEMA_VERSION to 8
+- `crates/unimatrix-store/src/db.rs` — Add column to CREATE TABLE, update ENTRY_COLUMNS, update entry_from_row, update INSERT in store method, update schema_version init counter to 8
+
+**Changes**:
+1. Add `pre_quarantine_status: Option<u8>` field to `EntryRecord` (after `unhelpful_count`, with `#[serde(default)]`)
+2. Add `pre_quarantine_status INTEGER` to entries CREATE TABLE in `create_tables()`
+3. Update `ENTRY_COLUMNS` constant to include `pre_quarantine_status`
+4. Update `entry_from_row()` to read the new column (nullable i64 -> Option<u8>)
+5. Update entry INSERT statement to include `pre_quarantine_status` (NULL for new entries)
+6. Add migration block for `current_version < 8`: ALTER TABLE + backfill UPDATE
+7. Bump `CURRENT_SCHEMA_VERSION` from 7 to 8
+8. Update fresh-db counter init from 7 to 8
+
+**Tests**: EntryRecord serialization with new field, entry_from_row with NULL and valid values
+
+### Chunk 2: Server Logic (unimatrix-server)
+
+**Files**:
+- `crates/unimatrix-server/src/mcp/tools.rs` — Remove Active-only guard in quarantine path
+- `crates/unimatrix-server/src/server.rs` — Update change_status_with_audit to set/clear pre_quarantine_status, update restore_with_audit to use pre_quarantine_status
+
+**Changes**:
+1. In `context_quarantine` (tools.rs): Remove the `entry.status != Status::Active` check and its error response. The only remaining guard is the idempotent check for already-quarantined entries.
+2. In `change_status_with_audit` (server.rs): When `new_status == Quarantined`, add `pre_quarantine_status = old_status as u8` to the UPDATE SQL. When restoring (new_status != Quarantined), set `pre_quarantine_status = NULL`.
+3. In `restore_with_audit` (server.rs): Fetch entry first, read `pre_quarantine_status`, convert via `Status::try_from()`, fall back to Active. Pass the resolved status to `change_status_with_audit`.
+4. Update audit detail strings to include pre_quarantine_status info.
+
+**Tests**: Integration tests for all status transitions, counter integrity, fallback behavior
+
+### Chunk 3: Migration Integration Test
+
+**Files**:
+- New test in `crates/unimatrix-store/` migration test module or integration tests
+
+**Changes**:
+1. Test: create v7 database with quarantined entry, open store (triggers migration), verify pre_quarantine_status=0
+2. Test: re-open store, verify no re-migration (idempotent)
+
+## Ordering
+
+Chunk 1 -> Chunk 2 -> Chunk 3 (sequential dependency)
+
+## ADR References
+
+- Unimatrix #600: ADR-001 — Option<u8> storage for pre_quarantine_status
+- Unimatrix #601: ADR-002 — Restore fallback to Active
+
+## Risk Hotspots
+
+1. **entry_from_row column index**: Adding a column shifts indices if positional. Verify ENTRY_COLUMNS ordering matches the SELECT.
+2. **UPDATE SQL in change_status_with_audit**: Two SQL variants (with/without modified_by) both need the pre_quarantine_status column added.
+3. **Migration guard**: Must handle the case where ALTER TABLE fails because column already exists (re-run after partial migration).
+
+## Effort Estimate
+
+Small. ~100-150 lines of production code changes, ~200 lines of test code. Single-session implementation.

--- a/product/features/vnc-010/RISK-TEST-STRATEGY.md
+++ b/product/features/vnc-010/RISK-TEST-STRATEGY.md
@@ -1,0 +1,100 @@
+# vnc-010: Risk-Test Strategy
+
+## Risk Registry
+
+### R-01: Migration Column Addition Failure (from SR-01)
+
+**Description**: ALTER TABLE ADD COLUMN could fail if the column already exists (re-run scenario) or if the database is locked.
+**Severity**: High
+**Likelihood**: Low
+**Mitigation**: Guard with pragma_table_info check before ALTER. SQLite ADD COLUMN is atomic within a transaction.
+**Test**: Integration test: open store at v7, verify migration adds column, re-open to verify idempotency.
+
+### R-02: Backfill Correctness (from SR-01)
+
+**Description**: Existing quarantined entries get pre_quarantine_status=0 (Active). If any were not actually quarantined from Active (impossible under current code, but defensive), the backfill is wrong.
+**Severity**: Medium
+**Likelihood**: Very Low
+**Mitigation**: Backfill is correct by construction (old code only allowed Active->Quarantined). Audit log can be consulted for manual correction.
+**Test**: Integration test: create quarantined entry at v7 schema, migrate, verify pre_quarantine_status=0.
+
+### R-03: Counter Drift on Non-Active Quarantine (from SR-02)
+
+**Description**: Quarantining a Deprecated entry must decrement total_deprecated and increment total_quarantined. If the counter logic uses hardcoded status names instead of the generic status_counter_key(), counters drift.
+**Severity**: Medium
+**Likelihood**: Low (existing code is generic)
+**Mitigation**: The existing `change_status_with_audit` uses `status_counter_key(old_status)` which is fully generic. No code change needed for counters.
+**Test**: Integration test: quarantine Deprecated entry, verify total_deprecated decremented and total_quarantined incremented. Restore, verify reverse.
+
+### R-04: Invalid pre_quarantine_status on Restore (from SR-04)
+
+**Description**: If pre_quarantine_status contains a value not in {0,1,2}, Status::try_from will fail. The restore must handle this gracefully.
+**Severity**: Medium
+**Likelihood**: Very Low
+**Mitigation**: ADR-002 specifies fallback to Active. The try_from error is caught, Active is used, and the audit log records the fallback.
+**Test**: Unit test: manually set pre_quarantine_status=99, restore, verify entry becomes Active.
+
+### R-05: Regression in Existing Quarantine Behavior
+
+**Description**: The Active->Quarantined->Active path must continue to work identically to the current implementation.
+**Severity**: High
+**Likelihood**: Low
+**Mitigation**: All existing quarantine tests must pass. The Active path now additionally sets pre_quarantine_status=0, which is additive.
+**Test**: Run all existing quarantine/restore tests unchanged.
+
+## Scope Risk Traceability
+
+| Scope Risk | Architecture Risk | Test Coverage |
+|------------|-------------------|---------------|
+| SR-01: Migration backfill | R-01, R-02 | Migration integration tests |
+| SR-02: Counter bookkeeping | R-03 | Counter integrity integration tests |
+| SR-03: Correct operation | N/A (no change) | Existing correction tests |
+| SR-04: Restore target integrity | R-04 | Invalid status fallback unit test |
+| SR-05: Concurrent race | N/A (existing SQLite) | N/A (existing serialization) |
+
+## Test Plan
+
+### Unit Tests (unimatrix-store)
+
+| Test | Covers |
+|------|--------|
+| EntryRecord with pre_quarantine_status serialization round-trip | Schema field |
+| EntryRecord with pre_quarantine_status=None serialization | Nullable handling |
+| entry_from_row with NULL pre_quarantine_status | SQL mapping |
+| entry_from_row with valid pre_quarantine_status | SQL mapping |
+
+### Integration Tests (unimatrix-server)
+
+| Test | Covers | Risk |
+|------|--------|------|
+| Quarantine Active entry -> pre_quarantine_status=0 | AC-3 | R-05 |
+| Quarantine Deprecated entry -> pre_quarantine_status=1 | AC-1 | R-03 |
+| Quarantine Proposed entry -> pre_quarantine_status=2 | AC-2 | R-03 |
+| Restore to Deprecated (round-trip) | AC-4 | R-03 |
+| Restore to Proposed (round-trip) | AC-4 | R-03 |
+| Restore with NULL pre_quarantine_status -> Active fallback | AC-5 | R-04 |
+| Restore with invalid pre_quarantine_status -> Active fallback | AC-10 | R-04 |
+| Idempotent quarantine (already quarantined) | AC-6 | R-05 |
+| Counter integrity: Deprecated quarantine round-trip | AC-8 | R-03 |
+| Migration v7->v8: column added, backfill correct | AC-7 | R-01, R-02 |
+| Migration idempotency: re-open at v8 | AC-7 | R-01 |
+| Audit log contains pre_quarantine_status detail | AC-9 | - |
+
+### Existing Tests (Must Pass)
+
+All tests in:
+- `crates/unimatrix-server/src/mcp/tools.rs` (quarantine params tests)
+- `crates/unimatrix-store/src/schema.rs` (status round-trip tests)
+- Any integration tests exercising quarantine/restore
+
+## Risk Summary
+
+| Risk | Severity | Test Coverage |
+|------|----------|---------------|
+| R-01: Migration failure | High | Integration |
+| R-02: Backfill correctness | Medium | Integration |
+| R-03: Counter drift | Medium | Integration |
+| R-04: Invalid restore target | Medium | Unit + Integration |
+| R-05: Regression | High | Existing tests |
+
+**Top 3 by severity**: R-01, R-05, R-03

--- a/product/features/vnc-010/SCOPE-RISK-ASSESSMENT.md
+++ b/product/features/vnc-010/SCOPE-RISK-ASSESSMENT.md
@@ -1,0 +1,53 @@
+# vnc-010: Scope Risk Assessment
+
+## SR-01: Migration Backfill Assumption
+
+**Risk**: Existing quarantined entries (created under v7 schema) have no `pre_quarantine_status` value. The migration must backfill these. Since the old code only allowed quarantine from Active status, backfilling as `Active` (0) is correct — but if any entries were quarantined via direct SQL manipulation outside the tool handler, the assumption may be wrong.
+
+**Severity**: Medium
+**Likelihood**: Low (all quarantine operations go through the tool handler)
+**Mitigation**: Backfill as Active (0). Document the assumption in migration comments. The audit_log can be consulted post-migration if any entry's pre-quarantine status needs manual correction.
+
+## SR-02: Status Counter Bookkeeping for Non-Active Sources
+
+**Risk**: The `change_status_with_audit` method decrements the source status counter and increments the target status counter. Currently only Active->Quarantined is tested. Adding Deprecated->Quarantined and Proposed->Quarantined paths means `total_deprecated` and `total_proposed` counters must decrement correctly. On restore, the reverse must happen (e.g., increment `total_deprecated` not `total_active`).
+
+**Severity**: Medium
+**Likelihood**: Low (the existing code already uses `status_counter_key(old_status)` generically)
+**Mitigation**: The existing generic counter logic should work without changes. Add integration tests for each status transition to verify.
+
+## SR-03: Interaction with Correct Operation
+
+**Risk**: The `correct` operation rejects both Deprecated and Quarantined entries. Now that Deprecated entries can be quarantined, there's a question: can a Deprecated entry that was quarantined and then restored be corrected? Answer: No — correction rejects Deprecated entries regardless. No behavior change needed.
+
+**Severity**: Low
+**Likelihood**: N/A (no change required)
+**Mitigation**: Document in specification that correction eligibility is unchanged.
+
+## SR-04: Restore Target Status Integrity
+
+**Risk**: If `pre_quarantine_status` contains an invalid status value (e.g., corruption, future status enum variant), the restore operation could fail or set an unexpected status.
+
+**Severity**: Medium
+**Likelihood**: Very Low
+**Mitigation**: Validate `pre_quarantine_status` via `Status::try_from()` during restore. Fall back to Active if the value is invalid, with a warning in the audit log.
+
+## SR-05: Concurrent Quarantine/Restore Race
+
+**Risk**: Two concurrent quarantine or restore operations on the same entry could create inconsistent state. This is an existing risk not introduced by this feature — the `change_status_with_audit` method runs in a transaction.
+
+**Severity**: Low
+**Likelihood**: Very Low (single-writer SQLite, serialized via spawn_blocking)
+**Mitigation**: No change needed. SQLite serializes writes.
+
+## Summary
+
+| ID | Risk | Severity | Likelihood | Action |
+|----|------|----------|------------|--------|
+| SR-01 | Migration backfill assumption | Medium | Low | Backfill as Active, document |
+| SR-02 | Counter bookkeeping | Medium | Low | Verify existing generic logic, add tests |
+| SR-03 | Correct operation interaction | Low | N/A | Document only |
+| SR-04 | Restore target integrity | Medium | Very Low | Validate + fallback |
+| SR-05 | Concurrent race | Low | Very Low | No change (existing SQLite serialization) |
+
+**Top 3 risks for architect attention**: SR-01, SR-02, SR-04

--- a/product/features/vnc-010/SCOPE.md
+++ b/product/features/vnc-010/SCOPE.md
@@ -1,0 +1,69 @@
+# vnc-010: Quarantine State Restoration
+
+## Problem Statement
+
+Quarantine currently only works from Active status (crt-003 implementation). Two deficiencies:
+
+1. **Cannot quarantine deprecated entries** (#43). Deprecated entries discovered to contain bad information (stale patterns, incorrect conventions) cannot be quarantined. They continue to leak through semantic search since deprecation only applies a confidence penalty — it does not fully hide entries like quarantine does.
+
+2. **Restore always returns to Active**. The `restore_with_audit` method hardcodes `Status::Active` as the target. An entry that was Deprecated before quarantine should return to Deprecated, not Active — otherwise quarantine-then-restore promotes entries incorrectly.
+
+## Root Cause
+
+The original crt-003 quarantine design assumed quarantine would only apply to Active entries. No mechanism exists to track an entry's pre-quarantine status.
+
+- `tools.rs:877`: `if entry.status != Status::Active` guard rejects Deprecated/Proposed
+- `server.rs:833`: `restore_with_audit` hardcodes `Status::Active`
+- `EntryRecord` has no `pre_quarantine_status` field
+- `entries` table has no `pre_quarantine_status` column
+
+## Scope
+
+### In Scope
+
+- Allow quarantine from Active, Deprecated, and Proposed statuses
+- Add `pre_quarantine_status` field to EntryRecord (Option<u8>)
+- Add `pre_quarantine_status` column to entries table (INTEGER, nullable)
+- Schema migration v7 -> v8 (add column, backfill existing quarantined entries as Active)
+- Restore returns entry to its pre-quarantine status instead of always Active
+- Update context_quarantine tool validation
+- Update change_status_with_audit to record/use pre_quarantine_status
+- Unit and integration tests for all new paths
+
+### Out of Scope
+
+- Quarantine from Quarantined status (already idempotent — no change needed)
+- Bulk quarantine operations
+- Quarantine cascading (e.g., quarantining an entry and its supersession chain)
+- Changes to confidence computation for quarantined entries
+- UI/dashboard changes
+
+## Key Stakeholders
+
+- **unimatrix-store**: Schema change, EntryRecord field addition, migration
+- **unimatrix-server**: Tool handler logic, change_status_with_audit updates
+- **All agents**: Can now quarantine entries from any non-quarantined status
+
+## Success Criteria
+
+1. `context_quarantine` accepts entries in Active, Deprecated, or Proposed status
+2. Pre-quarantine status is stored in the database when quarantine occurs
+3. `context_quarantine action=restore` returns entries to their pre-quarantine status
+4. Schema migration v7->v8 is backward-compatible (new column is nullable)
+5. Existing quarantined entries (from v7) get backfilled with pre_quarantine_status=Active
+6. All existing quarantine/restore tests continue to pass
+7. New tests cover Deprecated->Quarantined->Deprecated round-trip
+
+## Risks
+
+- SR-01: Migration must handle existing quarantined entries that have no pre_quarantine_status (backfill as Active — the only valid source status under old logic)
+- SR-02: Status counter bookkeeping must correctly decrement/increment for non-Active source statuses
+- SR-03: The `correct` operation rejects quarantined entries — no change needed, but must verify Deprecated entries can still be corrected (they are rejected too, so no interaction)
+
+## Dependencies
+
+- None. This is Wave 1 (parallel, no prerequisites).
+
+## Effort Estimate
+
+Small. 1 schema column + 1 struct field + ~20 lines of logic changes + migration step + tests.

--- a/product/features/vnc-010/architecture/ARCHITECTURE.md
+++ b/product/features/vnc-010/architecture/ARCHITECTURE.md
@@ -1,0 +1,131 @@
+# vnc-010: Architecture — Quarantine State Restoration
+
+## Overview
+
+Extend the quarantine subsystem to accept entries in any non-quarantined status (Active, Deprecated, Proposed) and track the pre-quarantine status so restore returns entries to their original state.
+
+## Changes by Crate
+
+### unimatrix-store
+
+#### Schema Change (v7 -> v8)
+
+Add nullable column to `entries` table:
+
+```sql
+ALTER TABLE entries ADD COLUMN pre_quarantine_status INTEGER;
+```
+
+Migration step in `migrate_if_needed()`:
+
+```sql
+-- Add column (idempotent via IF NOT EXISTS not available for ALTER TABLE,
+-- so guard with pragma_table_info check or use IF NOT EXISTS pattern)
+ALTER TABLE entries ADD COLUMN pre_quarantine_status INTEGER;
+
+-- Backfill: existing quarantined entries were quarantined from Active (old logic)
+UPDATE entries SET pre_quarantine_status = 0 WHERE status = 3 AND pre_quarantine_status IS NULL;
+```
+
+Schema version bumps from 7 to 8. The `CURRENT_SCHEMA_VERSION` constant updates. The `db.rs` fresh-database schema adds the column.
+
+#### EntryRecord
+
+Add field:
+
+```rust
+#[serde(default)]
+pub pre_quarantine_status: Option<u8>,
+```
+
+Using `Option<u8>` rather than `Option<Status>` for storage simplicity — the column is nullable INTEGER. Conversion to/from `Status` happens at the service layer.
+
+**ADR-001**: `Option<u8>` over `Option<Status>` for the stored field. Status enum conversion at service layer avoids serde complexity and aligns with how `status` itself is stored as INTEGER.
+
+#### entry_from_row / ENTRY_COLUMNS
+
+Update the SQL column list and row-parsing function to include `pre_quarantine_status`. The column maps to `Option<u8>` via `row.get::<_, Option<i64>>()` converted to `Option<u8>`.
+
+### unimatrix-server
+
+#### context_quarantine tool handler (tools.rs)
+
+**Quarantine path**: Remove the `entry.status != Status::Active` guard. Replace with:
+
+```rust
+if entry.status == Status::Quarantined {
+    // idempotent — already quarantined
+    return Ok(format_quarantine_success(...));
+}
+// All non-quarantined statuses are valid quarantine sources
+```
+
+**Restore path**: Instead of hardcoding `Status::Active`, read `pre_quarantine_status` from the entry and restore to that status. Validate via `Status::try_from()`. Fall back to Active if missing or invalid (SR-04).
+
+#### change_status_with_audit (server.rs)
+
+When `new_status == Quarantined`:
+- Record `pre_quarantine_status = old_status as u8` in the UPDATE SQL
+- Include the column in the UPDATE statement
+
+When `new_status != Quarantined` (restore case):
+- Clear `pre_quarantine_status` to NULL in the UPDATE SQL
+
+#### quarantine_with_audit / restore_with_audit
+
+`quarantine_with_audit` — no signature change. The pre_quarantine_status is derived from the entry's current status inside `change_status_with_audit`.
+
+`restore_with_audit` — change to use pre_quarantine_status instead of hardcoded Active:
+
+```rust
+pub(crate) async fn restore_with_audit(
+    &self,
+    entry_id: u64,
+    reason: Option<String>,
+    audit_event: AuditEvent,
+) -> Result<EntryRecord, ServerError> {
+    // Fetch entry to read pre_quarantine_status
+    let entry = self.entry_store.get(entry_id).await
+        .map_err(|e| ServerError::Core(e))?;
+    let restore_to = entry.pre_quarantine_status
+        .and_then(|v| Status::try_from(v).ok())
+        .unwrap_or(Status::Active);
+    self.change_status_with_audit(
+        entry_id, restore_to, reason, audit_event, true,
+    ).await
+}
+```
+
+**ADR-002**: Restore fallback to Active when `pre_quarantine_status` is NULL or invalid. This handles entries quarantined before the migration that were not caught by the backfill, and protects against data corruption. The fallback is logged in the audit trail.
+
+## Data Flow
+
+```
+Quarantine:
+  Entry(Active/Deprecated/Proposed)
+    -> change_status_with_audit(Quarantined)
+    -> SQL: SET status=3, pre_quarantine_status={old_status}
+    -> Counter: decrement old, increment quarantined
+
+Restore:
+  Entry(Quarantined, pre_quarantine_status=X)
+    -> read pre_quarantine_status -> Status::try_from(X)
+    -> change_status_with_audit(restored_status)
+    -> SQL: SET status=X, pre_quarantine_status=NULL
+    -> Counter: decrement quarantined, increment X
+```
+
+## Integration Surfaces
+
+- **SearchService**: No change. Already filters by status; quarantined entries excluded.
+- **BriefingService**: No change. Delegates to SearchService.
+- **ConfidenceService**: No change. Confidence recomputation after quarantine/restore is fire-and-forget and status-aware.
+- **StatusService**: No change. Counter bookkeeping is generic.
+- **SecurityGateway**: No change. Capability check (Admin) unchanged.
+
+## Decisions
+
+| ID | Decision | Rationale |
+|----|----------|-----------|
+| ADR-001 | Store pre_quarantine_status as Option<u8>, not Option<Status> | Aligns with status column (INTEGER), avoids serde enum complexity in schema |
+| ADR-002 | Restore falls back to Active when pre_quarantine_status is NULL/invalid | Safety net for pre-migration entries and data corruption |

--- a/product/features/vnc-010/specification/SPECIFICATION.md
+++ b/product/features/vnc-010/specification/SPECIFICATION.md
@@ -1,0 +1,110 @@
+# vnc-010: Specification — Quarantine State Restoration
+
+## Domain Model
+
+### Modified Entities
+
+**EntryRecord** — Add field:
+- `pre_quarantine_status: Option<u8>` — The status the entry held before quarantine. NULL when not quarantined. Set on quarantine, cleared on restore.
+
+**entries table** — Add column:
+- `pre_quarantine_status INTEGER` — Nullable. Maps to Status enum via u8 representation (0=Active, 1=Deprecated, 2=Proposed).
+
+### Status Transitions
+
+```
+Active(0)      --quarantine--> Quarantined(3) [pre_quarantine_status=0]
+Deprecated(1)  --quarantine--> Quarantined(3) [pre_quarantine_status=1]
+Proposed(2)    --quarantine--> Quarantined(3) [pre_quarantine_status=2]
+Quarantined(3) --restore-----> {pre_quarantine_status} [pre_quarantine_status=NULL]
+```
+
+Invalid transitions (rejected):
+- Quarantined -> Quarantine (idempotent, returns success with "already quarantined")
+- Non-Quarantined -> Restore (rejected, "entry is not quarantined")
+
+## Acceptance Criteria
+
+### AC-1: Quarantine from Deprecated Status
+
+**Given** an entry with status=Deprecated
+**When** `context_quarantine` is called with the entry's ID and action="quarantine"
+**Then** the entry's status becomes Quarantined AND pre_quarantine_status is set to 1 (Deprecated)
+
+### AC-2: Quarantine from Proposed Status
+
+**Given** an entry with status=Proposed
+**When** `context_quarantine` is called with the entry's ID and action="quarantine"
+**Then** the entry's status becomes Quarantined AND pre_quarantine_status is set to 2 (Proposed)
+
+### AC-3: Quarantine from Active Status (Existing Behavior)
+
+**Given** an entry with status=Active
+**When** `context_quarantine` is called with the entry's ID and action="quarantine"
+**Then** the entry's status becomes Quarantined AND pre_quarantine_status is set to 0 (Active)
+
+### AC-4: Restore to Pre-Quarantine Status
+
+**Given** an entry with status=Quarantined and pre_quarantine_status=1 (Deprecated)
+**When** `context_quarantine` is called with action="restore"
+**Then** the entry's status becomes Deprecated AND pre_quarantine_status is set to NULL
+
+### AC-5: Restore with Missing Pre-Quarantine Status (Fallback)
+
+**Given** an entry with status=Quarantined and pre_quarantine_status=NULL
+**When** `context_quarantine` is called with action="restore"
+**Then** the entry's status becomes Active (fallback) AND pre_quarantine_status is set to NULL
+
+### AC-6: Idempotent Quarantine
+
+**Given** an entry already in Quarantined status
+**When** `context_quarantine` is called with action="quarantine"
+**Then** the tool returns success with message "already quarantined" and no state changes
+
+### AC-7: Schema Migration v7 to v8
+
+**Given** a database at schema version 7
+**When** the store is opened
+**Then** the `pre_quarantine_status` column is added to the entries table AND existing quarantined entries have pre_quarantine_status backfilled to 0 (Active) AND schema_version is updated to 8
+
+### AC-8: Status Counter Integrity
+
+**Given** an entry with status=Deprecated
+**When** quarantined and then restored
+**Then** total_deprecated decrements by 1 on quarantine, total_quarantined increments by 1 on quarantine, total_quarantined decrements by 1 on restore, total_deprecated increments by 1 on restore — net zero change after round-trip
+
+### AC-9: Audit Trail
+
+**Given** a quarantine or restore operation
+**When** the operation completes
+**Then** an audit_log entry records the operation, agent_id, entry_id, and outcome (including the pre_quarantine_status value in the detail string)
+
+### AC-10: Restore with Invalid Pre-Quarantine Status
+
+**Given** an entry with status=Quarantined and pre_quarantine_status=99 (invalid)
+**When** `context_quarantine` is called with action="restore"
+**Then** the entry's status becomes Active (fallback) AND the audit detail notes the fallback
+
+## Constraints
+
+- C-1: The migration must be backward-compatible — new column is nullable, no NOT NULL constraint
+- C-2: The migration must be idempotent — re-running on a v8 database is a no-op
+- C-3: `pre_quarantine_status` must only contain values 0, 1, or 2 (Active, Deprecated, Proposed) — never 3 (Quarantined)
+- C-4: Correction eligibility is unchanged — Deprecated and Quarantined entries remain ineligible for correction
+- C-5: Search/lookup filtering is unchanged — quarantined entries remain excluded from results
+
+## API Changes
+
+### context_quarantine
+
+No parameter changes. Behavioral change:
+- **Before**: Rejects entries not in Active status with "only active entries can be quarantined"
+- **After**: Accepts entries in Active, Deprecated, or Proposed status
+
+Response includes pre_quarantine_status information in the detail text when quarantining or restoring.
+
+## Test Strategy Summary
+
+- Unit tests: Status::try_from round-trips, EntryRecord serialization with new field
+- Integration tests: Quarantine from each status, restore to each status, round-trip counter integrity, migration test, fallback behavior
+- Existing test preservation: All current quarantine/restore tests must pass (Active path unchanged)


### PR DESCRIPTION
## Summary

- Design session for vnc-010: Quarantine State Restoration (#43)
- Allows quarantine from Active, Deprecated, and Proposed statuses (currently Active-only)
- Tracks pre-quarantine status so restore returns entries to their original state
- Schema migration v7->v8 adds `pre_quarantine_status` column to entries table

## Artifacts

| File | Purpose |
|------|---------|
| `SCOPE.md` | Problem statement, scope boundaries, success criteria |
| `SCOPE-RISK-ASSESSMENT.md` | 5 scope risks (SR-01 through SR-05) |
| `architecture/ARCHITECTURE.md` | Schema change, crate-level changes, data flow, 2 ADRs |
| `specification/SPECIFICATION.md` | 10 acceptance criteria, domain model, constraints |
| `RISK-TEST-STRATEGY.md` | 5 implementation risks, 12+ test cases |
| `ALIGNMENT-REPORT.md` | All vision dimensions PASS, no variances |
| `IMPLEMENTATION-BRIEF.md` | 3 implementation chunks with file-level guidance |
| `ACCEPTANCE-MAP.md` | AC-to-chunk and risk-to-AC traceability |

## ADRs (Unimatrix)

- **#600**: `pre_quarantine_status` stored as `Option<u8>` (aligns with INTEGER status column)
- **#601**: Restore falls back to Active when `pre_quarantine_status` is NULL or invalid

## Test plan

- [ ] Review SCOPE.md for completeness
- [ ] Review ARCHITECTURE.md for correctness against codebase
- [ ] Review SPECIFICATION.md acceptance criteria (10 ACs)
- [ ] Verify risk coverage in RISK-TEST-STRATEGY.md
- [ ] Approve to proceed to Session 2 (implementation)

Closes: linked to #43 (design phase only, not implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)