### PR TITLE
workflow: single-branch lifecycle + worktree cleanup

### DIFF
--- a/.claude/agents/uni/uni-design-scrum-master.md
+++ b/.claude/agents/uni/uni-design-scrum-master.md
@@ -28,7 +28,8 @@ From the primary agent's spawn prompt:
 ```
 SESSION 1 COMPLETE — Design artifacts ready for review.
 
-PR: {URL}
+Branch: feature/{feature-id}
+Draft PR: {URL}
 GH Issue: {URL}
 
 Artifacts: SCOPE.md, SCOPE-RISK-ASSESSMENT.md, ARCHITECTURE.md, SPECIFICATION.md,
@@ -38,7 +39,8 @@ Vision Alignment: {PASS/WARN/VARIANCE/FAIL counts}
 Variances requiring approval: {list or "none"}
 Open questions: {list or "none"}
 
-Human action required: Review and merge PR to approve. Then proceed to Session 2.
+Human action required: Review design artifacts. Then proceed to Session 2
+(implementation will continue on the same branch).
 ```
 
 ---
@@ -62,7 +64,7 @@ Human action required: Review and merge PR to approve. Then proceed to Session 2
 
 ## Initialization
 
-Create the design branch: `git checkout -b design/{feature-id}`
+Create the feature branch: `git checkout -b feature/{feature-id}`
 
 ---
 
@@ -201,15 +203,32 @@ Agent(uni-synthesizer, "
   Return: file paths + GH Issue URL.")
 ```
 
-### Phase 2d: Commit, Push, PR, and Return
+### Phase 2d: Commit, Push, and Checkpoint
 
-Commit all artifacts, push the design branch, and open a PR:
+Commit all artifacts and push the feature branch:
 
 ```bash
 git add product/features/{feature-id}/
 git commit -m "design: {feature-id} design artifacts (#{issue})"
-git push -u origin design/{feature-id}
-gh pr create --title "[{feature-id}] Design artifacts" --body "..."
+git push -u origin feature/{feature-id}
+```
+
+Open a **draft PR** as a review surface (NOT for merge — implementation will add commits to this same branch):
+
+```bash
+gh pr create --draft --title "[{feature-id}] {short description}" --body "$(cat <<'EOF'
+## Design Artifacts
+- Architecture: product/features/{id}/architecture/ARCHITECTURE.md
+- Specification: product/features/{id}/specification/SPECIFICATION.md
+- Risk Strategy: product/features/{id}/RISK-TEST-STRATEGY.md
+- Implementation Brief: product/features/{id}/IMPLEMENTATION-BRIEF.md
+
+## GH Issue
+Closes #{N}
+
+Session 1 (Design) complete. Session 2 (Implementation) will add code commits to this branch.
+EOF
+)"
 ```
 
 Return using the format in "What You Return" above. **Session 1 ends here.**
@@ -248,14 +267,14 @@ Use `/record-outcome` with:
 
 Before returning to the primary agent:
 
-- [ ] Design branch created (`design/{feature-id}`)
+- [ ] Feature branch created (`feature/{feature-id}`)
 - [ ] SCOPE.md exists and was approved by human
 - [ ] All source documents exist (Architecture, Specification, Risk Strategy)
 - [ ] ADRs stored in Unimatrix (entry IDs recorded)
 - [ ] IMPLEMENTATION-BRIEF.md and ACCEPTANCE-MAP.md exist
 - [ ] GH Issue created
-- [ ] Design artifacts committed and pushed to design branch
-- [ ] PR opened to main
+- [ ] Design artifacts committed and pushed to feature branch
+- [ ] Draft PR opened (NOT merged — implementation continues on this branch)
 - [ ] Outcome recorded in Unimatrix
 
 ---

--- a/.claude/agents/uni/uni-implementation-scrum-master.md
+++ b/.claude/agents/uni/uni-implementation-scrum-master.md
@@ -67,8 +67,12 @@ Human action required: {Approve and merge | Address blocking items}.
 1. Read `product/features/{id}/IMPLEMENTATION-BRIEF.md` — Component Map, ADR references, constraints
 2. Read `product/features/{id}/ACCEPTANCE-MAP.md` — AC verification methods
 3. Verify the three source documents exist (Architecture, Specification, Risk Strategy) — paths are listed in the brief
-4. Create feature branch: `git checkout -b feature/{phase}-{NNN}` (see `/uni-git`)
-5. Spawn worker agents with `isolation: "worktree"` for parallel workstreams
+4. Detect branch state:
+   - If already on `feature/{id}` with design commits → stay (Session 1 handoff)
+   - If `feature/{id}` exists but not checked out → `git checkout feature/{id}`
+   - If on main with no feature branch → `git checkout -b feature/{phase}-{NNN}` (see `/uni-git`)
+5. If a draft PR exists for this branch, note the PR number for later conversion to ready
+6. Spawn worker agents with `isolation: "worktree"` for parallel workstreams
 
 ---
 
@@ -361,11 +365,19 @@ git add product/features/{id}/testing/ product/features/{id}/reports/
 git commit -m "test: risk coverage + gate reports (#{issue})"
 ```
 
