### PR TITLE
docs: add retro and security review reports for nan-002

### DIFF
--- a/product/features/nan-002/agents/nan-002-retro-architect-report.md
+++ b/product/features/nan-002/agents/nan-002-retro-architect-report.md
@@ -1,0 +1,96 @@
+# nan-002 Retrospective Architect Report
+
+**Agent ID:** nan-002-retro-architect
+**Feature:** nan-002 (Knowledge Import)
+**Mode:** Retrospective (post-ship review)
+
+## 1. Patterns
+
+### Updated
+
+| Entry | Title | Action | Reason |
+|-------|-------|--------|--------|
+| #1102 -> #1160 | Sync CLI Subcommand Pattern for unimatrix-server | Corrected | Import used directory module (import/mod.rs + inserters.rs) and extracted embed_reconstruct.rs as separate top-level module. Pattern updated to document both simple (single-file) and complex (directory + extracted phase) structural templates. |
+
+### New
+
+| Entry | Title | Reason |
+|-------|-------|--------|
+| #1161 | Shared Typed Deserialization Structs for Cross-Module Format Contract | format.rs establishes a reusable pattern: typed serde structs as compile-time contract between producer (export) and consumer (import) of a serialization format. Generalizable to any multi-module format sharing. |
+| #1162 | Two-Phase Import: DB Transaction Then Embedding Reconstruction | Separating DB commit from embedding reconstruction is a reusable architecture for systems with relational stores + derived indexes. Applicable to future re-indexing, model upgrades, or backup restore. |
+
+### Validated (no changes needed)
+
+| Entry | Title | Reason |
+|-------|-------|--------|
+| #1103 | Explicit SQL-to-JSONL Row Serialization Pattern | Export-side pattern. Import consumed the format correctly. Pattern remains accurate. |
+| #344 | Store::open() + Raw SQL Hybrid for Bulk Data Import | Import used exactly this approach: Store::open() for DDL/PRAGMA setup, then lock_conn() for direct SQL INSERT. |
+| #343 | JSON-Lines Intermediate Format for Cross-Backend Data Migration | Distinct from the SQLite JSONL format (this is the old redb migration format). No overlap. |
+
+### Skipped
+
+No components were skipped -- all produced generalizable patterns or validated existing ones.
+
+## 2. Procedures
+
+No procedure changes detected:
+- **Schema migration**: No new migration steps introduced. Import consumes existing schema, does not modify it.
+- **Build/test process**: No changes to build tooling or test infrastructure.
+- **New technique**: The two-phase import technique is captured as pattern #1162. No procedural how-to needed beyond the pattern description.
+
+## 3. ADR Validation
+
+All 4 ADRs validated by successful implementation and gate passage:
+
+| ADR | Entry | Status | Evidence |
+|-----|-------|--------|----------|
+| ADR-001: Shared Format Types | #1143 | Validated | format.rs successfully bridges export and import. Gate 3b confirmed interface consistency. 22 unit tests cover deserialization edge cases. |
+| ADR-002: Direct SQL INSERT | #1144 | Validated | All 8 insert_* functions use parameterized SQL via rusqlite params![]. Round-trip test confirms lossless data preservation across 26 entry columns. |
+| ADR-003: --force Flag Safety | #1145 | Validated | Stderr warning without interactive prompt. 3 integration tests cover force-replaces, rejection-without-force, and force-on-empty. |
+| ADR-004: Embedding After Commit | #1146 | Validated | Two-phase separation confirmed correct. Database usable for non-search operations after Phase 1 even if Phase 2 fails. Extracted to embed_reconstruct.rs for reuse. |
+
+No ADRs flagged for supersession.
+
+## 4. Lessons
+
+### From Gate Failures
+
+| Entry | Title | Source |
+|-------|-------|--------|
+| (not stored) | Gate 3a stewardship compliance failure | Gate 3a failed because architect and synthesizer reports lacked `## Knowledge Stewardship` sections. This is NOT a new lesson -- stewardship block requirements are already documented in gate rules. The failure was an execution gap (agents not following existing rules), not a knowledge gap. Storing a lesson would be redundant. |
+
+### From Hotspots
+
+| Entry | Title | Source |
+|-------|-------|--------|
+| #1163 | Excessive Context Loading Before First Write Inflates Session Cost | context_load_before_first_write_kb at 4.4 sigma (282 KB vs 19.7 KB mean). Agents reading full source files when only signatures needed. |
+| #1164 | Bash Permission Retries Indicate Missing Allowlist Entries | 6 permission retries on Bash tool. Common cargo commands not in settings.json allowlist. |
+| #1165 | High Compile Cycles Signal Need for Targeted Test Invocations | 60 compile cycles. Agents running cargo build/test --workspace instead of targeted -p unimatrix-server. |
+
+### Hotspot Analysis: output_parsing_struggle
+
+The "cargo test piped through 6 different filters within 3 minutes" hotspot is an info-level signal. This occurs when agents try to parse cargo test output to find specific failures. Not storing as a lesson because it is a one-off friction point, not a recurring pattern with a clear mitigation.
+
+## 5. Retrospective Findings
+
+**Summary entry:** #1166 (Retrospective findings: nan-002)
+
+### Positive Outliers
+- **knowledge_entries_stored**: 14 vs. 2.8 mean (2.6 sigma). This feature had excellent knowledge capture: 4 ADRs, 6 outcomes, and patterns tagged during design and delivery. The design session's knowledge discipline likely contributed to the clean delivery (no code rework, gates 3b and 3c passed first try).
+
+### Negative Outliers
+- **context_load_before_first_write_kb**: 282 KB vs. 19.7 KB mean (4.4 sigma). See lesson #1163.
+- **total_context_loaded_kb**: 3985 KB vs. 639 KB mean (1.8 sigma). Correlated with the front-loading issue. Also influenced by 79 distinct files accessed and 66 re-reads.
+- **friction_hotspot_count**: 7 vs. 2.2 mean (1.8 sigma). Driven by permission retries and compile cycles.
+
+### Recommendation Actions
+
+| Recommendation | Action Taken |
+|----------------|-------------|
+| Add common build/test commands to settings.json allowlist | Lesson #1164 stored. Implementation deferred to human (requires settings.json edit). |
+| Consider incremental compilation or targeted cargo test invocations | Lesson #1165 stored. Actionable by implementation agents immediately. |
+
+## Knowledge Stewardship
+
+- Queried: #1102, #1103, #344, #343 (patterns), lesson-learned category for gate failures, procedures for schema migration, bash permission lessons, context loading lessons
+- Stored: #1160 (corrected #1102), #1161 (new pattern), #1162 (new pattern), #1163 (lesson), #1164 (lesson), #1165 (lesson), #1166 (retrospective findings)

