### PR TITLE
[vnc-010] Quarantine State Restoration

### DIFF
--- a/crates/unimatrix-engine/src/confidence.rs
+++ b/crates/unimatrix-engine/src/confidence.rs
@@ -534,6 +534,7 @@ mod tests {
             trust_source: trust_source.to_string(),
             helpful_count,
             unhelpful_count,
+            pre_quarantine_status: None,
         }
     }
 

--- a/crates/unimatrix-server/src/infra/coherence.rs
+++ b/crates/unimatrix-server/src/infra/coherence.rs
@@ -244,6 +244,7 @@ mod tests {
             trust_source: String::new(),
             helpful_count: 0,
             unhelpful_count: 0,
+            pre_quarantine_status: None,
         }
     }
 

--- a/crates/unimatrix-server/src/mcp/response/mod.rs
+++ b/crates/unimatrix-server/src/mcp/response/mod.rs
@@ -223,6 +223,7 @@ mod tests {
             trust_source: "agent".to_string(),
             helpful_count: 0,
             unhelpful_count: 0,
+            pre_quarantine_status: None,
         }
     }
 

--- a/crates/unimatrix-server/src/mcp/tools.rs
+++ b/crates/unimatrix-server/src/mcp/tools.rs
@@ -873,15 +873,7 @@ impl UnimatrixServer {
                     ));
                 }
 
-                // Only active entries can be quarantined
-                if entry.status != Status::Active {
-                    return Err(rmcp::ErrorData::from(
-                        crate::error::ServerError::InvalidInput {
-                            field: "id".to_string(),
-                            reason: "only active entries can be quarantined".to_string(),
-                        },
-                    ));
-                }
+                // All non-quarantined statuses (Active, Deprecated, Proposed) are valid
 
                 // Atomic quarantine + audit
                 let audit_event = AuditEvent {

--- a/crates/unimatrix-server/src/server.rs
+++ b/crates/unimatrix-server/src/server.rs
@@ -337,6 +337,7 @@ impl UnimatrixServer {
                 trust_source: entry.trust_source,
                 helpful_count: 0,
                 unhelpful_count: 0,
+                pre_quarantine_status: None,
             };
 
             // INSERT into entries with named params (ADR-004)
@@ -548,6 +549,7 @@ impl UnimatrixServer {
                 trust_source: correction_entry.trust_source,
                 helpful_count: 0,
                 unhelpful_count: 0,
+                pre_quarantine_status: None,
             };
 
             // 6. INSERT correction with named params (ADR-004)
@@ -821,16 +823,23 @@ impl UnimatrixServer {
         ).await
     }
 