-2. Push and open PR (see `/uni-git` for PR template):
+2. Push and open/update PR:
 ```bash
 git push -u origin feature/{phase}-{NNN}
-gh pr create --title "[{feature-id}] {title}" --body "..."
 ```
+   - If a draft PR exists (from Session 1): convert to ready and update body:
+     ```bash
+     gh pr ready {pr-number}
+     gh pr edit {pr-number} --title "[{feature-id}] {title}" --body "..."
+     ```
+   - If no PR exists: create one (see `/uni-git` for PR template):
+     ```bash
+     gh pr create --title "[{feature-id}] {title}" --body "..."
+     ```
 
 3. Comment on GH Issue with PR link
 
@@ -476,17 +488,44 @@ cargo clippy --workspace -- -D warnings 2>&1 | head -30
 
 Before returning to the primary agent:
 
-- [ ] Feature branch created (`feature/{phase}-{NNN}`)
+- [ ] Feature branch exists (`feature/{phase}-{NNN}`)
 - [ ] All three gates passed (3a, 3b, 3c)
 - [ ] Gate commits made after each PASS
 - [ ] All unit tests passing
 - [ ] Integration smoke tests passing
 - [ ] No todo!(), unimplemented!(), TODO, FIXME, HACK in non-test code
 - [ ] RISK-COVERAGE-REPORT.md exists
-- [ ] PR opened, GH Issue updated with PR link
+- [ ] PR opened (or draft converted to ready), GH Issue updated with PR link
 - [ ] Auto-chain deploy completed (or failure noted)
-- [ ] Worktrees cleaned up (`git worktree remove` or noted for human)
+- [ ] Worker worktrees cleaned up (see Worktree Cleanup below)
 - [ ] Outcome recorded in Unimatrix
+
+---
+
+## Worktree Cleanup (MANDATORY)
+
+Worker agents spawned with `isolation: "worktree"` create directories under `.claude/worktrees/`.
+Each worktree contains a full `target/` build directory (~1-2GB). Clean up after their work
+is committed to the feature branch.
+
+**When to clean up worker worktrees:** After each gate pass (their changes have been committed).
+
+```bash
+# List worktrees to find agent-created ones
+git worktree list
+
+# Remove each worker worktree (safe — their code is committed)
+git worktree remove .claude/worktrees/{agent-id}/ 2>/dev/null
+
+# Prune stale entries (handles already-deleted directories)
+git worktree prune
+```
+
+**Do NOT remove the session's own worktree** (if the coordinator is running in one).
+That worktree holds the feature branch and must persist until the PR is merged.
+The deploy scrum master or human handles final cleanup after merge.
+
+If a worktree has uncommitted changes, warn the human — do NOT force-remove.
 
 ---
 

--- a/.claude/protocols/uni/uni-design-protocol.md
+++ b/.claude/protocols/uni/uni-design-protocol.md
@@ -6,7 +6,7 @@ Triggers on: specification, architecture, design, research, scope, risk strategy
 
 ## Execution Model
 
