### PR TITLE
[crt-012] Design: Neural Pipeline Cleanup

### DIFF
--- a/product/features/crt-012/ACCEPTANCE-MAP.md
+++ b/product/features/crt-012/ACCEPTANCE-MAP.md
@@ -1,0 +1,44 @@
+# crt-012: Acceptance Map
+
+## Acceptance Criteria to Implementation Mapping
+
+| AC | Description | Implementation Step | Test Coverage | Risk |
+|----|-------------|--------------------|----|------|
+| AC-01 | EwcState deduplication | Step 3: Replace regularization.rs with re-export | Compilation + existing T-LC-04, T-LC-05 | R-02 |
+| AC-02 | TrainingReservoir deduplication | Step 4: Remove struct, import from learn | T-SVC-03, T-SVC-07, T-TRN-14/15/16 | R-03 |
+| AC-03 | AdaptConfig reservoir_seed | Step 2 + Step 4: Add field, wire in service | T-COMPAT-01, existing config tests | R-01 |
+| AC-04 | AdaptConfig init_seed | Step 2 + Step 4: Add field, wire in service | T-COMPAT-01, existing config tests | R-01 |
+| AC-05 | LearnConfig model init seeds | Step 1: Add fields, wire in service | T-FR-CONFIG-01 (updated) | None |
+| AC-06 | Classifier seed constructor | Step 1: Add new_with_baseline_seed() | T-SEED-01, T-CS-01 | R-04 |
+| AC-07 | Scorer seed constructor | Step 1: Add new_with_baseline_seed() | T-SEED-02, T-CS-04 | R-04 |
+| AC-08 | Persistence backward compat | Step 2: #[serde(default)] on new fields | T-COMPAT-01, T-PER-01, T-SVC-10 | R-01 |
+| AC-09 | Test suite passes | Step 5: Full workspace validation | cargo test --workspace | All |
+| AC-10 | Duplicate tests removed | Steps 3-4: Remove from adapt | Canonical tests in learn | None |
+| AC-11 | Different seeds = different results | Step 1: Seed constructors | T-SEED-03, T-SEED-04 | None |
+| AC-12 | No public API changes | All steps: Verify no external changes | cargo check for server/observe/engine | None |
+
+## New Test Summary
+
+| Test ID | File | Validates |
+|---------|------|-----------|
+| T-SEED-01 | unimatrix-learn/src/models/classifier.rs | AC-06: baseline_seed(42) == baseline() |
+| T-SEED-02 | unimatrix-learn/src/models/scorer.rs | AC-07: baseline_seed(123) == baseline() |
+| T-SEED-03 | unimatrix-learn/src/models/classifier.rs | AC-11: seed(42) != seed(99) |
+| T-SEED-04 | unimatrix-learn/src/models/scorer.rs | AC-11: seed(123) != seed(99) |
+| T-COMPAT-01 | unimatrix-adapt/src/config.rs | AC-08: old format deserializes with defaults |
+
+## Removed Tests
+
+| Test ID(s) | File | Reason |
+|------------|------|--------|
+| T-REG-01 to T-REG-09 | unimatrix-adapt/src/regularization.rs | Duplicates of unimatrix-learn/src/ewc.rs tests |
+| T-TRN-01 to T-TRN-03, T-TRN-10 | unimatrix-adapt/src/training.rs | Duplicates of unimatrix-learn/src/reservoir.rs tests |
+
+## Exit Checklist
+
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace` clean
+- [ ] No TODO/unimplemented!() in changed files
+- [ ] AC-01 through AC-12 verified
+- [ ] #113 and #51 closable
+- [ ] No changes to unimatrix-server, unimatrix-observe, unimatrix-engine, unimatrix-core

--- a/product/features/crt-012/ALIGNMENT-REPORT.md
+++ b/product/features/crt-012/ALIGNMENT-REPORT.md
@@ -1,0 +1,49 @@
+# crt-012: Vision Alignment Report
+
+## Alignment Summary
+
+| Dimension | Status | Notes |
+|-----------|--------|-------|
+| Product Vision | PASS | Structural debt cleanup directly supports Intelligence Sharpening milestone |
+| Milestone Fit | PASS | Wave 2 of Intelligence Sharpening, parallel with nxs-009 |
+| Crate Architecture | PASS | Reinforces unimatrix-learn as "shared ML infrastructure" per its crate description |
+| Security | PASS | No security surface changes. Internal refactoring only. |
+| API Stability | PASS | Zero public API changes. No MCP tool modifications. |
+| Backward Compatibility | PASS | Config defaults preserve deterministic behavior. Persistence format unchanged. |
+| Test Infrastructure | PASS | Removes duplicate tests, adds targeted seed verification tests. Net reduction in test code. |
+
+## Vision Alignment Details
+
+### Product Vision: "Self-learning expertise engine"
+
+crt-012 improves the self-learning pipeline's maintainability by eliminating exact code duplication between the learning and adaptation subsystems. This is prerequisite work for Intelligence Sharpening -- cleaning structural debt before tuning and validating the pipeline (Waves 3-4).
+
+### Crate Architecture Alignment
+
+The product vision establishes a clear crate hierarchy. This refactoring reinforces the intended relationship:
+
+- `unimatrix-learn`: "Shared ML infrastructure and neural models" -- becomes the canonical owner of ML primitives (EwcState, TrainingReservoir, neural models).
+- `unimatrix-adapt`: "Adaptive embedding pipeline" -- consumes ML primitives from learn, focuses on LoRA-specific adaptation logic.
+
+The existing dependency `unimatrix-adapt -> unimatrix-learn` was declared but unused. Activating it aligns the code with the declared architecture.
+
+### RNG Configurability and Training Quality
+
+The vision states the pipeline should "get better with every feature delivered." Hardcoded RNG seeds cause identical sampling sequences across training restarts, which can bias model learning. Configurable seeds enable varied sampling in production while preserving determinism for testing.
+
+## Variances
+
+None. All design decisions align with the product vision and milestone goals.
+
+## Cross-Feature Dependencies
+
+| Feature | Relationship |
+|---------|-------------|
+| crt-011 (Confidence Signal Integrity) | No dependency. Different crates (observe/store/server). |
+| crt-013 (Retrieval Calibration) | Touches unimatrix-adapt. crt-012 must land first if both modify AdaptConfig. No conflict: crt-013 modifies service behavior, not config structure. |
+| nxs-009 (Observation Metrics) | No dependency. Different crates (store/observe). |
+| col-015 (E2E Validation) | Benefits from crt-012: unified types simplify the test infrastructure. |
+
+## Risk Items Requiring Attention
+
+None. All risks are mitigated within the design (see RISK-TEST-STRATEGY.md).

--- a/product/features/crt-012/IMPLEMENTATION-BRIEF.md
+++ b/product/features/crt-012/IMPLEMENTATION-BRIEF.md
@@ -1,0 +1,99 @@
+# crt-012: Implementation Brief
+
+## Summary
+
+Deduplicate EwcState and TrainingReservoir across unimatrix-learn and unimatrix-adapt. Make all RNG seeds configurable. Pure refactoring with zero public API changes.
+
+## Implementation Order
+
+### Step 1: LearnConfig seed fields + model constructors (unimatrix-learn)
+
+1. Add `classifier_init_seed: u64` (default 42) and `scorer_init_seed: u64` (default 123) to `LearnConfig` in `src/config.rs`.
+
+2. In `src/models/classifier.rs`:
+   - Rename `new_with_baseline()` body to `new_with_baseline_seed(seed: u64)`.
+   - Make `new_with_baseline()` call `Self::new_with_baseline_seed(42)`.
+
+3. In `src/models/scorer.rs`:
+   - Rename `new_with_baseline()` body to `new_with_baseline_seed(seed: u64)`.
+   - Make `new_with_baseline()` call `Self::new_with_baseline_seed(123)`.
+
+4. In `src/service.rs`:
+   - Update `TrainingService::new()` to use `SignalClassifier::new_with_baseline_seed(config.classifier_init_seed)` and `ConventionScorer::new_with_baseline_seed(config.scorer_init_seed)`.
+   - Update the `try_train_step()` closure similarly.
+
+5. Add tests T-SEED-01 through T-SEED-04 in the respective model test modules.
+
+6. Run `cargo test -p unimatrix-learn`. All existing tests must pass.
+
+### Step 2: AdaptConfig seed fields (unimatrix-adapt)
+
+1. In `src/config.rs`, add:
+   ```rust
+   #[serde(default = "default_reservoir_seed")]
+   pub reservoir_seed: u64,
+   #[serde(default = "default_init_seed")]
+   pub init_seed: u64,
+   ```
+   With `fn default_reservoir_seed() -> u64 { 42 }` and `fn default_init_seed() -> u64 { 42 }`.
+   Update `Default` impl.
+
+2. Add T-COMPAT-01 in `src/config.rs` tests or `src/persistence.rs` tests.
+
+3. Run `cargo test -p unimatrix-adapt`. All existing tests must pass.
+
+### Step 3: EwcState deduplication (unimatrix-adapt)
+
+1. Replace `src/regularization.rs` contents with:
+   ```rust
+   //! EWC++ regularization re-exported from unimatrix-learn.
+   pub use unimatrix_learn::ewc::EwcState;
+   ```
+
+2. Remove all tests from the old `regularization.rs` (canonical tests are in unimatrix-learn).
+
+3. Run `cargo test -p unimatrix-adapt`. Verify `persistence.rs` and `service.rs` compile (they use `crate::regularization::EwcState`).
+
+### Step 4: TrainingReservoir deduplication (unimatrix-adapt)
+
+1. In `src/training.rs`:
+   - Remove the `TrainingReservoir` struct, `use rand::...` imports for it.
+   - Add `use unimatrix_learn::reservoir::TrainingReservoir;`.
+   - The reservoir type becomes `TrainingReservoir<TrainingPair>`.
+   - Update `TrainingReservoir::new()` calls (same signature, just different source).
+   - For `add()`: callers previously passed `&[(u64, u64, u32)]`. Now they must pass `&[TrainingPair]`. Update `add()` call sites to construct `TrainingPair` first.
+   - Remove duplicate reservoir tests (T-TRN-01 through T-TRN-03, T-TRN-10).
+
+2. In `src/service.rs`:
+   - Update `record_training_pairs()` to convert `&[(u64, u64, u32)]` tuples to `Vec<TrainingPair>` before calling `reservoir.add()`.
+   - Wire `config.reservoir_seed` into `TrainingReservoir::new(config.reservoir_capacity, config.reservoir_seed)`.
+   - Wire `config.init_seed` into `MicroLoRA::with_seed(lora_config, config.init_seed)`.
+
+3. Run `cargo test -p unimatrix-adapt`. All remaining tests must pass.
+
+### Step 5: Full workspace validation
+
+1. `cargo test --workspace` -- all tests pass.
+2. `cargo clippy --workspace` -- no new warnings.
+3. `cargo check --workspace` -- clean compilation.
+
+## Key Implementation Notes
+
+- **TrainingPair stays in unimatrix-adapt.** It is an adapt-specific type (co-access pairs). Do not move it to unimatrix-learn.
+- **The adapt-side `training.rs` still contains:** `TrainingPair`, `infonce_loss()`, `infonce_gradients()`, `execute_training_step()`, `add_ewc_gradient()`, `dot()`. Only `TrainingReservoir` is removed.
+- **No changes to `unimatrix-adapt/Cargo.toml`.** The `unimatrix-learn` dependency is already declared.
+- **Persistence module (`persistence.rs`)** uses `use crate::regularization::EwcState` which continues to work via re-export.
+
+## ADRs (for Unimatrix storage when available)
+
+| ADR | Decision |
+|-----|----------|
+| ADR-001 | Re-export pattern for type deduplication |
+| ADR-002 | RNG seed configurability strategy |
+| ADR-003 | No RunningAverage trait extraction |
+
+## Related Issues
+
+- Closes #113 (TrainingReservoir/EwcState dedup)
+- Closes #51 (reservoir RNG seed hardcoded)
+- Parent: #144

--- a/product/features/crt-012/RISK-TEST-STRATEGY.md
+++ b/product/features/crt-012/RISK-TEST-STRATEGY.md
@@ -1,0 +1,120 @@
+# crt-012: Risk-Test Strategy
+
+## Risk Registry
+
+### R-01: Bincode Deserialization Failure with New AdaptConfig Fields (SR-03)
+
+**Severity:** High | **Likelihood:** Medium | **Category:** Data Integrity
+
+Adding `reservoir_seed` and `init_seed` to `AdaptConfig` which is embedded in `AdaptationState` and serialized via bincode. Bincode v2 with serde path has strict field matching. If `#[serde(default)]` is not correctly applied or bincode does not honor it, existing `adaptation.state` files will fail to deserialize, causing the adaptation pipeline to start from scratch.
+
+**Mitigation:**
+- Use `#[serde(default = "default_reservoir_seed")]` with explicit default functions.
+- Add a regression test: serialize `AdaptConfig` without new fields, deserialize with them.
+- The existing `load_state()` already handles deserialization failure gracefully (logs warning, returns None, renames to `.corrupt`). Worst case: cold restart, no data loss.
+
+**Test:** T-COMPAT-01: Deserialize old-format AdaptConfig with new fields present.
+
+### R-02: Import Path Breakage in Adapt-Side Code (SR-02)
+
+**Severity:** Medium | **Likelihood:** Low | **Category:** Build
+
+Changing `regularization.rs` from a full module to a re-export could break internal imports if any code uses `crate::regularization::EwcState` with glob imports or references internal items.
+
+**Mitigation:**
+- The re-export preserves `crate::regularization::EwcState` path.
+- `persistence.rs` is the only internal consumer: `use crate::regularization::EwcState`. This continues to work.
+- Compiler will catch any missed paths immediately.
+
+**Test:** Compilation success is the test. No specific test needed.
+
+### R-03: TrainingReservoir API Mismatch at Call Sites (SR-01)
+
+**Severity:** Medium | **Likelihood:** Medium | **Category:** Build
+
+The adapt-side `TrainingReservoir::add()` accepts `&[(u64, u64, u32)]` tuples. After unification, `TrainingReservoir<TrainingPair>::add()` accepts `&[TrainingPair]`. Call sites must convert.
+
+**Mitigation:**
+- Two call sites to update: `AdaptationService::record_training_pairs()` and `execute_training_step()` (indirectly, via the reservoir being pre-filled).
+- `record_training_pairs()` currently passes raw tuples. After change: map tuples to `TrainingPair` before calling `add()`.
+- The conversion is trivial: `TrainingPair { entry_id_a, entry_id_b, count }`.
+
+**Test:** Existing tests T-SVC-03, T-SVC-06, T-SVC-07 cover `record_training_pairs` and training step execution. They will validate the conversion works.
+
+### R-04: Model Init Seed Constructor Regression (SR-05)
+
+**Severity:** High | **Likelihood:** Low | **Category:** Correctness
+
+If `new_with_baseline_seed(42)` does not produce identical weights to current `new_with_baseline()`, all baseline tests (T-CS-01, T-CS-04) will fail and the production model behavior changes.
+
+**Mitigation:**
+- Implementation: Extract the body of `new_with_baseline()` into `new_with_baseline_seed()`, then `new_with_baseline()` calls `new_with_baseline_seed(42)`. This is a pure mechanical refactoring.
+- The RNG sequence is deterministic for a given seed. Same seed = same weights.
+
+**Test:** T-SEED-01: Verify `new_with_baseline()` and `new_with_baseline_seed(42)` produce identical `flat_parameters()`.
+
+### R-05: Unused Dependency Activation Side Effects
+
+**Severity:** Low | **Likelihood:** Low | **Category:** Build
+
+Activating the `unimatrix-learn` dependency in `unimatrix-adapt` (currently declared but unused) could cause compile-time issues if the crate has feature flags or conditional compilation that interacts unexpectedly.
+
+**Mitigation:**
+- `unimatrix-learn` has no feature flags. No conditional compilation. Simple dependency.
+- Verify `cargo check -p unimatrix-adapt` succeeds with the import added.
+
+**Test:** Compilation success.
+
+## Scope Risk Traceability
+
+| Scope Risk | Architecture Decision | Implementation Risk | Test Coverage |
+|-----------|----------------------|--------------------|----|
+| SR-01 (API mismatch) | ADR-001: Re-export + type alias | R-03 | Existing T-SVC-03, T-SVC-06, T-SVC-07 |
+| SR-02 (test coupling) | ADR-001: Re-export preserves paths | R-02 | Compilation |
+| SR-03 (serde compat) | ADR-002: `#[serde(default)]` | R-01 | T-COMPAT-01 |
+| SR-04 (re-export leakage) | ADR-001: Thin re-exports | None (non-issue) | N/A |
+| SR-05 (baseline constructors) | ADR-002: Seed constructor pattern | R-04 | T-SEED-01 |
+
+## Test Strategy
+
+### New Tests Required
+
+| Test ID | Description | Validates |
+|---------|-------------|-----------|
+| T-SEED-01 | `SignalClassifier::new_with_baseline()` produces same params as `new_with_baseline_seed(42)` | R-04, AC-06 |
+| T-SEED-02 | `ConventionScorer::new_with_baseline()` produces same params as `new_with_baseline_seed(123)` | R-04, AC-07 |
+| T-SEED-03 | Different seeds produce different weights (classifier) | AC-11 |
+| T-SEED-04 | Different seeds produce different weights (scorer) | AC-11 |
+| T-COMPAT-01 | Bincode round-trip with old AdaptConfig format (without new fields) | R-01, AC-08 |
+
+### Existing Tests Providing Coverage
+
+| Test ID(s) | Coverage |
+|------------|----------|
+| T-CS-01 (baseline zero-digest noise) | Classifier baseline determinism (AC-06) |
+| T-CS-04 (scorer baseline low score) | Scorer baseline determinism (AC-07) |
+| T-SVC-03 (record pairs accumulation) | Reservoir API compatibility (AC-02) |
+| T-SVC-07 (train step fires) | End-to-end training with unified types (AC-02) |
+| T-SVC-10 (persistence roundtrip) | Persistence with new config fields (AC-08) |
+| T-PER-01 (save/load roundtrip) | State persistence compatibility (AC-08) |
+| T-FR-CONFIG-01 (default config values) | LearnConfig default verification (AC-05) |
+
+### Tests Removed (Duplicates)
+
+| Removed Test(s) | Canonical Coverage |
+|-----------------|-------------------|
+| T-REG-01 through T-REG-09 (adapt regularization.rs) | T-LC-04, T-LC-05 + ewc.rs tests in unimatrix-learn |
+| T-TRN-01 through T-TRN-03, T-TRN-10 (adapt training.rs reservoir) | T-LC-01 through T-LC-03, reservoir_overflow_no_growth in unimatrix-learn |
+
+## Risk Severity Summary
+
+| Severity | Count | Items |
+|----------|-------|-------|
+| High | 2 | R-01 (bincode compat), R-04 (baseline regression) |
+| Medium | 2 | R-02 (import paths), R-03 (API mismatch) |
+| Low | 1 | R-05 (unused dep activation) |
+
+**Top 3 risks by severity:**
+1. R-01: Bincode deserialization with new fields (mitigated by `#[serde(default)]` + graceful fallback)
+2. R-04: Model init seed constructor regression (mitigated by mechanical refactoring + T-SEED-01)
+3. R-03: TrainingReservoir API mismatch at call sites (mitigated by trivial conversion, caught by compiler)

