### PR TITLE
fix: add content-based attribution fallback for retrospective (#162)

### DIFF
--- a/crates/unimatrix-observe/src/source.rs
+++ b/crates/unimatrix-observe/src/source.rs
@@ -4,7 +4,7 @@
 //! Implemented by SqlObservationSource in unimatrix-server.
 
 use crate::error::Result;
-use crate::types::{ObservationRecord, ObservationStats};
+use crate::types::{ObservationRecord, ObservationStats, ParsedSession};
 
 /// Abstraction over observation data storage.
 ///
@@ -24,6 +24,13 @@ pub trait ObservationSource {
     ///
     /// Returns session IDs from the sessions table where feature_cycle matches.
     fn discover_sessions_for_feature(&self, feature_cycle: &str) -> Result<Vec<String>>;
+
+    /// Load sessions with NULL feature_cycle and their observations.
+    ///
+    /// Returns `ParsedSession` structs (grouped by session_id, sorted by timestamp)
+    /// for sessions where `feature_cycle IS NULL`. Used as a fallback for
+    /// content-based attribution when the direct feature_cycle query returns empty.
+    fn load_unattributed_sessions(&self) -> Result<Vec<ParsedSession>>;
 
     /// Get aggregate observation statistics.
     ///

--- a/crates/unimatrix-server/src/mcp/tools.rs
+++ b/crates/unimatrix-server/src/mcp/tools.rs
@@ -1024,12 +1024,27 @@ impl UnimatrixServer {
             .map_err(rmcp::ErrorData::from)?;
 
         // 3. Load observations from SQL via ObservationSource (col-012)
+        //    First try direct feature_cycle query (fast path).
+        //    If empty, fall back to content-based attribution (#162).
         let store_for_obs = Arc::clone(&self.store);
         let feature_cycle_for_load = params.feature_cycle.clone();
         let attributed = tokio::task::spawn_blocking(move || -> std::result::Result<Vec<unimatrix_observe::ObservationRecord>, unimatrix_observe::ObserveError> {
             use unimatrix_observe::ObservationSource;
             let source = crate::services::observation::SqlObservationSource::new(store_for_obs);
-            source.load_feature_observations(&feature_cycle_for_load)
+
+            // Fast path: direct feature_cycle query
+            let direct = source.load_feature_observations(&feature_cycle_for_load)?;
+            if !direct.is_empty() {
+                return Ok(direct);
+            }
+
+            // Fallback: content-based attribution for sessions with NULL feature_cycle
+            let unattributed = source.load_unattributed_sessions()?;
+            if unattributed.is_empty() {
+                return Ok(vec![]);
+            }
+
+            Ok(unimatrix_observe::attribute_sessions(&unattributed, &feature_cycle_for_load))
         })
         .await
         .unwrap()

--- a/crates/unimatrix-server/src/services/observation.rs
+++ b/crates/unimatrix-server/src/services/observation.rs
@@ -9,7 +9,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use unimatrix_observe::error::{ObserveError, Result};
 use unimatrix_observe::source::ObservationSource;
-use unimatrix_observe::types::{HookType, ObservationRecord, ObservationStats};
+use unimatrix_observe::types::{HookType, ObservationRecord, ObservationStats, ParsedSession};
 use unimatrix_store::rusqlite;
 use unimatrix_store::Store;
 
@@ -134,6 +134,101 @@ impl ObservationSource for SqlObservationSource {
             .map_err(|e| ObserveError::Database(e.to_string()))?;
 
         Ok(sessions)
+    }
+
+    fn load_unattributed_sessions(&self) -> Result<Vec<ParsedSession>> {
+        let conn = self.store.lock_conn();
+
+        // Step 1: Get session_ids where feature_cycle IS NULL.
+        let mut session_stmt = conn
+            .prepare("SELECT session_id FROM sessions WHERE feature_cycle IS NULL")
+            .map_err(|e| ObserveError::Database(e.to_string()))?;
+
+        let session_ids: Vec<String> = session_stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| ObserveError::Database(e.to_string()))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| ObserveError::Database(e.to_string()))?;
+
+        drop(session_stmt);
+
+        if session_ids.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // Step 2: Load observations for those sessions, ordered by session then timestamp.
+        let placeholders: String = session_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "SELECT session_id, ts_millis, hook, tool, input, response_size, response_snippet
+             FROM observations
+             WHERE session_id IN ({})
+             ORDER BY session_id, ts_millis ASC",
+            placeholders
+        );
+
+        let mut obs_stmt = conn
+            .prepare(&sql)
+            .map_err(|e| ObserveError::Database(e.to_string()))?;
+
+        let rows = obs_stmt
+            .query_map(rusqlite::params_from_iter(session_ids.iter()), |row| {
+                Ok((
+                    row.get::<_, String>(0)?,         // session_id
+                    row.get::<_, i64>(1)?,            // ts_millis
+                    row.get::<_, String>(2)?,         // hook
+                    row.get::<_, Option<String>>(3)?, // tool
+                    row.get::<_, Option<String>>(4)?, // input
+                    row.get::<_, Option<i64>>(5)?,    // response_size
+                    row.get::<_, Option<String>>(6)?, // response_snippet
+                ))
+            })
+            .map_err(|e| ObserveError::Database(e.to_string()))?;
+
+        // Step 3: Group into ParsedSession structs.
+        let mut sessions_map: std::collections::HashMap<String, Vec<ObservationRecord>> =
+            std::collections::HashMap::new();
+
+        for row_result in rows {
+            let (session_id, ts_millis, hook_str, tool, input_str, response_size, response_snippet) =
+                row_result.map_err(|e| ObserveError::Database(e.to_string()))?;
+
+            let hook = match hook_str.as_str() {
+                "PreToolUse" => HookType::PreToolUse,
+                "PostToolUse" => HookType::PostToolUse,
+                "SubagentStart" => HookType::SubagentStart,
+                "SubagentStop" => HookType::SubagentStop,
+                _ => continue,
+            };
+
+            let input = match (&hook, input_str) {
+                (HookType::SubagentStart, Some(s)) => Some(serde_json::Value::String(s)),
+                (_, Some(s)) => serde_json::from_str(&s).ok(),
+                (_, None) => None,
+            };
+
+            sessions_map
+                .entry(session_id.clone())
+                .or_default()
+                .push(ObservationRecord {
+                    ts: ts_millis as u64,
+                    hook,
+                    session_id,
+                    tool,
+                    input,
+                    response_size: response_size.map(|v| v as u64),
+                    response_snippet,
+                });
+        }
+
+        let parsed: Vec<ParsedSession> = sessions_map
+            .into_iter()
+            .map(|(session_id, records)| ParsedSession {
+                session_id,
+                records,
+            })
+            .collect();
+
+        Ok(parsed)
     }
 
     fn observation_stats(&self) -> Result<ObservationStats> {
@@ -400,5 +495,151 @@ mod tests {
         assert_eq!(sessions.len(), 2);
         assert!(sessions.contains(&"sess-1".to_string()));
         assert!(sessions.contains(&"sess-2".to_string()));
+    }
+
+    #[test]
+    fn test_load_unattributed_sessions_returns_null_feature_cycle_only() {
+        let store = setup_test_store();
+        insert_session(&store, "sess-1", None);
+        insert_session(&store, "sess-2", Some("col-012"));
+        insert_session(&store, "sess-3", None);
+        insert_observation(&store, "sess-1", 1700000000000, "PreToolUse", Some("Read"),
+            Some(r#"{"file_path":"product/features/col-015/SCOPE.md"}"#), None, None);
+        insert_observation(&store, "sess-2", 1700000001000, "PreToolUse", Some("Read"),
+            Some(r#"{"file_path":"product/features/col-012/SCOPE.md"}"#), None, None);
+        insert_observation(&store, "sess-3", 1700000002000, "PreToolUse", Some("Write"),
+            Some(r#"{"file_path":"product/features/crt-013/test.rs"}"#), None, None);
+
+        let source = SqlObservationSource::new(Arc::clone(&store));
+        let sessions = source.load_unattributed_sessions().unwrap();
+
+        // Only sess-1 and sess-3 (NULL feature_cycle), not sess-2
+        assert_eq!(sessions.len(), 2);
+        let session_ids: Vec<&str> = sessions.iter().map(|s| s.session_id.as_str()).collect();
+        assert!(session_ids.contains(&"sess-1"));
+        assert!(session_ids.contains(&"sess-3"));
+        assert!(!session_ids.contains(&"sess-2"));
+    }
+
+    #[test]
+    fn test_load_unattributed_sessions_empty_when_all_attributed() {
+        let store = setup_test_store();
+        insert_session(&store, "sess-1", Some("col-012"));
+        insert_observation(&store, "sess-1", 1700000000000, "PreToolUse", Some("Read"), None, None, None);
+
+        let source = SqlObservationSource::new(Arc::clone(&store));
+        let sessions = source.load_unattributed_sessions().unwrap();
+        assert!(sessions.is_empty());
+    }
+
+    #[test]
+    fn test_load_unattributed_sessions_groups_by_session_id() {
+        let store = setup_test_store();
+        insert_session(&store, "sess-1", None);
+        insert_observation(&store, "sess-1", 1700000000000, "PreToolUse", Some("Read"),
+            Some(r#"{"file_path":"product/features/col-015/SCOPE.md"}"#), None, None);
+        insert_observation(&store, "sess-1", 1700000001000, "PostToolUse", Some("Read"),
+            None, Some(512), Some("file contents"));
+
+        let source = SqlObservationSource::new(Arc::clone(&store));
+        let sessions = source.load_unattributed_sessions().unwrap();
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id, "sess-1");
+        assert_eq!(sessions[0].records.len(), 2);
+        // Records should be sorted by timestamp
+        assert!(sessions[0].records[0].ts <= sessions[0].records[1].ts);
+    }
+
+    #[test]
+    fn test_load_unattributed_sessions_empty_when_no_sessions() {
+        let store = setup_test_store();
+        let source = SqlObservationSource::new(Arc::clone(&store));
+        let sessions = source.load_unattributed_sessions().unwrap();
+        assert!(sessions.is_empty());
+    }
+
+    /// Integration test for the full fallback path: NULL feature_cycle sessions
+    /// with observations containing feature file paths are attributed via
+    /// content-based attribution and returned for the correct feature (AC-01, AC-02, AC-08).
+    #[test]
+    fn test_attribution_fallback_end_to_end() {
+        use unimatrix_observe::attribute_sessions;
+
+        let store = setup_test_store();
+
+        // Session with NULL feature_cycle but observations referencing col-test
+        insert_session(&store, "sess-1", None);
+        insert_observation(&store, "sess-1", 1700000000000, "PreToolUse", Some("Read"),
+            Some(r#"{"file_path":"product/features/col-test/SCOPE.md"}"#), None, None);
+        insert_observation(&store, "sess-1", 1700000001000, "PreToolUse", Some("Write"),
+            Some(r#"{"file_path":"product/features/col-test/impl.rs"}"#), None, None);
+
+        // Session with NULL feature_cycle referencing a different feature
+        insert_session(&store, "sess-2", None);
+        insert_observation(&store, "sess-2", 1700000002000, "PreToolUse", Some("Read"),
+            Some(r#"{"file_path":"product/features/nxs-001/SCOPE.md"}"#), None, None);
+
+        let source = SqlObservationSource::new(Arc::clone(&store));
+
+        // Direct query returns empty (no sessions have feature_cycle = 'col-test')
+        let direct = source.load_feature_observations("col-test").unwrap();
+        assert!(direct.is_empty());
+
+        // Fallback: load unattributed, run attribution
+        let unattributed = source.load_unattributed_sessions().unwrap();
+        assert_eq!(unattributed.len(), 2);
+
+        let attributed = attribute_sessions(&unattributed, "col-test");
+
+        // Only sess-1 records attributed to col-test (AC-04: multi-feature partitioning)
+        assert_eq!(attributed.len(), 2);
+        assert!(attributed.iter().all(|r| r.session_id == "sess-1"));
+    }
+
+    /// AC-03: Sessions with populated feature_cycle still use the direct query path.
+    #[test]
+    fn test_direct_path_preserved_for_populated_feature_cycle() {
+        let store = setup_test_store();
+        insert_session(&store, "sess-1", Some("col-015"));
+        insert_observation(&store, "sess-1", 1700000000000, "PreToolUse", Some("Read"),
+            Some(r#"{"file_path":"product/features/col-015/SCOPE.md"}"#), None, None);
+
+        let source = SqlObservationSource::new(Arc::clone(&store));
+        let direct = source.load_feature_observations("col-015").unwrap();
+
+        // Direct path returns data -- no fallback needed
+        assert_eq!(direct.len(), 1);
+        assert_eq!(direct[0].session_id, "sess-1");
+    }
+
+    /// AC-04: Multi-feature session correctly partitioned.
+    #[test]
+    fn test_multi_feature_session_partitioned_via_fallback() {
+        use unimatrix_observe::attribute_sessions;
+
+        let store = setup_test_store();
+        insert_session(&store, "sess-1", None);
+
+        // Session touches col-015 then crt-013
+        insert_observation(&store, "sess-1", 1700000000000, "PreToolUse", Some("Read"),
+            Some(r#"{"file_path":"product/features/col-015/SCOPE.md"}"#), None, None);
+        insert_observation(&store, "sess-1", 1700000001000, "PreToolUse", Some("Write"),
+            Some(r#"{"file_path":"product/features/col-015/impl.rs"}"#), None, None);
+        insert_observation(&store, "sess-1", 1700000002000, "PreToolUse", Some("Read"),
+            Some(r#"{"file_path":"product/features/crt-013/SCOPE.md"}"#), None, None);
+        insert_observation(&store, "sess-1", 1700000003000, "PreToolUse", Some("Write"),
+            Some(r#"{"file_path":"product/features/crt-013/test.rs"}"#), None, None);
+
+        let source = SqlObservationSource::new(Arc::clone(&store));
+        let unattributed = source.load_unattributed_sessions().unwrap();
+
+        let col015 = attribute_sessions(&unattributed, "col-015");
+        assert_eq!(col015.len(), 2);
+        assert!(col015.iter().all(|r| r.ts <= 1700000001000));
+
+        let crt013 = attribute_sessions(&unattributed, "crt-013");
+        assert_eq!(crt013.len(), 2);
+        assert!(crt013.iter().all(|r| r.ts >= 1700000002000));
     }
 }


### PR DESCRIPTION
## Summary

- `context_retrospective` returned "No observation data found" because `sessions.feature_cycle` is always NULL — Claude Code doesn't send this field in hook input JSON
- Adds a fallback path: when the direct `feature_cycle` query returns empty, loads sessions with NULL `feature_cycle`, runs the existing `attribute_sessions()` content-based attribution (scans tool inputs for file paths and feature ID patterns), then proceeds with the existing metric pipeline
- No schema migration required — read-path only fix using existing tables and the well-tested `attribution.rs` logic (15 existing tests)

## Changes

| File | Change |
|------|--------|
| `crates/unimatrix-observe/src/source.rs` | Added `load_unattributed_sessions()` to `ObservationSource` trait |
| `crates/unimatrix-server/src/services/observation.rs` | Implemented `load_unattributed_sessions()` — queries NULL feature_cycle sessions, loads observations, groups into `ParsedSession` |
| `crates/unimatrix-server/src/mcp/tools.rs` | Added attribution fallback in `context_retrospective` handler |

## New Tests (7)

- `test_load_unattributed_sessions_returns_null_feature_cycle_only`
- `test_load_unattributed_sessions_empty_when_all_attributed`
- `test_load_unattributed_sessions_groups_by_session_id`
- `test_load_unattributed_sessions_empty_when_no_sessions`
- `test_attribution_fallback_end_to_end` (AC-01, AC-02, AC-08)
- `test_direct_path_preserved_for_populated_feature_cycle` (AC-03)
- `test_multi_feature_session_partitioned_via_fallback` (AC-04)

## Test plan

- [x] All 1759 workspace tests pass (0 failures)
- [x] No new clippy warnings in changed files
- [x] No stubs (todo!, unimplemented!, TODO, FIXME, HACK)
- [x] All 8 acceptance criteria from #162 verified
- [x] Existing attribution.rs tests (15) still pass
- [x] No schema migration required

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)