-Session 1 produces three sacred source-of-truth documents, a scope risk assessment, a vision alignment report, an implementation brief, and an acceptance map. All work happens on a `design/{feature-id}` branch. The session ends by opening a PR to main — the human reviews and merges the PR as the approval step.
+Session 1 produces three sacred source-of-truth documents, a scope risk assessment, a vision alignment report, an implementation brief, and an acceptance map. All work happens on a `feature/{feature-id}` branch. The session ends by opening a **draft PR** — the human reviews the design artifacts and approves verbally. Session 2 (Implementation) continues on the same branch and converts the draft PR to ready when complete.
 
 ```
 Primary Agent                    uni-scrum-master (Design Leader)    Design Agents
@@ -46,7 +46,7 @@ Each message batches ALL related operations of the same type:
 
 ### Branch Workflow
 
-The Design Leader creates a `design/{feature-id}` branch at session start and opens a PR at session end. See `/uni-git` for branch naming and PR conventions.
+The Design Leader creates a `feature/{feature-id}` branch at session start and opens a **draft PR** at session end. Implementation continues on the same branch — no separate design merge step. See `/uni-git` for branch naming and PR conventions.
 
 ---
 
@@ -241,15 +241,20 @@ Task(
 
 The synthesizer gets a fresh context window — it reads artifacts directly for higher quality synthesis.
 
-#### Phase 2d: Commit, PR, and Return to Human
+#### Phase 2d: Commit, Push, and Checkpoint
 
-The Design Leader commits all artifacts to the design branch and opens a PR:
+The Design Leader commits all artifacts and pushes the feature branch:
 
 ```bash
 git add product/features/{feature-id}/
 git commit -m "design: {feature-id} design artifacts (#{issue})"
-git push -u origin design/{feature-id}
-gh pr create --title "[{feature-id}] Design artifacts" --body "..."
+git push -u origin feature/{feature-id}
+```
+
+Open a **draft PR** as a review surface (NOT for merge — implementation will add commits to this branch):
+
+```bash
+gh pr create --draft --title "[{feature-id}] {short description}" --body "..."
 ```
 
 Then returns to the human:
@@ -257,7 +262,8 @@ Then returns to the human:
 ```
 SESSION 1 COMPLETE — Design artifacts ready for review.
 
-PR: {URL}
+Branch: feature/{feature-id}
+Draft PR: {URL}
 GH Issue: {URL}
 
 Artifacts:
@@ -269,10 +275,11 @@ Vision Alignment: {summary}
 Variances requiring approval: {list or "none"}
 Open questions: {list or "none"}
 
-Human action required: Review and merge PR to approve. Then proceed to Session 2 (Delivery).
+Human action required: Review design artifacts. Then proceed to Session 2
+(implementation will continue on the same branch).
 ```
 
-**Session 1 ends here.** Human merges the PR as the approval step. Session 2 is a separate invocation.
+**Session 1 ends here.** Session 2 continues on the same branch — no merge needed between sessions.
 
 ---
 
@@ -292,7 +299,7 @@ Do NOT paste full documents into agent prompts. Agents read files themselves.
 
 ```
 DESIGN LEADER (uni-scrum-master):
-  Init:       git checkout -b design/{feature-id}
+  Init:       git checkout -b feature/{feature-id}
   Phase 1:    Task(uni-researcher) — scope exploration with human
               ...human approves SCOPE.md...
   Phase 1b:   Task(uni-risk-strategist, MODE: scope-risk) — scope risk assessment
@@ -303,7 +310,7 @@ DESIGN LEADER (uni-scrum-master):
               ...wait...
   Phase 2b:   Task(uni-vision-guardian) — alignment check
   Phase 2c:   Task(uni-synthesizer) — brief + maps + GH Issue (fresh context)