--- a/product/features/crt-012/SCOPE-RISK-ASSESSMENT.md
+++ b/product/features/crt-012/SCOPE-RISK-ASSESSMENT.md
@@ -1,0 +1,64 @@
+# crt-012: Scope Risk Assessment
+
+## SR-01: API Surface Mismatch Between Generic and Concrete Reservoirs
+
+**Severity:** Medium
+**Likelihood:** Medium
+
+The learn-side `TrainingReservoir<T: Clone>` uses `add(&[T])` and `sample_batch(usize) -> Vec<&T>`. The adapt-side concrete `TrainingReservoir` uses `add(&[(u64, u64, u32)])` which internally constructs `TrainingPair` structs before adding. The `add` method signature differs: the generic version accepts `&[T]` directly, while the adapt-side accepts raw tuples and converts.
+
+**Impact:** The adapt-side `add` method performs a tuple-to-struct conversion that the generic version does not. Callers in `unimatrix-adapt/src/training.rs` (`execute_training_step`) and `unimatrix-adapt/src/service.rs` (`record_training_pairs`) pass `&[(u64, u64, u32)]` tuples. After unification, these call sites must either: (a) construct `TrainingPair` before calling `add`, or (b) the reservoir type becomes `TrainingReservoir<TrainingPair>` and callers convert tuples to `TrainingPair` at the call site.
+
+**Mitigation:** The conversion is trivial (3 fields). Move tuple-to-struct conversion to call sites or add a convenience method on `TrainingPair`. Architect should specify the exact call-site pattern.
+
+## SR-02: Test Coupling to Module Paths
+
+**Severity:** Low
+**Likelihood:** Medium
+
+Tests in `unimatrix-adapt` that use `use crate::regularization::EwcState` or `use crate::training::TrainingReservoir` will need import path updates. Tests within the removed modules will need to move or be deleted (they test the same code now living in `unimatrix-learn`).
+
+**Impact:** Test files that import directly from removed modules will fail to compile. Tests within `regularization.rs` (T-REG-01 through T-REG-09) duplicate tests already in `unimatrix-learn/src/ewc.rs`. Tests within `training.rs` for `TrainingReservoir` (T-TRN-01 through T-TRN-03, T-TRN-10) duplicate tests in `unimatrix-learn/src/reservoir.rs`.
+
+**Mitigation:** Re-export types from `unimatrix-adapt` at the same module path (e.g., `pub use unimatrix_learn::ewc::EwcState;` in a thin `regularization.rs`). Duplicated unit tests can be removed since the canonical tests live in `unimatrix-learn`. Integration tests in `unimatrix-adapt` that exercise the combined pipeline remain unchanged.
+
+## SR-03: AdaptConfig Serde Backward Compatibility
+
+**Severity:** Medium
+**Likelihood:** Low
+
+Adding `reservoir_seed` and `init_seed` fields to `AdaptConfig` changes its serialized format. `AdaptConfig` derives `Serialize, Deserialize` and is persisted via bincode in `unimatrix-adapt/src/persistence.rs`. Existing persisted state files will not contain the new fields.
+
+**Impact:** Loading old adaptation state files will fail deserialization if the new fields are not marked with `#[serde(default)]`. The persistence format uses bincode, which has strict field matching by default.
+
+**Mitigation:** Use `#[serde(default)]` on new fields with default values matching current hardcoded constants (42 for both). Verify bincode compatibility in tests. The persistence module's `AdaptState` struct may also need updating if it embeds `AdaptConfig`.
+
+## SR-04: Re-export Leakage and Public API Surface
+
+**Severity:** Low
+**Likelihood:** Low
+
+Making `unimatrix-adapt` re-export types from `unimatrix-learn` means downstream crates (like `unimatrix-server`) could theoretically access `unimatrix-learn` types through `unimatrix-adapt`. This is not a functional problem but muddies the API surface.
+
+**Impact:** Minimal. The server already depends on both crates directly. No new transitive exposure.
+
+**Mitigation:** Use thin re-export modules (`pub use`) to maintain the existing import paths. Document in `lib.rs` that these types originate from `unimatrix-learn`.
+
+## SR-05: Model Init Seed Configurability Breaks Deterministic Baselines
+
+**Severity:** Medium
+**Likelihood:** Low
+
+Making `SignalClassifier::new_with_baseline()` and `ConventionScorer::new_with_baseline()` accept a seed parameter changes their function signatures. All call sites (in `service.rs`, tests, and potentially `unimatrix-observe`) must be updated.
+
+**Impact:** If the `new_with_baseline()` signature changes, all callers break. The function is used in `TrainingService::new()` (service.rs), `TrainingService::try_train_step()` closure, and numerous tests. The baseline weights are deterministic and relied upon by tests like T-CS-01 (baseline zero-digest noise classification).
+
+**Mitigation:** Add `new_with_baseline_seed(seed: u64)` alongside the existing `new_with_baseline()` (which calls the new one with the default seed). Alternatively, keep `new_with_baseline()` as-is and add a parallel constructor. The architect should decide which pattern.
+
+## Top 3 Risks for Architect Attention
+
+1. **SR-01 (API mismatch):** The adapt-side reservoir wraps tuple-to-struct conversion in `add()`. The architect must specify how call sites adapt to the generic `TrainingReservoir<TrainingPair>`.
+
+2. **SR-03 (serde compat):** Bincode deserialization of `AdaptConfig` with new fields. Must verify `#[serde(default)]` works with bincode v2's strict mode.
+
+3. **SR-05 (baseline constructors):** Model init seed configurability affects a widely-called constructor. Architect should specify the constructor evolution pattern.