-    /// Restore a quarantined entry: set status to Active using direct SQL (nxs-008).
+    /// Restore a quarantined entry to its pre-quarantine status (vnc-010).
+    /// Falls back to Active if pre_quarantine_status is NULL or invalid (ADR-002).
     pub(crate) async fn restore_with_audit(
         &self,
         entry_id: u64,
         reason: Option<String>,
         audit_event: AuditEvent,
     ) -> Result<EntryRecord, ServerError> {
+        // Fetch entry to read pre_quarantine_status
+        let entry = self.entry_store.get(entry_id).await
+            .map_err(ServerError::Core)?;
+        let restore_to = entry.pre_quarantine_status
+            .and_then(|v| unimatrix_store::Status::try_from(v).ok())
+            .unwrap_or(unimatrix_store::Status::Active);
         self.change_status_with_audit(
             entry_id,
-            unimatrix_store::Status::Active,
+            restore_to,
             reason,
             audit_event,
             true, // set modified_by from audit agent_id
@@ -896,23 +905,33 @@ impl UnimatrixServer {
                 .unwrap_or_default()
                 .as_secs();
 
+            // vnc-010: set pre_quarantine_status when quarantining, clear when restoring
+            let old_pre_q = record.pre_quarantine_status;
+            let pre_q_value: Option<i64> = if new_status == unimatrix_store::Status::Quarantined {
+                Some(old_status as u8 as i64)
+            } else {
+                None
+            };
+
             if set_modified_by {
                 conn.execute(
-                    "UPDATE entries SET status = ?1, modified_by = ?2, updated_at = ?3 WHERE id = ?4",
+                    "UPDATE entries SET status = ?1, modified_by = ?2, updated_at = ?3, pre_quarantine_status = ?4 WHERE id = ?5",
                     rusqlite::params![
                         new_status as u8 as i64,
                         &audit_event.agent_id,
                         now as i64,
+                        pre_q_value,
                         entry_id as i64
                     ],
                 ).map_err(|e| ServerError::Core(CoreError::Store(StoreError::Sqlite(e))))?;
                 record.modified_by = audit_event.agent_id.clone();
             } else {
                 conn.execute(
-                    "UPDATE entries SET status = ?1, updated_at = ?2 WHERE id = ?3",
+                    "UPDATE entries SET status = ?1, updated_at = ?2, pre_quarantine_status = ?3 WHERE id = ?4",
                     rusqlite::params![
                         new_status as u8 as i64,
                         now as i64,
+                        pre_q_value,
                         entry_id as i64
                     ],
                 ).map_err(|e| ServerError::Core(CoreError::Store(StoreError::Sqlite(e))))?;
@@ -920,6 +939,7 @@ impl UnimatrixServer {
 
             record.status = new_status;
             record.updated_at = now;
+            record.pre_quarantine_status = pre_q_value.map(|v| v as u8);
 
             // 4. Update status counters
             unimatrix_store::counters::decrement_counter(conn, status_counter_key(old_status), 1)
@@ -927,10 +947,18 @@ impl UnimatrixServer {
             unimatrix_store::counters::increment_counter(conn, status_counter_key(new_status), 1)
                 .map_err(|e| ServerError::Core(CoreError::Store(e)))?;
 
-            // 5. Write audit event
+            // 5. Write audit event (vnc-010: include pre_quarantine_status)
+            let pre_q_info = if new_status == unimatrix_store::Status::Quarantined {
+                format!(" (pre_quarantine_status={})", old_status as u8)
+            } else if let Some(pq) = old_pre_q {
+                // This is a restore — note what we restored from
+                format!(" (restored from pre_quarantine_status={})", pq)
+            } else {
+                String::new()
+            };
             let detail = match &reason {
-                Some(r) => format!("{action_name} entry #{entry_id}: {r}"),
-                None => format!("{action_name} entry #{entry_id}"),
+                Some(r) => format!("{action_name} entry #{entry_id}{pre_q_info}: {r}"),
+                None => format!("{action_name} entry #{entry_id}{pre_q_info}"),
             };
             let audit_with_detail = AuditEvent {
                 target_ids: vec![entry_id],
@@ -1857,6 +1885,320 @@ mod tests {
             .await;
 
         assert!(result.is_err(), "quarantining nonexistent entry should fail");
+    }
+
+    // -- vnc-010: Quarantine State Restoration tests --
+
+    /// Helper: insert entry and deprecate it, returning the entry id.
+    async fn insert_and_deprecate(server: &UnimatrixServer) -> u64 {
+        let id = insert_test_entry(&server.store);
+        let audit_event = crate::infra::audit::AuditEvent {
+            event_id: 0,
+            timestamp: 0,
+            session_id: String::new(),
+            agent_id: "system".to_string(),
+            operation: "context_deprecate".to_string(),
+            target_ids: vec![],
+            outcome: crate::infra::audit::Outcome::Success,
+            detail: String::new(),
+        };
+        server
+            .deprecate_with_audit(id, None, audit_event)
+            .await
+            .unwrap();
+        assert_eq!(
+            server.store.get(id).unwrap().status,
+            unimatrix_store::Status::Deprecated
+        );
+        id
+    }
+
+    // AC-1: Quarantine from Deprecated status
+    #[tokio::test]
+    async fn test_quarantine_deprecated_entry() {
+        let server = make_server();
+        let id = insert_and_deprecate(&server).await;
+
+        let updated = server
+            .quarantine_with_audit(id, Some("obsolete and harmful".into()), make_audit_event("system"))
+            .await
+            .unwrap();
+
+        assert_eq!(updated.status, unimatrix_store::Status::Quarantined);
+        assert_eq!(updated.pre_quarantine_status, Some(1)); // Deprecated = 1
+
+        let fetched = server.store.get(id).unwrap();
+        assert_eq!(fetched.status, unimatrix_store::Status::Quarantined);
+        assert_eq!(fetched.pre_quarantine_status, Some(1));
+    }
+
+    // AC-3: Quarantine from Active sets pre_quarantine_status=0
+    #[tokio::test]
+    async fn test_quarantine_active_sets_pre_quarantine_status() {
+        let server = make_server();
+        let id = insert_test_entry(&server.store);
+
+        let updated = server
+            .quarantine_with_audit(id, None, make_audit_event("system"))
+            .await
+            .unwrap();
+
+        assert_eq!(updated.status, unimatrix_store::Status::Quarantined);
+        assert_eq!(updated.pre_quarantine_status, Some(0)); // Active = 0
+    }
+
+    // AC-4: Restore to pre-quarantine status (Deprecated round-trip)
+    #[tokio::test]
+    async fn test_restore_to_deprecated() {
+        let server = make_server();
+        let id = insert_and_deprecate(&server).await;
+
+        // Quarantine from Deprecated
+        server
+            .quarantine_with_audit(id, None, make_audit_event("system"))
+            .await
+            .unwrap();
+
+        // Restore -- should go back to Deprecated, not Active
+        let restored = server
+            .restore_with_audit(id, None, make_audit_event("system"))
+            .await
+            .unwrap();
+
+        assert_eq!(restored.status, unimatrix_store::Status::Deprecated);
+        assert_eq!(restored.pre_quarantine_status, None); // cleared after restore
+    }
+
+    // AC-5: Restore with NULL pre_quarantine_status falls back to Active
+    #[tokio::test]
+    async fn test_restore_null_pre_quarantine_falls_back_to_active() {
+        let server = make_server();
+        let id = insert_test_entry(&server.store);
+
+        // Quarantine the entry
+        server
+            .quarantine_with_audit(id, None, make_audit_event("system"))
+            .await
+            .unwrap();
+
+        // Manually clear pre_quarantine_status to NULL to simulate pre-migration entry
+        {
+            let conn = server.store.lock_conn();
+            conn.execute(
+                "UPDATE entries SET pre_quarantine_status = NULL WHERE id = ?1",
+                rusqlite::params![id as i64],
+            )
+            .unwrap();
+        }
+
+        // Restore -- should fall back to Active
+        let restored = server
+            .restore_with_audit(id, None, make_audit_event("system"))
+            .await
+            .unwrap();
+
+        assert_eq!(restored.status, unimatrix_store::Status::Active);
+    }
+
+    // AC-8: Counter integrity for Deprecated quarantine round-trip
+    #[tokio::test]
+    async fn test_counter_integrity_deprecated_round_trip() {
+        let server = make_server();
+        let id = insert_and_deprecate(&server).await;
+
+        let before_deprecated = server.store.read_counter("total_deprecated").unwrap();
+        let before_quarantined = server.store.read_counter("total_quarantined").unwrap();
+
+        // Quarantine from Deprecated
+        server
+            .quarantine_with_audit(id, None, make_audit_event("system"))
+            .await
+            .unwrap();
+
+        let mid_deprecated = server.store.read_counter("total_deprecated").unwrap();
+        let mid_quarantined = server.store.read_counter("total_quarantined").unwrap();
+        assert_eq!(mid_deprecated, before_deprecated - 1, "deprecated counter should decrement");
+        assert_eq!(mid_quarantined, before_quarantined + 1, "quarantined counter should increment");
+
+        // Restore to Deprecated
+        server
+            .restore_with_audit(id, None, make_audit_event("system"))
+            .await
+            .unwrap();
+
+        let after_deprecated = server.store.read_counter("total_deprecated").unwrap();
+        let after_quarantined = server.store.read_counter("total_quarantined").unwrap();
+        assert_eq!(after_deprecated, before_deprecated, "deprecated counter should return to initial");
+        assert_eq!(after_quarantined, before_quarantined, "quarantined counter should return to initial");
+    }
+
+    // AC-9: Audit trail includes pre_quarantine_status
+    #[tokio::test]
+    async fn test_quarantine_audit_includes_pre_quarantine_status() {
+        let server = make_server();
+        let id = insert_and_deprecate(&server).await;
+
+        server
+            .quarantine_with_audit(id, Some("harmful".into()), make_audit_event("system"))
+            .await
+            .unwrap();
+
+        let conn = server.store.lock_conn();
+        let detail: String = conn
+            .query_row(
+                "SELECT detail FROM audit_log WHERE operation = 'context_quarantine' ORDER BY event_id DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert!(
+            detail.contains("pre_quarantine_status=1"),
+            "audit detail should contain pre_quarantine_status: {detail}"
+        );
+    }
+
+    // AC-10: Restore with invalid pre_quarantine_status falls back to Active
+    #[tokio::test]
+    async fn test_restore_invalid_pre_quarantine_falls_back_to_active() {
+        let server = make_server();
+        let id = insert_test_entry(&server.store);
+
+        // Quarantine the entry
+        server
+            .quarantine_with_audit(id, None, make_audit_event("system"))
+            .await
+            .unwrap();
+
+        // Manually set pre_quarantine_status to invalid value (99)
+        {
+            let conn = server.store.lock_conn();
+            conn.execute(
+                "UPDATE entries SET pre_quarantine_status = 99 WHERE id = ?1",
+                rusqlite::params![id as i64],
+            )
+            .unwrap();
+        }
+
+        // Restore -- should fall back to Active
+        let restored = server
+            .restore_with_audit(id, None, make_audit_event("system"))
+            .await
+            .unwrap();
+
+        assert_eq!(restored.status, unimatrix_store::Status::Active);
+    }
+
+    // AC-7: Migration v7->v8 (tested at store level)
+    #[tokio::test]
+    async fn test_migration_v7_to_v8_backfill() {
+        // Create a database at v7 schema, quarantine an entry, then re-open
+        // (which triggers migration) and verify backfill
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("migrate.db");
+
+        // Create db at current schema (v8)
+        {
+            let store = unimatrix_store::Store::open(&path).unwrap();
+            // Insert an entry and manually quarantine it with old logic (no pre_quarantine_status)
+            let entry = unimatrix_core::NewEntry {
+                title: "Test".to_string(),
+                content: "Content".to_string(),
+                topic: "test".to_string(),
+                category: "convention".to_string(),
+                tags: vec![],
+                source: "test".to_string(),
+                status: unimatrix_core::Status::Active,
+                created_by: "system".to_string(),
+                feature_cycle: String::new(),
+                trust_source: String::new(),
+            };
+            let id = store.insert(entry).unwrap();
+
+            // Simulate a v7 quarantine (status=3 but no pre_quarantine_status)
+            let conn = store.lock_conn();
+            conn.execute(
+                "UPDATE entries SET status = 3, pre_quarantine_status = NULL WHERE id = ?1",
+                rusqlite::params![id as i64],
+            )
+            .unwrap();
+
+            // Set schema version back to 7 to trigger migration on next open
+            conn.execute(
+                "UPDATE counters SET value = 7 WHERE name = 'schema_version'",
+                [],
+            )
+            .unwrap();
+        }
+
+        // Re-open -- triggers v7->v8 migration
+        {
+            let store = unimatrix_store::Store::open(&path).unwrap();
+            let conn = store.lock_conn();
+
+            // Verify schema version is now 8
+            let version: i64 = conn
+                .query_row(
+                    "SELECT value FROM counters WHERE name = 'schema_version'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(version, 8);
+
+            // Verify backfill: quarantined entry should have pre_quarantine_status = 0
+            let pre_q: Option<i64> = conn
+                .query_row(
+                    "SELECT pre_quarantine_status FROM entries WHERE status = 3",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(pre_q, Some(0), "backfill should set pre_quarantine_status=0 for quarantined entries");
+        }
+
+        // Re-open again to verify idempotency
+        {
+            let store = unimatrix_store::Store::open(&path).unwrap();
+            let conn = store.lock_conn();
+            let version: i64 = conn
+                .query_row(
+                    "SELECT value FROM counters WHERE name = 'schema_version'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(version, 8, "schema version should remain 8 on re-open");
+        }
+    }
+
+    // R-05: Existing Active->Quarantined->Active path still works identically
+    #[tokio::test]
+    async fn test_active_quarantine_restore_round_trip_still_works() {
+        let server = make_server();
+        let id = insert_test_entry(&server.store);
+
+        let initial_active = server.store.read_counter("total_active").unwrap();
+
+        // Quarantine from Active
+        let quarantined = server
+            .quarantine_with_audit(id, None, make_audit_event("system"))
+            .await
+            .unwrap();
+        assert_eq!(quarantined.status, unimatrix_store::Status::Quarantined);
+        assert_eq!(quarantined.pre_quarantine_status, Some(0));
+
+        // Restore -- should go back to Active
+        let restored = server
+            .restore_with_audit(id, None, make_audit_event("system"))
+            .await
+            .unwrap();
+        assert_eq!(restored.status, unimatrix_store::Status::Active);
+        assert_eq!(restored.pre_quarantine_status, None);
+
+        // Counters should return to initial
+        let final_active = server.store.read_counter("total_active").unwrap();
+        assert_eq!(final_active, initial_active);
     }
 
     // -- PendingEntriesAnalysis tests (R-07) --

--- a/crates/unimatrix-server/src/services/store_correct.rs
+++ b/crates/unimatrix-server/src/services/store_correct.rs
@@ -199,6 +199,7 @@ impl StoreService {
                     trust_source: corrected.trust_source,
                     helpful_count: 0,
                     unhelpful_count: 0,
+                    pre_quarantine_status: None,
                 };
 
                 // 6. INSERT correction with named params (ADR-004)

--- a/crates/unimatrix-server/src/services/store_ops.rs
+++ b/crates/unimatrix-server/src/services/store_ops.rs
@@ -229,6 +229,7 @@ impl StoreService {
                 trust_source: entry.trust_source,
                 helpful_count: 0,
                 unhelpful_count: 0,
+                pre_quarantine_status: None,
             };
 
             // 2. INSERT into entries with named params (ADR-004)

--- a/crates/unimatrix-server/src/uds/listener.rs
+++ b/crates/unimatrix-server/src/uds/listener.rs
@@ -2027,6 +2027,7 @@ mod tests {
             trust_source: String::new(),
             helpful_count: 0,
             unhelpful_count: 0,
+            pre_quarantine_status: None,
         }
     }
 

--- a/crates/unimatrix-store/src/db.rs
+++ b/crates/unimatrix-store/src/db.rs
@@ -114,7 +114,8 @@ fn create_tables(conn: &Connection) -> Result<()> {
             feature_cycle   TEXT    NOT NULL DEFAULT '',
             trust_source    TEXT    NOT NULL DEFAULT '',
             helpful_count   INTEGER NOT NULL DEFAULT 0,
-            unhelpful_count INTEGER NOT NULL DEFAULT 0
+            unhelpful_count INTEGER NOT NULL DEFAULT 0,
+            pre_quarantine_status INTEGER
         );
         CREATE TABLE IF NOT EXISTS entry_tags (
             entry_id INTEGER NOT NULL,
@@ -240,7 +241,7 @@ fn create_tables(conn: &Connection) -> Result<()> {
 
     // Initialize counters that other modules expect
     conn.execute_batch(
-        "INSERT OR IGNORE INTO counters (name, value) VALUES ('schema_version', 7);
+        "INSERT OR IGNORE INTO counters (name, value) VALUES ('schema_version', 8);
          INSERT OR IGNORE INTO counters (name, value) VALUES ('next_entry_id', 1);
          INSERT OR IGNORE INTO counters (name, value) VALUES ('next_signal_id', 0);
          INSERT OR IGNORE INTO counters (name, value) VALUES ('next_log_id', 0);

--- a/crates/unimatrix-store/src/migration.rs
+++ b/crates/unimatrix-store/src/migration.rs
@@ -15,7 +15,7 @@ use crate::schema::{deserialize_entry, serialize_entry};
 use crate::db::Store;
 
 /// Current schema version.
-pub(crate) const CURRENT_SCHEMA_VERSION: u64 = 7;
+pub(crate) const CURRENT_SCHEMA_VERSION: u64 = 8;
 
 /// Run migration if schema_version is behind CURRENT_SCHEMA_VERSION.
 /// Called from Store::open() after table creation.
@@ -98,6 +98,31 @@ pub(crate) fn migrate_if_needed(store: &Store, db_path: &Path) -> Result<()> {
                 );
                 CREATE INDEX IF NOT EXISTS idx_observations_session ON observations(session_id);
                 CREATE INDEX IF NOT EXISTS idx_observations_ts ON observations(ts_millis);"
+            ).map_err(StoreError::Sqlite)?;
+        }
+
+        // v7 -> v8: pre_quarantine_status column (vnc-010)
+        if current_version < 8 {
+            // Guard: check if column already exists (handles partial migration re-run)
+            let has_column: bool = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM pragma_table_info('entries') WHERE name = 'pre_quarantine_status'",
+                    [],
+                    |row| Ok(row.get::<_, i64>(0)? > 0),
+                )
+                .unwrap_or(false);
+
+            if !has_column {
+                conn.execute_batch(
+                    "ALTER TABLE entries ADD COLUMN pre_quarantine_status INTEGER;"
+                ).map_err(StoreError::Sqlite)?;
+            }
+
+            // Backfill: existing quarantined entries were quarantined from Active
+            // (old logic only allowed Active->Quarantined)
+            conn.execute(
+                "UPDATE entries SET pre_quarantine_status = 0 WHERE status = 3 AND pre_quarantine_status IS NULL",
+                [],
             ).map_err(StoreError::Sqlite)?;
         }
 
@@ -188,7 +213,8 @@ fn migrate_v5_to_v6(conn: &rusqlite::Connection, db_path: &Path) -> Result<()> {
                 feature_cycle   TEXT    NOT NULL DEFAULT '',
                 trust_source    TEXT    NOT NULL DEFAULT '',
                 helpful_count   INTEGER NOT NULL DEFAULT 0,
-                unhelpful_count INTEGER NOT NULL DEFAULT 0
+                unhelpful_count INTEGER NOT NULL DEFAULT 0,
+                pre_quarantine_status INTEGER
             );
             CREATE TABLE IF NOT EXISTS entry_tags (
                 entry_id INTEGER NOT NULL,

--- a/crates/unimatrix-store/src/read.rs
+++ b/crates/unimatrix-store/src/read.rs
@@ -14,7 +14,8 @@ pub const ENTRY_COLUMNS: &str =
      created_at, updated_at, last_accessed_at, access_count, \
      supersedes, superseded_by, correction_count, embedding_dim, \
      created_by, modified_by, content_hash, previous_hash, \
-     version, feature_cycle, trust_source, helpful_count, unhelpful_count";
+     version, feature_cycle, trust_source, helpful_count, unhelpful_count, \
+     pre_quarantine_status";
 
 /// Construct EntryRecord from a SQLite row using column-by-name access.
 /// Tags are set to vec![] -- caller MUST use load_tags_for_entries() (ADR-006, C-10).
@@ -47,6 +48,8 @@ pub fn entry_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EntryRecord> 
         trust_source: row.get("trust_source")?,
         helpful_count: row.get::<_, i64>("helpful_count")? as u32,
         unhelpful_count: row.get::<_, i64>("unhelpful_count")? as u32,
+        pre_quarantine_status: row.get::<_, Option<i64>>("pre_quarantine_status")?
+            .map(|v| v as u8),
     })
 }
 

--- a/crates/unimatrix-store/src/schema.rs
+++ b/crates/unimatrix-store/src/schema.rs
@@ -93,6 +93,12 @@ pub struct EntryRecord {
     /// Times this entry was marked unhelpful by agents (deduped per session).
     #[serde(default)]
     pub unhelpful_count: u32,
+    // -- vnc-010: quarantine state restoration (appended after unhelpful_count) --
+    /// The status this entry held before quarantine. None when not quarantined.
+    /// Stored as u8 (0=Active, 1=Deprecated, 2=Proposed). Conversion to/from
+    /// Status happens at the service layer (ADR-001).
+    #[serde(default)]
+    pub pre_quarantine_status: Option<u8>,
 }
 
 // -- NewEntry --
@@ -477,6 +483,7 @@ mod tests {
             trust_source: "agent".to_string(),
             helpful_count: 7,
             unhelpful_count: 3,
+            pre_quarantine_status: None,
         };
 
         let bytes = serialize_entry(&record).expect("serialize");
@@ -513,6 +520,7 @@ mod tests {
             trust_source: String::new(),
             helpful_count: 0,
             unhelpful_count: 0,
+            pre_quarantine_status: None,
         };
 
         let bytes = serialize_entry(&record).expect("serialize");
@@ -717,6 +725,7 @@ mod tests {
             trust_source: String::new(),
             helpful_count: 0,
             unhelpful_count: 0,
+            pre_quarantine_status: None,
         }
     }
 }

--- a/crates/unimatrix-store/tests/sqlite_parity.rs
+++ b/crates/unimatrix-store/tests/sqlite_parity.rs
@@ -113,6 +113,7 @@ fn test_update_not_found() {
         trust_source: String::new(),
         helpful_count: 0,
         unhelpful_count: 0,
+        pre_quarantine_status: None,
     };
     let result = db.store().update(fake_record);
     assert!(matches!(result, Err(StoreError::EntryNotFound(999))));


### PR DESCRIPTION
## Summary
- Schema migration v7->v8 adds `pre_quarantine_status` nullable INTEGER column to entries table
- Quarantine now accepts entries in Active, Deprecated, or Proposed status (removes Active-only guard)
- Stores pre-quarantine status on quarantine action, clears on restore
- Restore returns entry to pre-quarantine status with fallback to Active for NULL/invalid values (ADR-002)
- Backfill migration sets pre_quarantine_status=0 for existing quarantined entries
- Audit trail includes pre_quarantine_status in detail strings

## Files Changed
- `crates/unimatrix-store/src/schema.rs` — Added `pre_quarantine_status: Option<u8>` to EntryRecord
- `crates/unimatrix-store/src/db.rs` — Added column to CREATE TABLE, bumped schema_version to 8
- `crates/unimatrix-store/src/migration.rs` — Added v7->v8 migration with idempotent guard + backfill
- `crates/unimatrix-store/src/read.rs` — Updated ENTRY_COLUMNS and entry_from_row
- `crates/unimatrix-server/src/mcp/tools.rs` — Removed Active-only quarantine guard
- `crates/unimatrix-server/src/server.rs` — Updated change_status_with_audit to set/clear pre_quarantine_status, updated restore_with_audit to use pre_quarantine_status with fallback
- 6 additional files updated for EntryRecord field addition (test helpers)

## Tests (9 new, 1568 total passing)
| Test | Covers |
|------|--------|
| test_quarantine_deprecated_entry | AC-1: Quarantine from Deprecated |
| test_quarantine_active_sets_pre_quarantine_status | AC-3: Active quarantine sets field |
| test_restore_to_deprecated | AC-4: Restore to pre-quarantine status |
| test_restore_null_pre_quarantine_falls_back_to_active | AC-5: NULL fallback |
| test_counter_integrity_deprecated_round_trip | AC-8: Counter integrity |
| test_quarantine_audit_includes_pre_quarantine_status | AC-9: Audit trail |
| test_restore_invalid_pre_quarantine_falls_back_to_active | AC-10: Invalid fallback |
| test_migration_v7_to_v8_backfill | AC-7: Migration + idempotency |
| test_active_quarantine_restore_round_trip_still_works | R-05: Regression |

## Risk Coverage
| Risk | Status |
|------|--------|
| R-01: Migration failure | Covered (migration test with idempotency) |
| R-02: Backfill correctness | Covered (migration test verifies backfill) |
| R-03: Counter drift | Covered (deprecated round-trip counter test) |
| R-04: Invalid restore target | Covered (NULL and invalid fallback tests) |
| R-05: Regression | Covered (existing 774 server tests + new round-trip test) |

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)