-  Phase 2d:   git commit + push + gh pr create — SESSION 1 ENDS
+  Phase 2d:   git commit + push + gh pr create --draft — SESSION 1 ENDS
 ```
 
 ---

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,4 @@
 {
-  "env": {
-   "ENABLE_CLAUDEAI_MCP_SERVERS": "false"
-  },
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/skills/uni-git/SKILL.md
+++ b/.claude/skills/uni-git/SKILL.md
@@ -8,8 +8,7 @@ All workflows produce PRs. No workflow commits directly to main.
 
 | Context | Pattern | Example | Creator |
 |---------|---------|---------|---------|
-| Feature design (Session 1) | `design/{phase}-{NNN}` | `design/crt-009` | uni-design-scrum-master |
-| Feature delivery (Session 2) | `feature/{phase}-{NNN}` | `feature/crt-009` | uni-implementation-scrum-master |
+| Feature (design + delivery) | `feature/{phase}-{NNN}` | `feature/crt-009` | uni-design-scrum-master (Session 1 creates, Session 2 continues) |
 | Bug fix | `bugfix/{issue}-{desc}` | `bugfix/52-embed-retry` | uni-bugfix-scrum-master |
 | Ad-hoc docs/config | `docs/{short-desc}` | `docs/update-vision` | Human or primary agent |
 | Workflow/process | `workflow/{desc}` | `workflow/base-002` | Human or primary agent |
@@ -17,15 +16,17 @@ All workflows produce PRs. No workflow commits directly to main.
 ### Branch Lifecycle
 
 ```bash
-# Create branch at session start
-git checkout -b {branch-pattern}
+# Session 1 (Design): create feature branch, commit artifacts, open DRAFT PR
+git checkout -b feature/{phase}-{NNN}
+git add <files> && git commit -m "design: {description} (#{issue})"
+git push -u origin feature/{phase}-{NNN}
+gh pr create --draft --title "[{feature-id}] {title}" --body "..."
 
-# Commit after each gate pass or milestone
+# Session 2 (Implementation): continue on same branch, convert draft to ready
+git checkout feature/{phase}-{NNN}  # if not already on it
 git add <files> && git commit -m "{prefix}: {description} (#{issue})"
-git push -u origin {branch}
-
-# Open PR when session completes
-gh pr create --title "[{feature-id}] {title}" --body "..."
+git push -u origin feature/{phase}-{NNN}
+gh pr ready {pr-number}  # convert draft → ready for review
 
 # After merge: branch auto-deletes (repo setting enabled)
 ```
@@ -81,8 +82,19 @@ Coordinators use Claude Code's native `isolation: "worktree"` parameter when spa
 
 **Coordinator responsibilities:**
 - Spawn agents with `isolation: "worktree"` for parallel workstreams
-- Exit gate includes worktree cleanup: `git worktree remove .claude/worktrees/agent-{id}/`
+- Clean up **worker** worktrees after their code is committed to the feature branch (after each gate pass)
+- Do NOT remove the session's own worktree — it must persist until PR merge
 - If removal fails (dirty state): warn human, do NOT force-remove
+
+**Mandatory cleanup after each gate pass:**
+```bash
+# Remove worker worktrees whose code has been committed
+git worktree remove .claude/worktrees/{agent-id}/ 2>/dev/null
+# Prune stale entries
+git worktree prune
+```
+
+Each worktree contains a full `target/` build directory (~1-2GB). Failing to clean up causes disk exhaustion during parallel development.
 
 **Stale worktree recovery:** `git worktree prune` removes entries for deleted directories. Human can `git worktree remove --force` if needed.
 


### PR DESCRIPTION
## Summary
- **Single branch per feature**: Design session creates `feature/{id}` (not `design/{id}`), opens a draft PR. Implementation continues on the same branch and converts draft → ready. Eliminates the docs-only design PR merge step.
- **Mandatory worktree cleanup**: Worker worktrees cleaned after each gate pass to prevent disk exhaustion (~1-2GB each). Session worktree persists until PR merge.
- **Settings.json**: Remove stale env config

## Files Changed
- `.claude/agents/uni/uni-design-scrum-master.md` — feature/ branch, draft PR, updated return format + exit gate
- `.claude/agents/uni/uni-implementation-scrum-master.md` — branch detection logic, draft→ready conversion, worktree cleanup section
- `.claude/protocols/uni/uni-design-protocol.md` — aligned with agent changes
- `.claude/skills/uni-git/SKILL.md` — single branch pattern, cleanup commands
- `.claude/settings.json` — minor cleanup

## Test plan
- [ ] Next design session uses `feature/` branch and opens draft PR
- [ ] Next implementation session detects existing branch and continues
- [ ] Worker worktrees cleaned after gate passes
- [ ] `git worktree list` shows no stale entries after session

🤖 Generated with [Claude Code](https://claude.com/claude-code)