### PR TITLE
fix: use absolute paths in hook commands for dev environment

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "unimatrix hook SessionStart"
+            "command": "/workspaces/unimatrix/target/release/unimatrix hook SessionStart"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "unimatrix hook Stop"
+            "command": "/workspaces/unimatrix/target/release/unimatrix hook Stop"
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "unimatrix hook UserPromptSubmit"
+            "command": "/workspaces/unimatrix/target/release/unimatrix hook UserPromptSubmit"
           }
         ]
       }
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "unimatrix hook PreToolUse"
+            "command": "/workspaces/unimatrix/target/release/unimatrix hook PreToolUse"
           }
         ]
       }
@@ -50,7 +50,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "unimatrix hook PostToolUse"
+            "command": "/workspaces/unimatrix/target/release/unimatrix hook PostToolUse"
           }
         ]
       }
@@ -61,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "unimatrix hook SubagentStart"
+            "command": "/workspaces/unimatrix/target/release/unimatrix hook SubagentStart"
           }
         ]
       }
@@ -72,7 +72,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "unimatrix hook SubagentStop"
+            "command": "/workspaces/unimatrix/target/release/unimatrix hook SubagentStop"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Update hook commands in `.claude/settings.json` to use absolute path (`/workspaces/unimatrix/target/release/unimatrix`) instead of bare `unimatrix`
- Bare name requires PATH setup; absolute paths work immediately in the dev container

Closes #220 (final wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)