--- a/product/features/crt-012/SCOPE.md
+++ b/product/features/crt-012/SCOPE.md
@@ -1,0 +1,109 @@
+# crt-012: Neural Pipeline Cleanup
+
+## Problem Statement
+
+The neural and adaptive pipelines contain two instances of structural duplication and one hardcoded constant that limits training reproducibility control.
+
+### Duplication 1: TrainingReservoir exists in two crates
+
+`TrainingReservoir` is implemented independently in both `unimatrix-learn` and `unimatrix-adapt`:
+
+- **`crates/unimatrix-learn/src/reservoir.rs`** — Generic `TrainingReservoir<T: Clone>` with `add(&[T])`, `sample_batch(usize) -> Vec<&T>`, `len()`, `is_empty()`, `total_seen()`. Used by `TrainingService` in `service.rs` for `TrainingSample` buffering.
+
+- **`crates/unimatrix-adapt/src/training.rs`** — Concrete `TrainingReservoir` (not generic) specialized for `TrainingPair`. Same reservoir sampling algorithm, same `StdRng` seeded RNG, same `add`/`sample_batch`/`len`/`total_seen` API. Used by `AdaptationService` in `service.rs` for co-access pair buffering.
+
+Both implementations use identical reservoir sampling logic: fill-until-capacity, then replace with probability `capacity / total_seen`. Both use `rand::rngs::StdRng` seeded via `seed_from_u64`. The adapt-side version is a specialization of the learn-side generic.
+
+### Duplication 2: EwcState exists in two crates
+
+`EwcState` (EWC++ online regularization) is implemented identically in both:
+
+- **`crates/unimatrix-learn/src/ewc.rs`** — Full EWC++ state with `update()` (from grad matrices), `update_from_flat()` (from flat vectors), `penalty()`, `gradient_contribution()`, `to_vecs()`/`from_vecs()` serialization.
+
+- **`crates/unimatrix-adapt/src/regularization.rs`** — Identical implementation, same module-level docs, same struct fields (`fisher`, `reference_params`, `alpha`, `lambda`, `initialized`), same methods with identical signatures and logic.
+
+Both compute the running exponential average: `F_new = alpha * F_old + (1 - alpha) * F_batch` for Fisher diagonal, and the same formula for reference parameters. The duplication is exact copy-paste.
+
+### Hardcoded RNG Seed
+
+The RNG seed `42` is hardcoded in multiple locations:
+
+1. **`unimatrix-learn/src/config.rs:59`** — `reservoir_seed: 42` as the `LearnConfig` default.
+2. **`unimatrix-adapt/src/service.rs:54`** — `TrainingReservoir::new(config.reservoir_capacity, 42)` inline constant, not from config.
+3. **`unimatrix-adapt/src/lora.rs:41`** — `MicroLoRA::new()` calls `Self::with_seed(config, 42)`.
+4. **`unimatrix-learn/src/models/classifier.rs:72`** — `StdRng::seed_from_u64(42)` for Xavier init.
+5. **`unimatrix-learn/src/models/scorer.rs:27`** — `StdRng::seed_from_u64(123)` for Xavier init.
+
+The `LearnConfig` already has a `reservoir_seed` field, but `AdaptConfig` does not. The adapt-side hardcodes `42` in the service constructor rather than reading from config. MicroLoRA has a `with_seed()` constructor but the primary `new()` always uses `42`.
+
+This means every training epoch samples identically (same RNG sequence), reducing sampling diversity across restarts and potentially biasing which training examples the models see.
+
+## Goals
+
+1. **Extract shared `RunningAverage` trait or struct.** Identify the common running-average state management pattern used by both EwcState implementations. Consolidate into a single implementation. The consolidated EwcState lives in one crate and is imported by the other.
+
+2. **Unify TrainingReservoir.** The generic `TrainingReservoir<T: Clone>` in `unimatrix-learn` already subsumes the concrete version in `unimatrix-adapt`. Make `unimatrix-adapt` import from `unimatrix-learn` (or extract to a shared crate if the dependency direction is wrong).
+
+3. **Make RNG seed configurable in AdaptConfig.** Add a `reservoir_seed: u64` field to `AdaptConfig` (matching `LearnConfig`'s existing field). Wire it through `AdaptationService::new()` to replace the hardcoded `42`.
+
+4. **Add `init_seed` to AdaptConfig for MicroLoRA.** Make the LoRA initialization seed configurable instead of hardcoded `42` in `MicroLoRA::new()`.
+
+5. **Preserve all existing tests.** All 1025+ unit tests and 174+ integration tests must pass. Refactoring must not change observable behavior (same seed defaults mean same deterministic sequences).
+
+## Non-Goals
+
+- **No new functionality.** This is pure structural cleanup. No new ML algorithms, no new training strategies, no new MCP tools.
+- **No changing default seed values.** Defaults remain `42` (and `123` for scorer Xavier init) to preserve deterministic test behavior. The goal is configurability, not different defaults.
+- **No new crate.** Prefer dependency between existing crates over creating a `unimatrix-common` or `unimatrix-ml-core` crate. If dependency direction allows, `unimatrix-adapt` depends on `unimatrix-learn` for shared types. If not, evaluate alternatives.
+- **No changes to the neural extraction pipeline.** SignalClassifier and ConventionScorer initialization seeds (42/123) become configurable but defaults stay the same.
+- **No persistence format changes.** EwcState serialization (`to_vecs`/`from_vecs`) and AdaptConfig serde format remain backward-compatible. New config fields use `#[serde(default)]` for deserialization of old data.
+- **No changes to MCP tool interfaces.** This is internal refactoring only.
+
+## Scope Boundaries
+
+### Crates Modified
+
+| Crate | Changes |
+|-------|---------|
+| `unimatrix-learn` | Canonical home for `TrainingReservoir<T>` and `EwcState`. No structural changes, just becomes the "owner". |
+| `unimatrix-adapt` | Remove duplicated `TrainingReservoir` and `EwcState`. Import from `unimatrix-learn`. Add `reservoir_seed` and `init_seed` to `AdaptConfig`. Wire seed through service/lora constructors. |
+
+### Dependency Direction
+
+`unimatrix-adapt` already depends on `unimatrix-learn` in Cargo.toml (declared but unused). No new dependency needed. `unimatrix-learn` has no workspace dependencies, so no circular dependency risk. The refactoring activates an existing declared dependency.
+
+### Files Affected
+
+**unimatrix-learn:**
+- `src/reservoir.rs` — No changes (already generic, already canonical).
+- `src/ewc.rs` — No changes (already complete implementation).
+- `src/lib.rs` — Ensure `pub mod reservoir` and `pub mod ewc` are publicly exported.
+
+**unimatrix-adapt:**
+- `src/regularization.rs` — Remove entire module, replace with `pub use unimatrix_learn::ewc::EwcState;`.
+- `src/training.rs` — Remove `TrainingReservoir` struct, replace with `use unimatrix_learn::reservoir::TrainingReservoir;`. Adapt `TrainingPair` to work with generic reservoir.
+- `src/config.rs` — Add `reservoir_seed: u64` and `init_seed: u64` fields with `#[serde(default)]`.
+- `src/service.rs` — Wire `config.reservoir_seed` into `TrainingReservoir::new()`. Wire `config.init_seed` into `MicroLoRA::with_seed()`.
+- `src/lora.rs` — Optionally keep `with_seed()` as-is; the change is at the call site.
+- `src/lib.rs` — Update module declarations.
+- `Cargo.toml` — Add `unimatrix-learn` dependency.
+
+### Test Impact
+
+- All existing tests in both crates must pass without modification (same defaults).
+- Tests in `unimatrix-adapt` that directly construct `EwcState` or `TrainingReservoir` will use the imported types transparently (same API).
+- No new test files needed; existing tests cover the shared code.
+
+## Resolved Questions
+
+1. **Dependency direction: CONFIRMED.** `unimatrix-adapt/Cargo.toml` already declares `unimatrix-learn = { path = "../unimatrix-learn" }` as a dependency (line 16). No circular dependency exists. `unimatrix-learn` has zero workspace dependencies (only external: ndarray, rand, serde, bincode, tracing). The dependency exists but is currently unused (no `use unimatrix_learn::` in adapt source). This is the ideal refactoring path.
+
+2. **Model init seeds: YES, include in scope.** Per human decision: classifier seed (42) and scorer seed (123) will become configurable via `LearnConfig` fields `classifier_init_seed` and `scorer_init_seed`, with current values as defaults. This is consistent with the RNG configurability goal.
+
+3. **Shared types stay in `unimatrix-learn`.** Per human decision: ML primitives do not belong in `unimatrix-core` (which holds domain traits: entry types, search results). `unimatrix-learn` is already positioned as "shared ML infrastructure" per its crate description.
+
+## Related Issues
+
+- #113: TrainingReservoir/EwcState deduplication
+- #51: Reservoir RNG seed hardcoded
+- #144: Parent issue for this feature

--- a/product/features/crt-012/architecture/ARCHITECTURE.md
+++ b/product/features/crt-012/architecture/ARCHITECTURE.md
@@ -1,0 +1,142 @@
+# crt-012: Architecture — Neural Pipeline Cleanup
+
+## Overview
+
+Pure refactoring: consolidate duplicated ML primitives (`EwcState`, `TrainingReservoir`) into their canonical home in `unimatrix-learn`, and make all RNG seeds configurable via config structs. No new functionality, no new crates, no persistence format changes.
+
+## Crate Dependency Context
+
+```
+unimatrix-learn (no workspace deps)
+    ^
+    | (already declared in Cargo.toml, currently unused)
+    |
+unimatrix-adapt
+    ^
+    |
+unimatrix-server (depends on both directly)
+```
+
+`unimatrix-learn` is a leaf crate with zero workspace dependencies. `unimatrix-adapt` already declares it as a dependency. This refactoring activates that unused dependency.
+
+## Architecture Decision 1: Re-export Pattern for Backward Compatibility
+
+**Decision:** Thin re-export modules in `unimatrix-adapt` preserve existing import paths.
+
+**Context:** Removing `unimatrix-adapt/src/regularization.rs` entirely would break any code doing `use unimatrix_adapt::regularization::EwcState` (including internal tests and `persistence.rs` which does `use crate::regularization::EwcState`).
+
+**Choice:** Replace `regularization.rs` contents with a single re-export:
+```rust
+pub use unimatrix_learn::ewc::EwcState;
+```
+
+Tests that were inside `regularization.rs` (T-REG-01 through T-REG-09) are removed because identical tests already exist in `unimatrix-learn/src/ewc.rs`. The `crate::regularization::EwcState` import path continues to work.
+
+**Alternatives considered:**
+- Remove `regularization.rs` entirely and update all imports: Higher risk, more churn, no benefit.
+- Re-export at `lib.rs` level only: Breaks `use crate::regularization::EwcState` in internal modules.
+
+## Architecture Decision 2: TrainingReservoir Unification via Type Alias
+
+**Decision:** The adapt-side `TrainingReservoir` struct is replaced with a type alias to the generic learn-side version.
+
+**Context:** The adapt-side `TrainingReservoir` in `training.rs` is not generic -- it is hardcoded to `TrainingPair`. The learn-side version is `TrainingReservoir<T: Clone>`. The adapt-side `add()` method accepts `&[(u64, u64, u32)]` tuples and converts them to `TrainingPair` internally. The learn-side `add()` accepts `&[T]` directly.
+
+**Choice:**
+1. Remove the adapt-side `TrainingReservoir` struct from `training.rs`.
+2. Import the learn-side generic: `use unimatrix_learn::reservoir::TrainingReservoir;`
+3. The reservoir type in adapt becomes `TrainingReservoir<TrainingPair>`.
+4. Move tuple-to-`TrainingPair` conversion to call sites (`AdaptationService::record_training_pairs` and test code). This is 3 lines of mapping.
+
+**Rationale:** The conversion belongs at the API boundary (where raw tuples arrive), not inside the generic data structure. This keeps the reservoir truly generic.
+
+## Architecture Decision 3: Seed Configurability Strategy
+
+**Decision:** All RNG seeds become config fields with defaults matching current hardcoded values.
+
+### AdaptConfig Changes
+
+| Field | Type | Default | Replaces |
+|-------|------|---------|----------|
+| `reservoir_seed` | `u64` | `42` | Hardcoded `42` in `AdaptationService::new()` |
+| `init_seed` | `u64` | `42` | Hardcoded `42` in `MicroLoRA::new()` |
+
+Both fields get `#[serde(default = "...")]` for bincode backward compatibility.
+
+### LearnConfig Changes
+
+| Field | Type | Default | Replaces |
+|-------|------|---------|----------|
+| `classifier_init_seed` | `u64` | `42` | Hardcoded `42` in `SignalClassifier::new_with_baseline()` |
+| `scorer_init_seed` | `u64` | `123` | Hardcoded `123` in `ConventionScorer::new_with_baseline()` |
+
+### Constructor Evolution
+
+**Pattern:** Add `_with_seed(seed)` variant; existing no-arg constructor calls it with default.
+
+- `SignalClassifier::new_with_baseline()` unchanged (calls `new_with_baseline_seed(42)` internally).
+- `SignalClassifier::new_with_baseline_seed(seed: u64)` new public constructor.
+- Same pattern for `ConventionScorer`.
+- `MicroLoRA::new()` already has `with_seed()` -- no change to the type, only the call site in `AdaptationService::new()`.
+
+**Call site changes in `TrainingService::new()`:**
+```rust
+// Before:
+SignalClassifier::new_with_baseline()
+ConventionScorer::new_with_baseline()
+
+// After:
+SignalClassifier::new_with_baseline_seed(config.classifier_init_seed)
+ConventionScorer::new_with_baseline_seed(config.scorer_init_seed)
+```
+
+Also in `TrainingService::try_train_step()` closure where models are reconstructed.
+
+## Architecture Decision 4: Persistence Backward Compatibility
+
+**Decision:** New `AdaptConfig` fields use `#[serde(default)]` with explicit default functions. `AdaptationState` version remains 1 (no version bump needed).
+
+**Context:** `AdaptConfig` is embedded in `AdaptationState` which is persisted via bincode. Bincode v2 with serde path supports `#[serde(default)]` for missing fields during deserialization.
+
+**Rationale:** The new fields (`reservoir_seed`, `init_seed`) are metadata that do not affect the persisted adaptation weights. Old state files are still valid -- the defaults match the previously hardcoded values, so behavior is identical. No version bump is needed because the state's semantic meaning is unchanged.
+
+## Architecture Decision 5: No EwcState Trait Extraction
+
+**Decision:** Do not extract a `RunningAverage` trait from `EwcState`.
+
+**Context:** SCOPE.md Goal 1 mentioned potentially extracting a shared running-average trait. After code analysis, `EwcState` is the only consumer of this pattern in the codebase. The running-average logic is 4 lines within `update()` and `update_from_flat()`. Extracting a trait for a single implementor adds abstraction without value.
+
+**Choice:** Simply deduplicate by re-exporting. No new traits.
+
+## File Change Summary
+
+### unimatrix-learn (owner crate -- minimal changes)
+
+| File | Change |
+|------|--------|
+| `src/lib.rs` | Already exports `EwcState` and `TrainingReservoir` publicly. No change. |
+| `src/config.rs` | Add `classifier_init_seed: u64` (default 42), `scorer_init_seed: u64` (default 123). |
+| `src/models/classifier.rs` | Add `new_with_baseline_seed(seed: u64)`. Existing `new_with_baseline()` delegates to it. |
+| `src/models/scorer.rs` | Add `new_with_baseline_seed(seed: u64)`. Existing `new_with_baseline()` delegates to it. |
+| `src/service.rs` | Wire `config.classifier_init_seed` / `config.scorer_init_seed` into model constructors. |
+
+### unimatrix-adapt (consumer crate -- structural changes)
+
+| File | Change |
+|------|--------|
+| `src/regularization.rs` | Replace body with `pub use unimatrix_learn::ewc::EwcState;` (remove duplicated tests). |
+| `src/training.rs` | Remove `TrainingReservoir` struct. Import from `unimatrix_learn`. Callers convert tuples to `TrainingPair` before `add()`. |
+| `src/config.rs` | Add `reservoir_seed: u64` (default 42), `init_seed: u64` (default 42) with `#[serde(default)]`. |
+| `src/service.rs` | Wire `config.reservoir_seed` to `TrainingReservoir::new()`. Wire `config.init_seed` to `MicroLoRA::with_seed()`. |
+| `src/lib.rs` | No structural change (module declarations unchanged). |
+
+### No changes to
+
+- `unimatrix-core`, `unimatrix-store`, `unimatrix-vector`, `unimatrix-embed`
+- `unimatrix-engine`, `unimatrix-observe`, `unimatrix-server`
+- Any MCP tool interfaces
+- Any persistence formats (state version remains 1)
+
+## Integration Surface
+
+This refactoring has zero integration surface changes. All public APIs retain their signatures. All config defaults match current behavior. No downstream crates are affected.

--- a/product/features/crt-012/specification/SPECIFICATION.md
+++ b/product/features/crt-012/specification/SPECIFICATION.md
@@ -1,0 +1,116 @@
+# crt-012: Specification — Neural Pipeline Cleanup
+
+## Domain Model
+
+### Entities Modified
+
+**TrainingReservoir<T: Clone>** (canonical: `unimatrix-learn/src/reservoir.rs`)
+- No structural changes. Already generic. Becomes the single source of truth.
+- Adapt-side usage: `TrainingReservoir<TrainingPair>`.
+
+**EwcState** (canonical: `unimatrix-learn/src/ewc.rs`)
+- No structural changes. Becomes the single source of truth via re-export.
+- All existing methods retained: `new()`, `update()`, `update_from_flat()`, `penalty()`, `gradient_contribution()`, `to_vecs()`, `from_vecs()`, `is_initialized()`.
+
+**LearnConfig** (`unimatrix-learn/src/config.rs`)
+- New field: `classifier_init_seed: u64` (default: 42)
+- New field: `scorer_init_seed: u64` (default: 123)
+
+**AdaptConfig** (`unimatrix-adapt/src/config.rs`)
+- New field: `reservoir_seed: u64` (default: 42, `#[serde(default)]`)
+- New field: `init_seed: u64` (default: 42, `#[serde(default)]`)
+
+**SignalClassifier** (`unimatrix-learn/src/models/classifier.rs`)
+- New constructor: `new_with_baseline_seed(seed: u64)`
+- Existing: `new_with_baseline()` delegates to `new_with_baseline_seed(42)`
+
+**ConventionScorer** (`unimatrix-learn/src/models/scorer.rs`)
+- New constructor: `new_with_baseline_seed(seed: u64)`
+- Existing: `new_with_baseline()` delegates to `new_with_baseline_seed(123)`
+
+### Entities Removed
+
+**TrainingReservoir** (from `unimatrix-adapt/src/training.rs`)
+- Concrete type removed. Replaced by `unimatrix_learn::reservoir::TrainingReservoir<TrainingPair>`.
+- `TrainingPair` struct remains in `training.rs` (it is adapt-specific).
+
+**EwcState** (from `unimatrix-adapt/src/regularization.rs`)
+- Duplicate implementation removed. Module becomes a re-export.
+
+## Acceptance Criteria
+
+### AC-01: EwcState Deduplication
+- `unimatrix-adapt/src/regularization.rs` contains only `pub use unimatrix_learn::ewc::EwcState;` (plus optional module doc).
+- No EwcState struct definition exists in `unimatrix-adapt`.
+- All adapt-side code that uses `EwcState` compiles without changes to import paths.
+
+### AC-02: TrainingReservoir Deduplication
+- No `TrainingReservoir` struct definition exists in `unimatrix-adapt/src/training.rs`.
+- `unimatrix-adapt` imports `TrainingReservoir` from `unimatrix-learn::reservoir`.
+- The adapt-side reservoir type is `TrainingReservoir<TrainingPair>`.
+- `TrainingPair` struct remains in `unimatrix-adapt/src/training.rs`.
+
+### AC-03: AdaptConfig Reservoir Seed
+- `AdaptConfig` has a `reservoir_seed: u64` field with default value `42`.
+- `AdaptationService::new()` passes `config.reservoir_seed` to `TrainingReservoir::new()`.
+- The field has `#[serde(default)]` for backward-compatible deserialization.
+
+### AC-04: AdaptConfig Init Seed
+- `AdaptConfig` has an `init_seed: u64` field with default value `42`.
+- `AdaptationService::new()` passes `config.init_seed` to `MicroLoRA::with_seed()`.
+- The field has `#[serde(default)]` for backward-compatible deserialization.
+
+### AC-05: LearnConfig Model Init Seeds
+- `LearnConfig` has `classifier_init_seed: u64` (default 42) and `scorer_init_seed: u64` (default 123).
+- `TrainingService::new()` and `try_train_step()` use these seeds when constructing models.
+
+### AC-06: Classifier Seed Constructor
+- `SignalClassifier::new_with_baseline_seed(seed: u64)` exists and produces deterministic weights from the given seed.
+- `SignalClassifier::new_with_baseline()` calls `new_with_baseline_seed(42)` and produces identical output to the current implementation.
+
+### AC-07: Scorer Seed Constructor
+- `ConventionScorer::new_with_baseline_seed(seed: u64)` exists and produces deterministic weights from the given seed.
+- `ConventionScorer::new_with_baseline()` calls `new_with_baseline_seed(123)` and produces identical output to the current implementation.
+
+### AC-08: Persistence Backward Compatibility
+- Existing `adaptation.state` files (version 1) deserialize successfully with new `AdaptConfig` fields receiving default values.
+- The `AdaptationState` version remains 1.
+- A round-trip test (save with new fields, load without them in config) passes.
+
+### AC-09: Test Suite Passes
+- All existing unit tests in `unimatrix-learn` pass without modification.
+- All existing unit tests in `unimatrix-adapt` pass (with import path adjustments only where needed due to type unification).
+- All integration tests pass.
+- No new test failures introduced.
+
+### AC-10: Duplicate Tests Removed
+- Tests T-REG-01 through T-REG-09 in `unimatrix-adapt/src/regularization.rs` are removed (covered by identical tests in `unimatrix-learn/src/ewc.rs`).
+- Tests T-TRN-01 through T-TRN-03 and T-TRN-10 for `TrainingReservoir` in `unimatrix-adapt/src/training.rs` are removed (covered by T-LC-01 through T-LC-03 and `reservoir_overflow_no_growth` in `unimatrix-learn/src/reservoir.rs`).
+
+### AC-11: Different Seeds Produce Different Results
+- `SignalClassifier::new_with_baseline_seed(42)` and `new_with_baseline_seed(99)` produce different weight matrices.
+- `ConventionScorer::new_with_baseline_seed(123)` and `new_with_baseline_seed(99)` produce different weight matrices.
+- `TrainingReservoir::new(100, 42)` and `TrainingReservoir::new(100, 99)` produce different sampling sequences.
+
+### AC-12: No Public API Changes
+- No changes to MCP tool interfaces.
+- No changes to `AdaptationService` public method signatures.
+- No changes to `TrainingService` public method signatures.
+- `unimatrix-server` requires zero changes.
+
+## Constraints
+
+### C-01: No New Crates
+No `unimatrix-ml-core` or similar. Shared types live in `unimatrix-learn`.
+
+### C-02: Default Values Preserve Behavior
+All new config field defaults must match the previously hardcoded values. Tests relying on deterministic initialization (e.g., T-CS-01 baseline zero-digest noise classification) must continue to pass.
+
+### C-03: Serde Compatibility
+New fields in `AdaptConfig` must use `#[serde(default)]` with explicit default functions returning the correct values. Bincode v2 serde path must handle missing fields gracefully.
+
+### C-04: No Downstream Crate Changes
+`unimatrix-server`, `unimatrix-observe`, `unimatrix-engine`, `unimatrix-core` must not require any source changes.
+
+### C-05: Anti-Stub
+No TODO comments, no `unimplemented!()`, no placeholder functions. Complete implementation required.


### PR DESCRIPTION
## Summary

- Design artifacts for crt-012: Neural Pipeline Cleanup
- Deduplicates `TrainingReservoir` and `EwcState` across `unimatrix-learn` and `unimatrix-adapt` (#113)
- Makes all RNG seeds configurable instead of hardcoded (#51)
- Adds model init seed configurability for `SignalClassifier` and `ConventionScorer`
- Pure refactoring: zero public API changes, zero persistence format changes

## Artifacts

- `SCOPE.md` — Problem statement, goals, resolved questions
- `SCOPE-RISK-ASSESSMENT.md` — 5 scope risks identified
- `architecture/ARCHITECTURE.md` — 5 ADRs (re-export pattern, seed strategy, no trait extraction, persistence compat, dependency direction)
- `specification/SPECIFICATION.md` — 12 acceptance criteria, 5 constraints
- `RISK-TEST-STRATEGY.md` — 5 risks, scope risk traceability, 5 new tests, 13 removed duplicate tests
- `ALIGNMENT-REPORT.md` — All dimensions PASS, zero variances
- `IMPLEMENTATION-BRIEF.md` — 5-step implementation order
- `ACCEPTANCE-MAP.md` — AC-to-implementation mapping, exit checklist

## Key Findings

- `unimatrix-adapt` already declares `unimatrix-learn` as a dependency (unused) — no new dependency needed
- EwcState duplication is exact copy-paste across both crates
- Learn-side `TrainingReservoir<T: Clone>` already subsumes the adapt-side concrete version
- RNG seed `42` hardcoded in 4 locations; scorer uses `123`

## Related Issues

- Parent: #144
- Closes: #113 (via implementation)
- Closes: #51 (via implementation)

## Test plan

- [ ] Review SCOPE.md for completeness
- [ ] Verify architecture decisions are sound (especially ADR-001 re-export pattern and ADR-002 seed strategy)
- [ ] Confirm 12 acceptance criteria cover all requirements
- [ ] Validate risk mitigations are adequate
- [ ] Approve to proceed to Session 2 (implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)