### PR TITLE
fix: server recovery — PidGuard race, db retry, transport logging (#146)

### DIFF
--- a/crates/unimatrix-server/src/infra/pidfile.rs
+++ b/crates/unimatrix-server/src/infra/pidfile.rs
@@ -6,9 +6,17 @@
 //!
 //! `PidGuard` provides RAII-based lifecycle management: advisory locking (flock),
 //! PID file write, and cleanup on drop.
+//!
+//! ## Race safety (#146)
+//!
+//! `PidGuard::acquire` uses `OpenOptions` with create+write (no truncate) to
+//! avoid clobbering a PID file that another instance may have just written.
+//! The file content is overwritten only after the flock is acquired, and
+//! `handle_stale_pid_file` no longer removes the PID file -- it leaves it in
+//! place for the incoming server to lock and overwrite via `PidGuard::acquire`.
 
-use std::fs::{self, File};
-use std::io::{self, Write};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Seek, Write};
 use std::path::{Path, PathBuf};
 
 use fs2::FileExt;
@@ -28,11 +36,23 @@ pub struct PidGuard {
 impl PidGuard {
     /// Acquire an exclusive advisory lock on the PID file and write the current PID.
     ///
+    /// Opens with create+write (no truncate) to avoid clobbering a file another
+    /// instance may have just written. The flock is acquired first, then the file
+    /// is truncated and the current PID is written. This eliminates the TOCTOU
+    /// race between `handle_stale_pid_file` and `PidGuard::acquire` (#146).
+    ///
     /// Uses non-blocking `flock(LOCK_EX | LOCK_NB)` via the `fs2` crate.
     /// Returns `Err` if the lock is held by another process or on I/O failure.
     pub fn acquire(path: &Path) -> io::Result<Self> {
-        let mut file = File::create(path)?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(path)?;
         file.try_lock_exclusive()?;
+        // Truncate after lock is held, then write our PID.
+        file.set_len(0)?;
+        file.seek(io::SeekFrom::Start(0))?;
         write!(file, "{}\n", std::process::id())?;
         file.flush()?;
         Ok(PidGuard {
@@ -201,7 +221,8 @@ pub fn terminate_and_wait(_pid: u32, _timeout: std::time::Duration) -> bool {
 /// Handle a stale PID file found at startup.
 ///
 /// If the PID file exists:
-/// - If the recorded process is dead, removes the stale PID file.
+/// - If the recorded process is dead, the PID file is left in place for
+///   `PidGuard::acquire` to lock and overwrite (no TOCTOU race, #146).
 /// - If the recorded process is alive, sends SIGTERM and waits up to
 ///   `terminate_timeout` for it to exit.
 ///
@@ -218,8 +239,9 @@ pub fn handle_stale_pid_file(
     };
 
     if !is_process_alive(pid) {
-        tracing::info!(pid, "removing stale PID file (process is dead)");
-        remove_pid_file(pid_path);
+        tracing::info!(pid, "stale PID file found (process is dead); PidGuard will reclaim");
+        // Do NOT remove the file -- PidGuard::acquire will flock and overwrite it,
+        // eliminating the TOCTOU race (#146).
         return Ok(true);
     }
 
@@ -228,16 +250,16 @@ pub fn handle_stale_pid_file(
     if !is_unimatrix_process(pid) {
         tracing::info!(
             pid,
-            "PID is alive but not unimatrix-server; removing stale PID file"
+            "PID is alive but not unimatrix-server; PidGuard will reclaim"
         );
-        remove_pid_file(pid_path);
+        // Do NOT remove -- same TOCTOU rationale (#146).
         return Ok(true);
     }
 
     tracing::info!(pid, "stale unimatrix-server process detected, sending SIGTERM");
     if terminate_and_wait(pid, terminate_timeout) {
-        tracing::info!(pid, "stale process exited after SIGTERM");
-        remove_pid_file(pid_path);
+        tracing::info!(pid, "stale process exited after SIGTERM; PidGuard will reclaim");
+        // Do NOT remove -- PidGuard::acquire will flock and overwrite (#146).
         Ok(true)
     } else {
         tracing::warn!(pid, "stale process did not exit within timeout");
@@ -334,8 +356,8 @@ mod tests {
         let result =
             handle_stale_pid_file(&path, std::time::Duration::from_secs(1)).unwrap();
         assert!(result);
-        // PID file should have been removed.
-        assert!(!path.exists());
+        // PID file is left in place for PidGuard::acquire to reclaim (#146).
+        assert!(path.exists(), "PID file should remain for PidGuard to reclaim");
     }
 
     #[test]
@@ -444,7 +466,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn test_handle_stale_not_unimatrix_removes_without_sigterm() {
+    fn test_handle_stale_not_unimatrix_resolves_without_sigterm() {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("stale.pid");
         // PID 1 is init — alive but not unimatrix-server.
@@ -453,7 +475,8 @@ mod tests {
         let result =
             handle_stale_pid_file(&path, std::time::Duration::from_secs(1)).unwrap();
         assert!(result, "should resolve stale PID for non-unimatrix process");
-        assert!(!path.exists(), "PID file should be removed");
+        // PID file is left in place for PidGuard::acquire to reclaim (#146).
+        assert!(path.exists(), "PID file should remain for PidGuard to reclaim");
     }
 
     #[test]
@@ -467,6 +490,56 @@ mod tests {
         let result =
             handle_stale_pid_file(&path, std::time::Duration::from_secs(1)).unwrap();
         assert!(result);
+        // PID file remains for PidGuard::acquire to reclaim (#146).
+        assert!(path.exists());
+    }
+
+    // --- #146 race-safety tests ---
+
+    #[test]
+    fn test_pid_guard_acquire_opens_existing_file_without_truncate() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.pid");
+        // Pre-create a PID file with stale content.
+        fs::write(&path, "99999\n").unwrap();
+
+        // PidGuard::acquire should flock then overwrite with current PID.
+        let _guard = PidGuard::acquire(&path).unwrap();
+        let contents = fs::read_to_string(&path).unwrap();
+        let pid: u32 = contents.trim().parse().unwrap();
+        assert_eq!(pid, std::process::id());
+    }
+
+    #[test]
+    fn test_pid_guard_acquire_after_handle_stale_no_remove() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("test.pid");
+        // Simulate a stale PID file from a dead process.
+        fs::write(&path, "4000000\n").unwrap();
+
+        // handle_stale_pid_file should resolve without removing the file.
+        let resolved =
+            handle_stale_pid_file(&path, std::time::Duration::from_secs(1)).unwrap();
+        assert!(resolved);
+        assert!(path.exists(), "file should remain after handle_stale_pid_file");
+
+        // PidGuard::acquire should succeed on the existing file.
+        let _guard = PidGuard::acquire(&path).unwrap();
+        let contents = fs::read_to_string(&path).unwrap();
+        let pid: u32 = contents.trim().parse().unwrap();
+        assert_eq!(pid, std::process::id());
+    }
+
+    #[test]
+    fn test_pid_guard_acquire_creates_file_if_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("new.pid");
         assert!(!path.exists());
+
+        let _guard = PidGuard::acquire(&path).unwrap();
+        assert!(path.exists());
+        let contents = fs::read_to_string(&path).unwrap();
+        let pid: u32 = contents.trim().parse().unwrap();
+        assert_eq!(pid, std::process::id());
     }
 }

--- a/crates/unimatrix-server/src/main.rs
+++ b/crates/unimatrix-server/src/main.rs
@@ -271,19 +271,64 @@ async fn tokio_main(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     // Wait for session close or signal, then shutdown.
     // Flock-based PidGuard handles zombie cleanup at next startup.
-    let waiting = async { let _ = running.waiting().await; };
+    // Log transport close reason instead of silently discarding (#146).
+    let waiting = async {
+        match running.waiting().await {
+            Ok(reason) => {
+                tracing::info!(?reason, "MCP transport closed");
+            }
+            Err(join_err) => {
+                tracing::error!(error = %join_err, "MCP transport task failed");
+            }
+        }
+    };
     shutdown::graceful_shutdown(lifecycle_handles, waiting).await?;
 
     tracing::info!("unimatrix server exited cleanly");
     Ok(())
 }
 
-/// Open the database store.
+/// Maximum number of database open attempts before giving up.
+const DB_OPEN_MAX_ATTEMPTS: u32 = 3;
+
+/// Base delay between database open retries (doubles each attempt).
+const DB_OPEN_RETRY_BASE_MS: u64 = 1000;
+
+/// Open the database store with retry on lock contention.
+///
+/// Retries up to `DB_OPEN_MAX_ATTEMPTS` times with exponential backoff
+/// (1s, 2s, 4s). This gives a stale process time to release the SQLite
+/// lock after receiving SIGTERM in `handle_stale_pid_file` (#146).
 fn open_store_with_retry(
     db_path: &std::path::Path,
 ) -> Result<Arc<Store>, Box<dyn std::error::Error>> {
-    let store = Store::open(db_path)
-        .map_err(|e| ServerError::Core(CoreError::Store(e)))?;
-    Ok(Arc::new(store))
+    let mut last_err = None;
+    for attempt in 1..=DB_OPEN_MAX_ATTEMPTS {
+        match Store::open(db_path) {
+            Ok(store) => {
+                if attempt > 1 {
+                    tracing::info!(attempt, "database opened after retry");
+                }
+                return Ok(Arc::new(store));
+            }
+            Err(e) => {
+                if attempt < DB_OPEN_MAX_ATTEMPTS {
+                    let delay_ms = DB_OPEN_RETRY_BASE_MS * 2u64.pow(attempt - 1);
+                    tracing::warn!(
+                        attempt,
+                        max_attempts = DB_OPEN_MAX_ATTEMPTS,
+                        delay_ms,
+                        error = %e,
+                        "database open failed, retrying"
+                    );
+                    std::thread::sleep(Duration::from_millis(delay_ms));
+                }
+                last_err = Some(e);
+            }
+        }
+    }
+    Err(Box::new(ServerError::Core(CoreError::Store(
+        last_err.expect("at least one attempt was made"),
+    ))))
 }
 


### PR DESCRIPTION
## Summary

Fixes intermittent MCP server failure and unclean recovery (#146), a recurrence of #52.

- **PidGuard TOCTOU race**: `acquire()` now uses `OpenOptions` (create+write, no truncate) and truncates only after flock is held. `handle_stale_pid_file` no longer removes the PID file — `PidGuard::acquire` locks and overwrites it, eliminating the window where two instances can race.
- **Database open retry**: `open_store_with_retry` now retries 3 times with exponential backoff (1s/2s/4s), giving stale processes time to release SQLite WAL lock after SIGTERM.
- **Transport error logging**: `running.waiting()` result is now logged instead of silently discarded (`let _ =`), making transport close/failure visible for diagnostics.

## Test plan

- [x] 25 pidfile unit tests pass (3 new, 3 updated assertions)
- [x] 792 server crate tests pass
- [x] 1,652 full workspace tests pass
- [x] No new clippy warnings in changed files
- [x] No stubs (todo!, unimplemented!, TODO, FIXME)
- [x] No unsafe code (crate has `#![forbid(unsafe_code)]`)
- [ ] Manual verification: start two server instances simultaneously to confirm flock prevents race
- [ ] Manual verification: kill server with SIGKILL, verify next startup recovers cleanly

Generated with [Claude Code](https://claude.com/claude-code)