### PR TITLE
docs: retro and security review reports for crt-018, nan-001, nan-003

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,6 +2311,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/product/features/crt-018/agents/crt-018-retro-architect-report.md
+++ b/product/features/crt-018/agents/crt-018-retro-architect-report.md
@@ -1,0 +1,68 @@
+# Retrospective Architect Report: crt-018
+
+Agent: crt-018-retro-architect
+Date: 2026-03-11
+
+## 1. Patterns
+
+### New Entries
+
+| ID | Title | Reason |
+|----|-------|--------|
+| #1042 | Pure Computation Engine Module Pattern | Second instance (after confidence.rs) validates the zero-I/O engine module structure. Documents layout, conventions, and integration point. |
+| #1043 | Subquery Dedup Before JOIN Aggregation | New SQL technique from R-03 fix. Prevents count inflation when junction table has duplicate composite keys. |
+
+### Existing Patterns -- Verified Still Accurate
+
+| ID | Title | crt-018 Usage | Status |
+|----|-------|---------------|--------|
+| #726 | SQL Aggregation Struct | EffectivenessAggregates follows StatusAggregates pattern exactly. | Accurate, no update needed. |
+| #882 | Best-Effort Optional Computation | Phase 8 uses Option + match + warn + None for graceful degradation. | Accurate, no update needed. |
+| #320 | Intermediate Serialization Struct | EffectivenessReportJson + sub-structs with skip_serializing_if. | Accurate, no update needed. |
+
+### Skipped (One-Off Work)
+
+| Component | Reason |
+|-----------|--------|
+| DataWindow struct construction from flat fields | Specific to avoiding store-to-engine dependency. The broader principle (avoid cross-crate type imports when flat fields suffice) is already covered by #755 (Dependency Inversion). |
+| Match loop for EffectivenessCategory instead of HashMap | Minor deviation from pseudocode due to lacking Hash derive. Not a reusable pattern -- just an implementation detail. |
+
+## 2. Procedures
+
+### StatusService Phase Addition
+
+No existing procedure for "adding a new phase to StatusService::compute_report" was found. The closest is #323 (How to add a new service to ServiceLayer), which covers service creation but not phase extension.
+
+However, crt-018's Phase 8 follows the exact same structure as Phases 2-7 (spawn_blocking, store query, computation, assign to report field). This is covered by existing patterns (#882 Best-Effort, #726 SQL Aggregation) rather than requiring a dedicated procedure. The pattern composition is sufficient -- no new procedure needed.
+
+### Consolidated Store Query Pattern (ADR-001)
+
+ADR-001 follows the existing pattern documented in #704 (ADR-004 crt-013: Single StatusAggregates). The technique is the same: one method, one lock_conn(), multiple SQL queries, one return struct. The existing ADR + pattern entry cover this adequately. No new procedure.
+
+### Testing Technique for Pure Computation Modules
+
+The test structure (separate test module files, exhaustive boundary tests at every named constant, overflow guards) is documented in the new pattern #1042. No separate procedure needed.
+
+## 3. ADR Status
+
+All 4 ADRs were validated by successful implementation and all 3 gates passing first attempt.
+
+| ADR | Unimatrix ID | Status | Notes |
+|-----|-------------|--------|-------|
+| ADR-001: Consolidated effectiveness query | #1038 | VALIDATED | Implementation improved on pseudocode SQL with subquery dedup (R-03 fix). Design decision correct. |
+| ADR-002: NULL topic handling | #1039 | VALIDATED | Dual-layer defense (SQL + engine) implemented. Redundant but harmless. All NULL/empty tests pass. |
+| ADR-003: Data window indicator | #1040 | VALIDATED | DataWindow constructed from flat store fields (not cross-crate import). Correct separation. |
+| ADR-004: Configurable noisy trust sources | #1041 | VALIDATED | NOISY_TRUST_SOURCES constant with .contains() works as designed. Passed as parameter for test isolation. |
+
+No ADRs flagged for supersession. No prior ADRs were superseded by crt-018.
+
+## 4. Lessons
+
+| ID | Title | Summary |
+|----|-------|---------|
+| #1044 | Risk-based test strategy predicted and caught COUNT DISTINCT bug | R-03 risk identified during design directed the store agent to the right area. Agent improved the fix beyond what pseudocode specified (subquery vs COUNT DISTINCT). Validates risk strategy as attention-direction tool, not prescriptive solution. |
+
+### Additional Observations (Not Stored -- Feature-Specific)
+
+- **Clean single-session delivery**: crt-018 was designed and delivered in a single conversation with zero rework. Contributing factors: (a) tight scope with no schema migration, (b) pure computation module enabled exhaustive unit testing without DB fixtures, (c) consolidated store method minimized integration surface, (d) risk strategy pre-identified the one bug that materialized.
+- **Calibration binary vs weighted**: The spec-vs-architecture discrepancy (FR-04 weighted calibration vs architecture's bool type) was flagged at Gate 3a and accepted. This is a design trade-off, not a defect. Follow-on crt-018b could revisit if weighted calibration is needed.

--- a/product/features/crt-018/agents/crt-018-security-reviewer-report.md
+++ b/product/features/crt-018/agents/crt-018-security-reviewer-report.md
@@ -1,0 +1,60 @@
+# Security Review: crt-018-security-reviewer
+
+## Risk Level: low
+
+## Summary
+
+crt-018 adds read-only effectiveness analysis to `context_status`. The feature is well-scoped: no new MCP tool parameters, no external input surfaces, no schema migration, no writes, and no new dependencies. All SQL queries use parameterized statements. The code follows established patterns in the codebase with proper error handling and graceful degradation. Two minor non-blocking findings identified.
+
+## Findings
+
+### Finding 1: Markdown Table Injection via Entry Titles (Mitigated)
+
+- **Severity**: low
+- **Location**: `crates/unimatrix-server/src/mcp/response/status.rs:583,596,606`
+- **Description**: Entry titles rendered in markdown tables could contain pipe characters or newlines that break table formatting. The code already sanitizes titles via `.replace('|', "/").replace('\n', " ")` in all three entry list sections (ineffective, noisy, unmatched).
+- **Recommendation**: No action needed. The mitigation is already in place and covers all rendering paths.
+- **Blocking**: no
+
+### Finding 2: Two Separate lock_conn() Calls in Phase 8
+
+- **Severity**: low
+- **Location**: `crates/unimatrix-store/src/read.rs:871,978` and `crates/unimatrix-server/src/services/status.rs:528-529`
+- **Description**: `compute_effectiveness_aggregates()` and `load_entry_classification_meta()` each acquire their own connection lock. Between the two calls, an entry could theoretically be deleted, producing injection stats for an entry_id not present in the metadata. The integration code at `status.rs:551` handles this gracefully: entries not found in `stats_map` default to zero injection counts. However, the reverse case (entry deleted between calls, orphan in injection stats) means a classified entry could reference a now-deleted entry. This is a data freshness issue, not a security issue.
+- **Recommendation**: Acknowledged in RISK-TEST-STRATEGY.md (integration risk section). The impact is cosmetic at worst (a stale entry appears in the report for one cycle). No action needed.
+- **Blocking**: no
+
+### Finding 3: NaN/Infinity Guard in Utility and Aggregate Computation
+
+- **Severity**: low
+- **Location**: `crates/unimatrix-engine/src/effectiveness/mod.rs:112-121,223-228`
+- **Description**: `utility_score()` guards against division by zero (returns 0.0 when total=0). `aggregate_by_source()` guards against empty injection set (returns 0.0 when no injected entries). Both are correct. No NaN or infinity values can reach the JSON serializer (serde_json rejects NaN).
+- **Recommendation**: No action needed. Guards are in place.
+- **Blocking**: no
+
+### Finding 4: Case-Sensitive Noisy Trust Source Matching
+
+- **Severity**: low
+- **Location**: `crates/unimatrix-engine/src/effectiveness/mod.rs:159`
+- **Description**: `noisy_trust_sources.contains(&trust_source)` is a case-sensitive comparison. If `trust_source` is stored as "Auto" or "AUTO", it would bypass Noisy classification. The RISK-TEST-STRATEGY.md (R-10) acknowledges this. The store's SQL uses `COALESCE(trust_source, '')` without case normalization.
+- **Recommendation**: Verify that trust_source values in the database are consistently lowercase (the store layer should enforce this on write). Low risk given this is an internal analytical feature. Not blocking.
+- **Blocking**: no
+
+## Blast Radius Assessment
+
+**Worst case**: If `compute_effectiveness_aggregates()` returns corrupted data (e.g., inflated injection counts), agents could receive misleading effectiveness classifications in `context_status` output. This is informational only -- no automated actions are triggered by effectiveness data (SR-04 explicitly forbids it). The feature is purely diagnostic.
+
+**Failure mode**: If Phase 8 panics or errors, `effectiveness = None` and the rest of the StatusReport is unaffected. This matches the existing graceful degradation pattern used by the contradiction scan (Phase 4). The worst outcome of a bug is missing or incorrect informational text in status output.
+
+**No data corruption risk**: All code paths are SELECT-only. No writes to any table.
+
+## Regression Risk
+
+- **StatusReport JSON serialization**: The new `effectiveness` field uses `#[serde(skip_serializing_if = "Option::is_none")]`, so existing JSON consumers see no change when effectiveness is None. When present, it adds a new top-level key. Consumers using strict schemas would need updating, but the skip_serializing_if annotation means backwards compatibility is preserved for the common case (no injection data yet).
+- **context_status latency**: Phase 8 adds SQL queries. The queries are contained within a single `spawn_blocking` and do not block other phases. At scale (500 entries, 10K injection rows), the risk strategy identifies a 500ms budget. This is additive to existing status computation time.
+- **Existing test fixtures**: 8 existing test files set `effectiveness: None` in StatusReport construction, confirming the field integrates cleanly with existing code.
+
+## PR Comments
+
+- Posted 1 comment on PR #207
+- Blocking findings: no

--- a/product/features/nan-001/agents/nan-001-security-reviewer-report.md
+++ b/product/features/nan-001/agents/nan-001-security-reviewer-report.md
@@ -1,0 +1,59 @@
+# Security Review: nan-001-security-reviewer
+
+## Risk Level: Low
+
+## Summary
+
+Read-only JSONL export feature with no new external dependencies, no network exposure, and no deserialization of untrusted input. All SQL queries are static strings. The only non-trivial concern is the `preserve_order` feature flag on `serde_json` which changes `Map` backing from `BTreeMap` to `IndexMap` crate-wide, but this is acknowledged in ADR-003 and is semantically safe.
+
+## Findings
+
+### Finding 1: No output path validation (informational)
+- **Severity**: Low
+- **Location**: `crates/unimatrix-server/src/export.rs:44`
+- **Description**: The `--output` path is passed directly to `File::create()`. Acceptable for a CLI tool where the user has filesystem access. Would need validation if ever exposed via MCP.
+- **Recommendation**: Document that `run_export` trusts its caller.
+- **Blocking**: No
+
+### Finding 2: `preserve_order` feature has global scope
+- **Severity**: Low
+- **Location**: `crates/unimatrix-server/Cargo.toml:32`
+- **Description**: Changes `serde_json::Map` from `BTreeMap` to `IndexMap` for the entire crate. Acknowledged in ADR-003.
+- **Recommendation**: Confirmed acceptable.
+- **Blocking**: No
+
+### Finding 3: NaN confidence fallback to 0
+- **Severity**: Low
+- **Location**: `crates/unimatrix-server/src/export.rs:197`
+- **Description**: NaN confidence silently becomes 0.0 in export. NaN should not occur in practice.
+- **Recommendation**: Acceptable for v1.
+- **Blocking**: No
+
+### Finding 4: Transaction commit failure silently ignored
+- **Severity**: Low
+- **Location**: `crates/unimatrix-server/src/export.rs:57`
+- **Description**: `let _ = conn.execute_batch("COMMIT")` discards the result. Correct for read-only DEFERRED transaction.
+- **Recommendation**: Acceptable as-is.
+- **Blocking**: No
+
+### Finding 5: Audit log data included in export
+- **Severity**: Low (informational)
+- **Location**: `crates/unimatrix-server/src/export.rs:461-496`
+- **Description**: Export includes session IDs and operational metadata. Appropriate for backup but worth noting in docs if files are shared externally.
+- **Recommendation**: Document in user-facing docs.
+- **Blocking**: No
+
+## Blast Radius Assessment
+
+Worst case: export produces JSONL with missing or corrupted columns, leading to data loss on nan-002 import. Source database is never modified (read-only operation with DEFERRED transaction). The `preserve_order` feature flag is the widest-reaching change, affecting all `serde_json::Map` usage in `unimatrix-server`.
+
+## Regression Risk
+
+Low. The change is additive (new module + new CLI subcommand). No existing code paths modified beyond cosmetic import reordering. The `preserve_order` feature flag is the only change with potential side effects on existing behavior, mitigated by running the full test suite.
+
+## PR Comments
+- Posted 1 comment on PR #210
+- Blocking findings: No
+
+## Knowledge Stewardship
+- Stored: nothing novel to store -- standard CLI export pattern with no new security anti-patterns. Findings are specific to this PR (path validation reminder, feature flag scope) and not generalizable.

--- a/product/features/nan-003/agents/nan-003-retro-architect-report.md
+++ b/product/features/nan-003/agents/nan-003-retro-architect-report.md
@@ -1,0 +1,90 @@
+# nan-003 Retrospective Architect Report
+
+Agent: nan-003-retro-architect | Unimatrix ID: uni-architect
+
+## 1. Patterns
+
+### New Entries
+
+| ID | Title | Rationale |
+|----|-------|-----------|
+| #1118 | Versioned Sentinel Markers for Idempotent File Mutation | Generic pattern: any skill that mutates shared files needs open/close versioned comment sentinels for idempotency and future in-place updates. Established by ADR-002, applicable beyond nan-003 (e.g., future `/unimatrix-init --update`, config injection skills). |
+| #1119 | Human-Gated State Machine for Multi-Turn Conversational Skills | Generic pattern: any skill requiring progressive human decisions across phases needs explicit STOP gates, bold phrasing, depth limits, and exit options at every gate. Established by ADR-001, applicable to any future multi-turn skill (guided refactoring, config wizards, onboarding). |
+
+### Verified Existing (No Update Needed)
+
+| ID | Title | Verification |
+|----|-------|-------------|
+| #550 | Workflow-Only Scope: Markdown-Only Delivery Pattern | nan-003 confirms: no compilation, grep-based verification, content review gates all held. Single-commit delivery confirmed. Token budget note (agent defs <=150 lines, protocols <=250 lines) is about agent defs/protocols specifically, not skills -- no correction needed. |
+| #552 | Skill File as Single Source of Truth with Protocol References | nan-003 followed this: both skills are self-contained SKILL.md files. No protocol or agent def inlines skill logic. |
+| #1011 | Category-to-Skill Mapping: One Skill Per Knowledge Category | nan-003's quality gate (What/Why/Scope) for seed entries mirrors the skill-per-category enforcement model. Confirms the pattern holds for seeding too. |
+
+### Skipped
+
+- **Agent scan algorithm** (Component 4): One-off analysis specific to Unimatrix onboarding. Not a reusable pattern -- scanning agents for specific tool references is too domain-specific.
+- **CLAUDE.md block template** (Component 3): Content artifact, not a structural pattern. The sentinel pattern (#1118) captures the reusable aspect.
+- **Entry quality gate** (Component 6): The What/Why/Scope gate is already captured in #1011 (category-to-skill mapping). nan-003's seed quality gate is a specialization, not a new pattern.
+
+## 2. Procedures
+
+### New/Updated
+
+None. nan-003 did not change build/test/integration processes or schema migration steps. No new techniques emerged that require procedural documentation. The feature delivered markdown files only -- no compilation, no migration.
+
+## 3. ADR Validation
+
+All 6 ADRs validated by successful implementation. No ADR was contradicted or found incomplete during delivery.
+
+| ADR | Unimatrix ID | Status | Notes |
+|-----|-------------|--------|-------|
+| ADR-001: Hard STOP Gates | #1090 | Validated | 6 STOP gates in delivered SKILL.md. Gate 3b confirmed all present with bold phrasing. |
+| ADR-002: Versioned Sentinel | #1091 | Validated | Sentinel open/close pair present. Head-check fallback for >200 line files documented. Version "v1" appears 3 times (instruction + block open + block close). |
+| ADR-003: context_status Pre-flight | #1092 | Validated | Pre-flight is Step 1 in unimatrix-seed, before any file reads. Failure path halts with clear message. |
+| ADR-004: Terminal-Only Output | #1093 | Validated | Agent scan produces terminal-only report. No file writes. "No agents found" edge case handled. |
+| ADR-005: CLAUDE.md Block Lists unimatrix-* Only | #1094 | Validated | Block contains exactly 2 skills (unimatrix-init, unimatrix-seed). No existing skills (store-adr, retro, etc.) appear in block. |
+| ADR-006: Seed Categories + Quality Gate | #1095 | Validated | Only convention/pattern/procedure. Exclusion of decision/outcome/lesson-learned stated with rationale. Quality gate (What/Why/Scope) with field rules documented. |
+
+No ADRs flagged for supersession.
+
+## 4. Lessons
+
+### New Entries
+
+| ID | Title | Source |
+|----|-------|--------|
+| #1120 | Design-Only Features Naturally Produce High Session Counts and Mutation Spread | Hotspot analysis + baseline outlier (session_count 7 vs mean 2.92) |
+
+## 5. Retrospective Findings
+
+### Hotspot Analysis
+
+| Hotspot | Severity | Recurring? | Action |
+|---------|----------|-----------|--------|
+| permission_retries (14 Read retries) | Warning | Not clearly recurring -- Read tool permission retries are unusual and may reflect a transient environment issue rather than a missing allowlist entry. No matching procedure exists; not storing one because the root cause is unclear (Read is normally auto-approved). | No action -- monitor in future features. |
+| cold_restart (38-min gap, 8 re-reads) | Warning | Yes -- existing lesson #324 covers this exact scenario (session gaps cause expensive re-reads). nan-003 confirms the pattern still holds. | No new entry needed; #324 remains accurate. |
+| mutation_spread (19 files) | Warning | Explained by feature nature -- design-heavy features generate many markdown artifacts. Captured in lesson #1120. | Stored as lesson #1120. |
+| search_via_bash (46.7%) | Info | Common in design sessions where agents explore codebase structure. Not actionable -- search is the primary activity during architecture and spec phases. | No action. |
+| reread_rate (27 files) | Info | Partially explained by cold_restart (8 re-reads after gap). Remaining re-reads are cross-referencing during gate reviews, which is expected. | No action. |
+| file_breadth (38 files) | Info | Consistent with design-heavy feature profile. See lesson #1120. | No action. |
+| adr_count (6 ADRs) | Info | Reflects the feature's decision density -- 6 distinct design decisions for 2 skills. Not excessive given the novel patterns (sentinel, state machine, quality gate, pre-flight, output format, category scope). | No action. |
+
+### Recommendation Actions
+
+| Recommendation | Action Taken |
+|---------------|-------------|
+| "Add common build/test commands to settings.json allowlist" | Not stored. The 14 retries were on Read tool (not build/test commands), which is atypical. This appears to be an environment-specific transient issue, not a systematic gap. If it recurs in future features, revisit and store as a procedure. |
+
+### Baseline Outlier Notes
+
+**session_count (7 vs mean 2.92, stddev 2.04)**:
+
+This is explained by the feature's nature, not a process issue. nan-003 was a design-heavy feature that produced 6 ADRs, full architecture, 6 pseudocode components, risk strategy, and 3 gate reports -- but only 2 markdown skill files as implementation. The protocol's natural session boundaries (architecture session, spec session, pseudocode session, implementation session, 3 gate sessions) account for 7 sessions. Zero gate failures and zero rework confirm the sessions were productive, not wasteful. Captured in lesson #1120.
+
+## Summary
+
+| Category | New | Updated | Skipped |
+|----------|-----|---------|---------|
+| Patterns | 2 (#1118, #1119) | 0 | 3 (agent scan, block template, entry quality gate) |
+| Procedures | 0 | 0 | -- |
+| ADRs | -- | -- | 6 validated, 0 flagged |
+| Lessons | 1 (#1120) | 0 | -- |

--- a/product/features/nan-003/agents/nan-003-security-reviewer-report.md
+++ b/product/features/nan-003/agents/nan-003-security-reviewer-report.md
@@ -1,0 +1,80 @@
+# Security Review: nan-003-security-reviewer
+
+## Risk Level: low
+
+## Summary
+
+This PR delivers two markdown skill files and extensive design documentation. No executable code, no Rust changes, no schema modifications, no new dependencies. The deliverables are Claude Code skill instructions (markdown) that guide model behavior for repository onboarding. The attack surface is limited to model instruction-following fidelity and CLAUDE.md file operations.
+
+## Findings
+
+### Finding 1: CLAUDE.md Overwrite Risk (Write vs Edit Semantics)
+
+- **Severity**: medium
+- **Location**: `.claude/skills/unimatrix-init/SKILL.md` Phase 3
+- **Description**: The skill instructs Claude to append to CLAUDE.md using "Edit/append semantics -- do NOT overwrite the file." This is the correct instruction, and it is explicitly stated. However, the skill does not include a verification step after writing (e.g., "read CLAUDE.md after writing and verify all pre-existing content is preserved"). If the model misinterprets the instruction and uses Write instead of Edit, the entire CLAUDE.md is destroyed. The IMPLEMENTATION-BRIEF (C-07, function signatures table) reinforces "Edit (append, NOT Write/overwrite)" -- good.
+- **Recommendation**: No change required. The instruction is clear and explicit. The risk is a platform constraint (model instruction fidelity), not a code defect. The RISK-TEST-STRATEGY R-12 covers this with test scenarios.
+- **Blocking**: no
+
+### Finding 2: Prompt Injection via Adversarial README Content
+
+- **Severity**: low
+- **Location**: `.claude/skills/unimatrix-seed/SKILL.md` Step 3 (Level 0 reads README.md)
+- **Description**: `/unimatrix-seed` reads README.md and other repo files, then generates knowledge entries from their content. A malicious README could contain adversarial instructions designed to manipulate the model into storing harmful entries, bypassing the quality gate, or leaking context. The defense chain is: quality gate (What/Why/Scope) + human approval at every gate. This is documented in the RISK-TEST-STRATEGY security section.
+- **Recommendation**: No change required. The human-in-the-loop approval at every gate is the correct mitigation for this threat model. The quality gate provides a first line of defense, and no entries are stored without explicit human approval.
+- **Blocking**: no
+
+### Finding 3: No Path Traversal Risk
+
+- **Severity**: informational
+- **Location**: Both skill files
+- **Description**: Neither skill accepts user-provided file path parameters. `/unimatrix-init` globs a fixed pattern (`.claude/agents/**/*.md`) and writes to a fixed location (`CLAUDE.md`). `/unimatrix-seed` reads from a predetermined list of files (README.md, Cargo.toml, etc.) and stores via MCP `context_store`. No path traversal vectors exist.
+- **Recommendation**: None.
+- **Blocking**: no
+
+### Finding 4: No Secrets or Credentials
+
+- **Severity**: informational
+- **Location**: Entire diff
+- **Description**: Searched the full 4076-line diff for API keys, secrets, passwords, tokens, credentials, and bearer strings. Zero matches. Only external URLs are GitHub issue references to this project's own repository.
+- **Recommendation**: None.
+- **Blocking**: no
+
+### Finding 5: No New Dependencies
+
+- **Severity**: informational
+- **Location**: Entire diff
+- **Description**: No Cargo.toml, package.json, or any dependency manifest is modified. No new crates, no new npm packages. The deliverables are pure markdown files.
+- **Recommendation**: None.
+- **Blocking**: no
+
+### Finding 6: Seed Entry Poisoning via context_store
+
+- **Severity**: low
+- **Location**: `.claude/skills/unimatrix-seed/SKILL.md` Step 4, Step 5, Step 7
+- **Description**: Approved seed entries are stored via `context_store` and become visible to all future agents via `context_briefing` and `context_search`. If a low-quality or misleading entry passes human approval, it could provide incorrect guidance to future agents across the repository. The defense is the explicit human approval gate at every level, plus the quality gate (What/Why/Scope validation). The category restriction (convention/pattern/procedure only -- no decision/outcome/lesson-learned) limits the blast radius.
+- **Recommendation**: No change required. The multi-layer defense (quality gate + human approval + category restriction) is appropriate for the threat model. Stored entries can be corrected or deprecated via existing MCP tools (context_correct, context_deprecate).
+- **Blocking**: no
+
+## Blast Radius Assessment
+
+**Worst case if the fix has a subtle bug**: The most dangerous failure mode is `/unimatrix-init` using Write semantics instead of Edit/append, destroying existing CLAUDE.md content. This would cause loss of all project instructions for the target repository. The blast radius is limited to one file in one repository, and git history provides recovery. The skill instructions explicitly guard against this (repeated "do NOT overwrite" language), and dry-run mode exists for pre-verification.
+
+For `/unimatrix-seed`, the worst case is storing low-quality entries that mislead future agents. The blast radius is bounded by: (a) human approval required for every entry, (b) entries can be deprecated/corrected after the fact, (c) entries only affect semantic search relevance, not hard-coded behavior.
+
+Neither skill modifies any Rust code, schema, or runtime behavior of the Unimatrix server itself. The blast radius does not extend to the MCP server's operation.
+
+## Regression Risk
+
+**Minimal**. No existing code is modified. No existing files are changed. The two new skill files are additive -- they create new slash commands without touching the 11 existing skills. The only existing file referenced in git status as modified (`product/PRODUCT-VISION.md`) is NOT part of this PR diff, so no vision document regression.
+
+The only theoretical regression: if the Claude Code skill loader has path conflicts or naming collisions, the new `unimatrix-init` and `unimatrix-seed` directories could interfere. This is unlikely given the existing `.claude/skills/` convention with 11 other skills already following the same pattern.
+
+## PR Comments
+
+- Posted 1 review comment on PR #212
+- Blocking findings: no
+
+## Knowledge Stewardship
+
+- Stored: nothing novel to store -- this is a markdown-only delivery with no executable code. The prompt injection risk via README content is feature-specific and already documented in the RISK-TEST-STRATEGY. The Write-vs-Edit concern is a known platform constraint already captured in Unimatrix entry #550 (Markdown-Only Delivery Pattern). No 2+ feature evidence for a new pattern.


### PR DESCRIPTION
## Summary
- Add retrospective architect reports for crt-018 and nan-003
- Add security reviewer reports for crt-018, nan-001, and nan-003
- Update Cargo.lock (serde indexmap dependency)

## Test plan
- [ ] Verify no code changes, docs only
- [ ] Confirm Cargo.lock change is valid (serde indexmap dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)