### PR TITLE
fix: resolve deadlock in scan_sessions_by_feature_with_status (#152)

### DIFF
--- a/crates/unimatrix-store/src/sessions.rs
+++ b/crates/unimatrix-store/src/sessions.rs
@@ -228,28 +228,36 @@ impl Store {
         status_filter: Option<SessionLifecycleStatus>,
     ) -> Result<Vec<SessionRecord>> {
         let conn = self.lock_conn();
-        match status_filter {
-            None => self.scan_sessions_by_feature(feature_cycle),
-            Some(status) => {
-                let mut stmt = conn
-                    .prepare(&format!(
-                        "SELECT {} FROM sessions WHERE feature_cycle = ?1 AND status = ?2",
-                        SESSION_COLUMNS
-                    ))
-                    .map_err(StoreError::Sqlite)?;
-                let rows = stmt
-                    .query_map(
-                        rusqlite::params![feature_cycle, status as u8 as i64],
-                        session_from_row,
-                    )
-                    .map_err(StoreError::Sqlite)?;
-                let mut results = Vec::new();
-                for row in rows {
-                    results.push(row.map_err(StoreError::Sqlite)?);
-                }
-                Ok(results)
-            }
+        let mut stmt = match status_filter {
+            None => conn
+                .prepare(&format!(
+                    "SELECT {} FROM sessions WHERE feature_cycle = ?1",
+                    SESSION_COLUMNS
+                ))
+                .map_err(StoreError::Sqlite)?,
+            Some(_) => conn
+                .prepare(&format!(
+                    "SELECT {} FROM sessions WHERE feature_cycle = ?1 AND status = ?2",
+                    SESSION_COLUMNS
+                ))
+                .map_err(StoreError::Sqlite)?,
+        };
+        let rows = match status_filter {
+            None => stmt
+                .query_map(rusqlite::params![feature_cycle], session_from_row)
+                .map_err(StoreError::Sqlite)?,
+            Some(status) => stmt
+                .query_map(
+                    rusqlite::params![feature_cycle, status as u8 as i64],
+                    session_from_row,
+                )
+                .map_err(StoreError::Sqlite)?,
+        };
+        let mut results = Vec::new();
+        for row in rows {
+            results.push(row.map_err(StoreError::Sqlite)?);
         }
+        Ok(results)
     }
 
     /// GC sweep: mark old Active sessions as TimedOut; delete very old sessions


### PR DESCRIPTION
## Summary
- Fix deadlock in `scan_sessions_by_feature_with_status()` when called with `status_filter: None`
- The `None` branch delegated to `scan_sessions_by_feature()` which called `lock_conn()` on the already-held non-reentrant `std::sync::Mutex`, hanging forever
- Inlined both branches to use the already-acquired connection, deduplicating the result collection

## Test plan
- [x] `test_scan_sessions_with_status_filter` now passes (previously hung indefinitely)
- [x] Full `unimatrix-store` test suite passes (17/17)
- [x] Full workspace test suite passes
- [x] Clippy clean

Fixes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)