--- a/product/features/nan-002/agents/nan-002-security-reviewer-report.md
+++ b/product/features/nan-002/agents/nan-002-security-reviewer-report.md
@@ -1,0 +1,73 @@
+# Security Review: nan-002-security-reviewer
+
+## Risk Level: low
+
+## Summary
+
+The nan-002 Knowledge Import implementation is well-structured with strong security fundamentals. All SQL operations use parameterized queries via rusqlite `params![]`, preventing SQL injection. The input surface (JSONL file) is handled with line-by-line parsing, serde typed deserialization, and proper error propagation. One medium-severity design concern exists around `drop_all_data` executing outside the import transaction, creating a window where data loss is irrecoverable if the subsequent import fails.
+
+## Findings
+
+### Finding 1: drop_all_data executes outside transaction boundary
+- **Severity**: medium
+- **Location**: crates/unimatrix-server/src/import/mod.rs (run_import function, force-drop block)
+- **Description**: When `--force` is specified, `drop_all_data()` is called before `BEGIN IMMEDIATE`. If the import then fails (e.g., header validation, JSONL parse error, FK violation), the original data has already been permanently deleted with no rollback possible. The architecture (ADR-003) accepts this risk for the `--force` flag, but the current code structure amplifies it -- the drop could be moved inside the transaction to make it atomic with the import.
+- **Recommendation**: Move `drop_all_data()` to execute after `BEGIN IMMEDIATE` but before `ingest_rows()`, so that both the drop and the import are covered by the same transaction. If the import fails, everything rolls back including the drop.
+- **Blocking**: no
+
+### Finding 2: SQL injection prevention -- PASS
+- **Severity**: informational
+- **Location**: crates/unimatrix-server/src/import/inserters.rs (all 8 insert functions)
+- **Description**: All INSERT statements use `params![]` macro with positional parameters (?1, ?2, etc.). No string interpolation in production SQL. The one `format!()` call for SQL is in test code (`test_all_eight_tables_restored`) with hardcoded table names, which is acceptable.
+- **Recommendation**: None needed.
+- **Blocking**: no
+
+### Finding 3: Input file path -- no traversal risk
+- **Severity**: informational
+- **Location**: crates/unimatrix-server/src/main.rs (Import CLI args)
+- **Description**: The `--input` path is only used with `File::open()` for reading. No path components from JSONL content are used as file paths. No path traversal risk.
+- **Recommendation**: None needed.
+- **Blocking**: no
+
+### Finding 4: No secrets or credentials in diff
+- **Severity**: informational
+- **Location**: entire diff
+- **Description**: No hardcoded API keys, tokens, passwords, or credentials found in any of the 7,473 added lines.
+- **Recommendation**: None needed.
+- **Blocking**: no
+
+### Finding 5: Deserialization bounded by line-by-line reading
+- **Severity**: low
+- **Location**: crates/unimatrix-server/src/import/mod.rs (ingest_rows)
+- **Description**: JSONL is read line-by-line via BufReader, which bounds per-line memory allocation. serde_json rejects NaN/Infinity by default. However, there is no validation that `entry_count` in the header matches the actual number of entries ingested. A malicious file with `entry_count: 5` but millions of lines would be processed in full. The blast radius is disk exhaustion and long runtime, not data corruption.
+- **Recommendation**: Consider adding a check that compares the actual ingested entry count against `header.entry_count` as a post-ingestion sanity check. Low priority since the import is a local CLI tool processing user-provided files.
+- **Blocking**: no
+
+### Finding 6: No new external dependencies
+- **Severity**: informational
+- **Location**: Cargo.toml (unchanged in diff)
+- **Description**: The import module uses only existing workspace crates (unimatrix-store, unimatrix-embed, unimatrix-vector, unimatrix-engine) and existing external dependencies (serde, serde_json, clap, rusqlite). No new dependency supply chain risk.
+- **Recommendation**: None needed.
+- **Blocking**: no
+
+## Blast Radius Assessment
+
+The worst-case scenario involves `--force` on a production database where the import subsequently fails after `drop_all_data()` but before `COMMIT`. In this case, all existing knowledge base data is lost. The user would need a prior export to recover. This is partially mitigated by the `--force` flag being explicitly opt-in and by the stderr warning. Moving the drop inside the transaction would eliminate this risk entirely.
+
+For non-force imports, failure modes are safe: the transaction rolls back, leaving the database unchanged. Post-commit failures (ONNX model unavailability, embedding errors) leave the database intact but without a vector index -- the database remains queryable by ID but not by semantic search, which is an acceptable degraded state per ADR-004.
+
+## Regression Risk
+
+Low. The changes are purely additive:
+- Three new modules (`format.rs`, `import/mod.rs`, `import/inserters.rs`, `embed_reconstruct.rs`)
+- Three lines added to `lib.rs` (module registration)
+- One new CLI variant in `main.rs`
+
+No existing code was modified beyond registration. The new modules cannot affect existing MCP server behavior, export behavior, or hook behavior unless explicitly invoked via the `import` subcommand.
+
+## PR Comments
+- Posted 1 comment on PR #218
+- Blocking findings: no
+
+## Knowledge Stewardship
+- Nothing novel to store -- the anti-patterns checked (SQL injection, path traversal, deserialization, transaction safety) are already well-understood. The one finding (drop outside transaction) is specific to this PR's design choice rather than a generalizable anti-pattern.


### PR DESCRIPTION
## Summary
- Adds retrospective architect report from nan-002 retro (patterns, lessons, ADR validation)
- Adds security reviewer report for nan-002

## Test plan
- [ ] Verify report files render correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)