### PR TITLE
fix: correct empty content test expectation and error field name

### DIFF
--- a/crates/unimatrix-server/src/services/mod.rs
+++ b/crates/unimatrix-server/src/services/mod.rs
@@ -171,7 +171,7 @@ impl From<ServiceError> for ServerError {
                 }
             }
             ServiceError::ValidationFailed(msg) => ServerError::InvalidInput {
-                field: "service".to_string(),
+                field: "input".to_string(),
                 reason: msg,
             },
             ServiceError::Core(e) => ServerError::Core(e),

--- a/product/test/infra-001/suites/test_tools.py
+++ b/product/test/infra-001/suites/test_tools.py
@@ -72,9 +72,9 @@ def test_store_invalid_category(server):
 
 
 def test_store_empty_content(server):
-    """T-06: Store with empty content accepted (server allows empty content)."""
+    """T-06: Store with empty content rejected by gateway validation."""
     resp = server.context_store("", "testing", "convention", agent_id="human")
-    assert_tool_success(resp)
+    assert_tool_error(resp, "content")
 
 
 def test_store_empty_topic(server):


### PR DESCRIPTION
## Summary
- Fix `test_store_empty_content` to expect an error (gateway correctly rejects empty content at `gateway.rs:257`)
- Change `ValidationFailed` error mapping field from hardcoded `"service"` to `"input"` in `services/mod.rs`

## Test plan
- [ ] `cargo test -p unimatrix-server` passes (unit tests don't assert field value)
- [ ] Integration test `test_store_empty_content` now expects error with "content" in message
- [ ] Other validation errors (title, query, tags) correctly use `"input"` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)