### PR TITLE
workflow: primary agent acts as coordinator (#183)

### DIFF
--- a/.claude/agents/uni/README.md
+++ b/.claude/agents/uni/README.md
@@ -8,7 +8,7 @@ Agents for Unimatrix product development. These agents implement the Spec-Driven
 
 **Use `uni-` agents for all Unimatrix product work.** NDP agents in `.claude/agents/ndp/` are retained as reference only.
 
-- Spawn `uni-scrum-master` for feature work (design, delivery, or bugfix). It reads the appropriate protocol and orchestrates the swarm.
+- For feature work (design, delivery, or bugfix): read the protocol and `uni-scrum-master.md`, then act as coordinator — spawn specialist agents, never generate content.
 - Use `/review-pr` for PR security review and merge readiness.
 - Use `/retro` for post-merge knowledge extraction.
 

--- a/.claude/protocols/uni/uni-agent-routing.md
+++ b/.claude/protocols/uni/uni-agent-routing.md
@@ -9,9 +9,9 @@ Always use `uni-` agents for Unimatrix product work:
 | generic coder | `uni-rust-dev` | Knows Unimatrix Rust patterns, queries `/query-patterns` before implementing |
 | generic architect | `uni-architect` | ADR authority, stores decisions in Unimatrix |
 | generic tester | `uni-tester` | Risk-based testing, dual-phase role |
-| generic planner | `uni-scrum-master` | Protocol-driven, reads the right protocol for the session |
+| generic planner | Design Leader (you) | Protocol-driven, reads the right protocol for the session |
 | generic reviewer | `uni-validator` | Three-gate validation model |
-| generic debugger | `uni-scrum-master` (bugfix session) | Reads bugfix protocol, coordinates diagnosis → fix → review |
+| generic debugger | Bugfix Leader (you) | Reads bugfix protocol, coordinates diagnosis → fix → review |
 | generic security auditor | `uni-security-reviewer` | Fresh-context security review of diffs |
 
 ---
@@ -39,11 +39,9 @@ Every swarm also includes `uni-validator` at gates. Non-negotiable.
 
 ## Complete Agent Roster
 
-### Coordinator (1 agent — reads protocol per session)
+### Coordinator (you — the primary agent)
 
-| Agent | What It Does |
-|-------|-------------|
-| `uni-scrum-master` | Reads the protocol for the session type (design/delivery/bugfix). Spawns agents, manages gates, updates GH Issues. |
+You are the coordinator. Read the protocol for the session type, spawn specialist agents, manage gates, update GH Issues. Read `.claude/agents/uni/coordinator (you).md` for role boundaries and behavioral rules.
 
 ### Validation (1 agent — spawned at every gate)
 
@@ -82,7 +80,7 @@ Every swarm also includes `uni-validator` at gates. Non-negotiable.
 |-------|------|-------|-------------|
 | `uni-security-reviewer` | specialist | review | Fresh-context security review of PR diff, blast radius, OWASP assessment |
 
-**Total: 14 agents** (1 coordinator + 1 validator + 6 design + 3 delivery + 1 bug fix + 1 security + 1 retro-mode architect)
+**Total: 13 specialist agents** (1 validator + 6 design + 3 delivery + 1 bug fix + 1 security + 1 retro-mode architect). You coordinate.
 
 ---
 
@@ -91,7 +89,7 @@ Every swarm also includes `uni-validator` at gates. Non-negotiable.
 ### Design Session
 
 ```
-Coordinator:  uni-scrum-master (reads uni-design-protocol.md)
+Coordinator:  you (read uni-design-protocol.md + coordinator (you).md)
 Phase 1:      uni-researcher (scope exploration with human)
               ★ HUMAN CHECKPOINT — approve SCOPE.md ★
 Phase 1b:     uni-risk-strategist (scope-risk mode)
@@ -106,7 +104,7 @@ Phase 2d:     git commit + push + gh pr create --draft
 ### Delivery Session
 
 ```
-Coordinator:  uni-scrum-master (reads uni-delivery-protocol.md)
+Coordinator:  you (read uni-delivery-protocol.md + coordinator (you).md)
 Init:         Read IMPLEMENTATION-BRIEF.md, create feature branch
 Stage 3a:     uni-pseudocode + uni-tester (test plans)             (parallel)
               UPDATE Component Map in IMPLEMENTATION-BRIEF.md
@@ -123,7 +121,7 @@ Phase 4:      Commit, push, open PR
 ### Bug Fix Session
 
 ```
-Coordinator:  uni-scrum-master (reads uni-bugfix-protocol.md)
+Coordinator:  you (read uni-bugfix-protocol.md + coordinator (you).md)
 Init:         /query-patterns + /knowledge-search — prior knowledge
 Phase 1:      uni-bug-investigator (diagnose root cause)
               ★ HUMAN CHECKPOINT — approve diagnosis ★
@@ -161,11 +159,11 @@ Phase 5:      Summary + outcome recording — RETRO ENDS
 
 ## Composition Rules
 
-1. **Every swarm session**: exactly one `uni-scrum-master`. No exceptions.
-2. **Validation gates**: `uni-validator` spawned at each gate by the coordinator.
+1. **Every swarm session**: you are the coordinator. Read the protocol and SM definition. No exceptions.
+2. **Validation gates**: `uni-validator` spawned at each gate by you.
 3. **Design session**: All six design agents in defined phase order per protocol.
 4. **Delivery session**: pseudocode + tester + rust-dev + validator at three gates per protocol.
-5. **Bug fix**: SM + bug-investigator + rust-dev + tester + validator per protocol.
+5. **Bug fix**: bug-investigator + rust-dev + tester + validator per protocol.
 6. **PR review**: `/review-pr` skill + security-reviewer.
 7. **Retrospective**: `/retro` skill + architect (+ tester if testing lessons needed).
 8. **Skip swarm for**: typos, single-line obvious fixes, config-only changes, docs, exploration.
@@ -179,11 +177,11 @@ Phase 5:      Summary + outcome recording — RETRO ENDS
 |-------|------|-----|
 | `/query-patterns` | BEFORE designing or implementing | uni-architect, uni-pseudocode, uni-rust-dev |
 | `/store-adr` | AFTER each design decision | uni-architect |
-| `/record-outcome` | END of every session | uni-scrum-master, `/review-pr`, `/retro` |
-| `/store-procedure` | After successful sessions (reusable techniques) | uni-scrum-master, uni-bug-investigator |
-| `/store-lesson` | After failures | uni-bug-investigator, uni-validator, uni-scrum-master |
+| `/record-outcome` | END of every session | coordinator (you), `/review-pr`, `/retro` |
+| `/store-procedure` | After successful sessions (reusable techniques) | coordinator (you), uni-bug-investigator |
+| `/store-lesson` | After failures | uni-bug-investigator, uni-validator, coordinator (you) |
 | `/knowledge-search` | Exploring what's known | Any agent |
 | `/knowledge-lookup` | Exact-match retrieval | Any agent |
-| `/uni-git` | Git conventions | uni-scrum-master |
-| `/review-pr` | After PR creation or standalone | uni-scrum-master, human |
+| `/uni-git` | Git conventions | coordinator (you) |
+| `/review-pr` | After PR creation or standalone | coordinator (you), human |
 | `/retro` | After merge | human |

--- a/.claude/protocols/uni/uni-bugfix-protocol.md
+++ b/.claude/protocols/uni/uni-bugfix-protocol.md
@@ -8,26 +8,27 @@ Triggers on: bug, fix, bugfix, defect, regression, broken, failing, error, crash
 
 A single-session workflow that takes a bug report from diagnosis through merge. The session includes a human checkpoint after diagnosis — the human must agree with the root cause analysis before any code changes are made.
 
+**You are the Bugfix Leader.** Read the SM agent definition (`.claude/agents/uni/uni-scrum-master.md`) for role boundaries. You orchestrate — you NEVER generate content. Spawn specialist agents for all work.
+
 ```
-Primary Agent                    uni-scrum-master          Specialist Agents
-─────────────                    ──────────────────────          ─────────────────
-read bug report (GH Issue or description)
-spawn bugfix-scrum-master ─────► read protocol + bug report
-                                 spawn investigator (Phase 1)
-                                 ◄──────────────────────────── diagnosis + proposed fix
-                                 present diagnosis to human
-                                 ★ HUMAN CHECKPOINT ★
-                                 human approves diagnosis
-                                 create branch (Phase 2)
-                                 spawn rust-dev ─────────────► implement fix + tests
-                                 ◄──────────────────────────── changed files + test results
-                                 spawn tester (Phase 3)
-                                 ◄──────────────────────────── full test suite results
-                                 spawn validator (Gate 3) ───► validate fix
-                                 ◄──────────────────────────── PASS / REWORKABLE FAIL / SCOPE FAIL
-                                 on PASS: open PR
-                                 spawn security-reviewer ────► review PR diff (fresh context)
-                                 ◄──────────────────────────── security assessment
+Bugfix Leader (you)                                  Specialist Agents
+───────────────────                                  ─────────────────
+read protocol + bug report
+spawn investigator (Phase 1) ───────────────────────► diagnosis + proposed fix
+◄────────────────────────────────────────────────────
+present diagnosis to human
+★ HUMAN CHECKPOINT ★
+human approves diagnosis
+create branch (Phase 2)
+spawn rust-dev ─────────────────────────────────────► implement fix + tests
+◄────────────────────────────────────────────────────
+spawn tester (Phase 3) ─────────────────────────────► full test suite results
+◄────────────────────────────────────────────────────
+spawn validator (Gate 3) ───────────────────────────► validate fix
+◄──────────────────────────────────────────────────── PASS / REWORKABLE FAIL / SCOPE FAIL
+on PASS: open PR
+spawn security-reviewer ────────────────────────────► review PR diff (fresh context)
+◄────────────────────────────────────────────────────
 ◄──────────────────────────────  present PR + security assessment
 human reviews and merges
 ```
@@ -194,7 +195,7 @@ Task(subagent_type: "uni-tester",
     5. Integration suites relevant to the bug area (see USAGE-PROTOCOL.md suite table)
 
     INTEGRATION TEST FAILURE TRIAGE (CRITICAL):
-    - CAUSED BY THIS BUG FIX → Report back to bugfix-scrum-master for rework.
+    - CAUSED BY THIS BUG FIX → Report back to Bugfix Leader for rework.
     - PRE-EXISTING / UNRELATED → Do NOT fix. File a GH Issue, mark the test
       @pytest.mark.xfail(reason='Pre-existing: GH#NNN — description').
     - BAD TEST ASSERTION → Fix the test. Document in results.
@@ -364,7 +365,7 @@ NEVER pipe full cargo output into context.
 ## Quick Reference: Message Map
 
 ```
-BUGFIX MANAGER (uni-scrum-master):
+BUGFIX LEADER (you):
   Init:       /query-patterns + /knowledge-search — prior knowledge
   Phase 1:    Task(uni-bug-investigator) — diagnose root cause → GH Issue comment
               ...present diagnosis to human...

--- a/.claude/protocols/uni/uni-delivery-protocol.md
+++ b/.claude/protocols/uni/uni-delivery-protocol.md
@@ -28,7 +28,7 @@ Phase 4: Delivery
 
 **Critical sequence**: Stage 3a produces pseudocode + test plans → Delivery Leader updates the Component Map → Gate 3a validates designs → ONLY THEN does Stage 3b begin. Stage 3b agents each receive their specific component's validated pseudocode and test plan.
 
-**The Delivery Leader runs all stages autonomously.** Human re-enters only on scope/feasibility failures or when rework iterations are exhausted.
+**You are the Delivery Leader.** Read the SM agent definition (`.claude/agents/uni/uni-scrum-master.md`) for role boundaries. You orchestrate — you NEVER generate content. Spawn specialist agents for all work. Run all stages autonomously. Human re-enters only on scope/feasibility failures or when rework iterations are exhausted.
 
 ### Concurrency Rules
 
@@ -426,7 +426,7 @@ NEVER pipe full cargo output into context.
 ## Quick Reference: Message Map
 
 ```
-DELIVERY LEADER (uni-scrum-master):
+DELIVERY LEADER (you):
   Init:       Read IMPLEMENTATION-BRIEF.md + ACCEPTANCE-MAP.md
   Stage 3a:   Task(uni-pseudocode) + Task(uni-tester) — parallel, ONE message
               ...wait for both to complete...
@@ -454,7 +454,7 @@ DELIVERY LEADER (uni-scrum-master):
 
 **Authoritative reference**: `product/test/infra-001/USAGE-PROTOCOL.md` — contains commands, suite descriptions, failure triage decision tree, GH Issue templates, and xfail workflow.
 
-The uni-tester agent has full integration harness knowledge (suite selection, triage rules, commands). The delivery protocol does not duplicate those details. Key rules for the scrum master:
+The uni-tester agent has full integration harness knowledge (suite selection, triage rules, commands). The delivery protocol does not duplicate those details. Key rules for the Design Leader:
 
 - **uni-rust-dev** (Stage 3b): Do NOT run or modify integration tests. Stage 3c handles this.
 - **uni-tester** (Stage 3a): Include integration harness plan in test-plan/OVERVIEW.md — which suites apply, new tests needed.

--- a/.claude/protocols/uni/uni-design-protocol.md
+++ b/.claude/protocols/uni/uni-design-protocol.md
@@ -8,23 +8,24 @@ Triggers on: specification, architecture, design, research, scope, risk strategy
 
 Session 1 produces three sacred source-of-truth documents, a scope risk assessment, a vision alignment report, an implementation brief, and an acceptance map. All work happens on a `feature/{feature-id}` branch. The session ends by opening a **draft PR** — the human reviews the design artifacts and approves verbally. Session 2 (Implementation) continues on the same branch and converts the draft PR to ready when complete.
 
+**You are the Design Leader.** Read the SM agent definition (`.claude/agents/uni/uni-scrum-master.md`) for role boundaries. You orchestrate — you NEVER generate content. Spawn specialist agents for all work.
+
 ```
-Primary Agent                    uni-scrum-master (Design Leader)    Design Agents
-─────────────                    ────────────────────────────────    ─────────────
-read SCOPE.md (or initiate)
-spawn scrum-master ──────────►   read protocol + SCOPE.md
-                                 spawn researcher (Phase 1)
-                                 ◄──────────────────────────────── SCOPE.md written
-                                 human approves SCOPE.md
-                                 spawn risk strategist (Phase 1b) ► scope risk assessment
-                                 ◄──────────────────────────────── return SR-XX risks
-                                 spawn 2 specialists (Phase 2a) ──► produce arch + spec
-                                 ◄──────────────────────────────── return artifact paths
-                                 spawn risk strategist (Phase 2a+)► produce risk strategy
-                                 ◄──────────────────────────────── return artifact path
-                                 spawn vision guardian (Phase 2b)
-                                 spawn synthesizer (Phase 2c)
-◄──────────────────────────────  return all artifacts to human
+Design Leader (you)                                  Design Agents
+───────────────────                                  ─────────────
+read protocol + SCOPE.md (or initiate)
+spawn researcher (Phase 1) ─────────────────────────► SCOPE.md written
+◄────────────────────────────────────────────────────
+human approves SCOPE.md
+spawn risk strategist (Phase 1b) ───────────────────► scope risk assessment
+◄────────────────────────────────────────────────────
+spawn 2 specialists (Phase 2a) ─────────────────────► produce arch + spec
+◄────────────────────────────────────────────────────
+spawn risk strategist (Phase 2a+) ──────────────────► produce risk strategy
+◄────────────────────────────────────────────────────
+spawn vision guardian (Phase 2b)
+spawn synthesizer (Phase 2c)
+return all artifacts to human
 human reviews and approves
 ```
 
@@ -298,7 +299,7 @@ Do NOT paste full documents into agent prompts. Agents read files themselves.
 ## Quick Reference: Message Map
 
 ```
-DESIGN LEADER (uni-scrum-master):
+DESIGN LEADER (you):
   Init:       git checkout -b feature/{feature-id}
   Phase 1:    Task(uni-researcher) — scope exploration with human
               ...human approves SCOPE.md...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,13 @@
 # Unimatrix — Non-Negotiable Rules
 
-1. **Feature work uses swarms** — spawn `uni-scrum-master` with the session type. The SM reads the protocol and executes it.
+1. **Feature work uses swarms** — read the protocol for the session type and execute it as Design/Delivery/Bugfix Leader. You ARE the scrum master. Follow the protocol exactly — spawn specialist agents, never generate content yourself.
    | Intent | Session Type | Protocol |
    |--------|-------------|----------|
    | Design, scope, spec | design | `.claude/protocols/uni/uni-design-protocol.md` |
    | Implement, build, code | delivery | `.claude/protocols/uni/uni-delivery-protocol.md` |
    | Bug fix | bugfix | `.claude/protocols/uni/uni-bugfix-protocol.md` |
+
+   Read the SM agent definition (`.claude/agents/uni/uni-scrum-master.md`) for role boundaries and behavioral rules. The protocol defines what to do and when; the SM definition defines how you behave.
 
    For PR review: `/review-pr`. For retrospective: `/retro`.
 2. **Anti-stub**: Never leave TODO, `unimplemented!()`, `todo!()`, or placeholder functions. Ask if blocked.


### PR DESCRIPTION
## Summary
- Claude Code v2.1.69+ removed nested agent spawning — the SM subagent can no longer spawn specialist workers
- Primary agent now reads the protocol + SM definition and acts as coordinator directly
- `uni-scrum-master.md` preserved as behavioral reference for role boundaries
- Updates CLAUDE.md, all 3 protocols, agent routing, README

## Context
Filed comment on [anthropics/claude-code#19077](https://github.com/anthropics/claude-code/issues/19077#issuecomment-4028247157) requesting `maxDepth: 2` support. This change is the workaround until that lands.

## Test plan
- [ ] Verify design session spawns specialist agents correctly
- [ ] Verify protocol compliance (coordinator doesn't generate content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)