### PR TITLE
[col-023] Protocol Integration: SM agents call context_cycle

### DIFF
--- a/.claude/agents/uni/uni-scrum-master.md
+++ b/.claude/agents/uni/uni-scrum-master.md
@@ -93,6 +93,21 @@ From the primary agent's spawn prompt:
 
 ---
 
+## Feature Cycle Attribution
+
+**MUST call `context_cycle(type: "start")` before any file-touching tool calls.** This sets session-level feature attribution so all subsequent tool calls are tracked against the correct feature.
+
+| When | Call | Parameters |
+|------|------|------------|
+| After branch creation / initialization, before first agent spawn | `context_cycle(type: "start")` | `topic: "{feature-id}"`, `keywords: [...]` (3-5 semantic terms) |
+| After outcome recording, at session end | `context_cycle(type: "stop")` | `topic: "{feature-id}"` |
+
+- `topic` = the feature ID from your spawn prompt (e.g., `col-022`, `nxs-005`, `142-null-crash`)
+- `keywords` = 3-5 terms describing the feature work (e.g., `["lifecycle", "attribution", "cycle-management"]`)
+- Each protocol specifies the exact insertion point — follow it
+
+---
+
 ## Gate Management (Delivery + Bugfix)
 
 Spawn `uni-validator` with focused check sets per the protocol.

--- a/.claude/protocols/uni/uni-bugfix-protocol.md
+++ b/.claude/protocols/uni/uni-bugfix-protocol.md
@@ -62,7 +62,15 @@ The Bugfix Manager:
 3. Queries Unimatrix for prior knowledge:
    - `/query-patterns` — patterns related to the affected area
    - `/knowledge-search` — lessons from prior bugfixes in the same subsystem
-4. Passes relevant findings to the investigator in Phase 1
+4. **Declares feature cycle** — before any agent spawning:
+   ```
+   context_cycle(
+     type: "start",
+     topic: "{issue-number}-{short-description}",
+     keywords: ["{keyword-1}", "{keyword-2}", ...]  // 3-5 semantic terms for the bug area
+   )
+   ```
+5. Passes relevant findings to the investigator in Phase 1
 
 Worker agents are spawned with `isolation: "worktree"` for branch isolation (see `/uni-git` Worktree Isolation).
 
@@ -368,6 +376,7 @@ NEVER pipe full cargo output into context.
 ```
 BUGFIX LEADER (you):
   Init:       /query-patterns + /knowledge-search — prior knowledge
+              context_cycle(type: "start", topic: "{issue-number}-{desc}", keywords: [...])
   Phase 1:    Task(uni-bug-investigator) — diagnose root cause → GH Issue comment
               ...present diagnosis to human...
               ★ HUMAN CHECKPOINT — human approves diagnosis ★
@@ -381,7 +390,8 @@ BUGFIX LEADER (you):
               git commit + push + gh pr create
   Phase 4:    /review-pr — security review + merge readiness → GH Issue comment
               ...wait...
-  Phase 5:    /record-outcome + /store-lesson (if generalizable)
+  Phase 5:    context_cycle(type: "stop", topic: "{issue-number}-{desc}")
+              /record-outcome + /store-lesson (if generalizable)
               Present PR + security assessment to human — SESSION ENDS
 ```
 
@@ -389,7 +399,16 @@ BUGFIX LEADER (you):
 
 ## Outcome Recording
 
-After presenting the PR to the human, record the bugfix outcome using Unimatrix skills:
+After presenting the PR to the human, close the feature cycle and record the bugfix outcome:
+
+```
+context_cycle(
+  type: "stop",
+  topic: "{issue-number}-{short-description}"
+)
+```
+
+Then use Unimatrix skills:
 
 1. **Always**: `/record-outcome` — record the bugfix result (pass/fail, root cause summary, PR link). Include `caused_by_feature:{feature-id}` tag when the originating feature is known.
 2. **If root cause is generalizable**: `/store-lesson` — persist the root cause pattern so future investigators find it via `/knowledge-search`. Tag with `caused_by_feature:{feature-id}` when applicable. Include what could have been done during the originating feature's design phase to prevent the bug.

--- a/.claude/protocols/uni/uni-delivery-protocol.md
+++ b/.claude/protocols/uni/uni-delivery-protocol.md
@@ -54,7 +54,15 @@ The Delivery Leader:
 2. Reads `product/features/{feature-id}/ACCEPTANCE-MAP.md` — AC verification methods
 3. Reads paths to the three source documents (listed in the brief)
 4. **Creates feature branch**: `git checkout -b feature/{phase}-{NNN}` (see `/uni-git`)
-5. Spawns worker agents with `isolation: "worktree"` for parallel workstreams (see `/uni-git` Worktree Isolation)
+5. **Declares feature cycle** — before any agent spawning:
+   ```
+   context_cycle(
+     type: "start",
+     topic: "{feature-id}",
+     keywords: ["{keyword-1}", "{keyword-2}", ...]  // 3-5 semantic terms for the feature
+   )
+   ```
+6. Spawns worker agents with `isolation: "worktree"` for parallel workstreams (see `/uni-git` Worktree Isolation)
 
 ---
 
@@ -474,6 +482,7 @@ NEVER pipe full cargo output into context.
 ```
 DELIVERY LEADER (you):
   Init:       Read IMPLEMENTATION-BRIEF.md + ACCEPTANCE-MAP.md
+              context_cycle(type: "start", topic: "{feature-id}", keywords: [...])
   Stage 3a:   Task(uni-pseudocode) + Task(uni-tester) — parallel, ONE message
               ...wait for both to complete...
               UPDATE Component Map in IMPLEMENTATION-BRIEF.md with actual file paths
@@ -492,6 +501,7 @@ DELIVERY LEADER (you):
   Phase 4:    git commit + push + gh pr create
               [CONDITIONAL] uni-docs — documentation update (if trigger criteria met)
               /review-pr — security review + merge readiness
+              context_cycle(type: "stop", topic: "{feature-id}")
               Combined return — SESSION 2 ENDS
 ```
 
@@ -512,9 +522,14 @@ The uni-tester agent has full integration harness knowledge (suite selection, tr
 
 ## Outcome Recording
 
-After Phase 4, record the session outcome in Unimatrix:
+After Phase 4, close the feature cycle and record the session outcome:
 
 ```
+context_cycle(
+  type: "stop",
+  topic: "{feature-id}"
+)
+
 context_store(
   category: "outcome",
   feature_cycle: "{feature-id}",

--- a/.claude/protocols/uni/uni-design-protocol.md
+++ b/.claude/protocols/uni/uni-design-protocol.md
@@ -49,6 +49,20 @@ Each message batches ALL related operations of the same type:
 
 The Design Leader creates a `feature/{feature-id}` branch at session start and opens a **draft PR** at session end. Implementation continues on the same branch — no separate design merge step. See `/uni-git` for branch naming and PR conventions.
 
+### Feature Cycle Attribution
+
+After creating the branch — before spawning any agents — call `context_cycle` to declare the feature cycle:
+
+```
+context_cycle(
+  type: "start",
+  topic: "{feature-id}",
+  keywords: ["{keyword-1}", "{keyword-2}", ...]  // 3-5 semantic terms for the feature
+)
+```
+
+This sets session-level feature attribution so all subsequent tool calls are tracked against this feature.
+
 ---
 
 ## Flow: Phase 1 + Phase 2
@@ -301,6 +315,7 @@ Do NOT paste full documents into agent prompts. Agents read files themselves.
 ```
 DESIGN LEADER (you):
   Init:       git checkout -b feature/{feature-id}
+              context_cycle(type: "start", topic: "{feature-id}", keywords: [...])
   Phase 1:    Task(uni-researcher) — scope exploration with human
               ...human approves SCOPE.md...
   Phase 1b:   Task(uni-risk-strategist, MODE: scope-risk) — scope risk assessment
@@ -311,16 +326,22 @@ DESIGN LEADER (you):
               ...wait...
   Phase 2b:   Task(uni-vision-guardian) — alignment check
   Phase 2c:   Task(uni-synthesizer) — brief + maps + GH Issue (fresh context)
-  Phase 2d:   git commit + push + gh pr create --draft — SESSION 1 ENDS
+  Phase 2d:   git commit + push + gh pr create --draft
+              context_cycle(type: "stop", topic: "{feature-id}") — SESSION 1 ENDS
 ```
 
 ---
 
 ## Outcome Recording
 
-After returning artifacts to the human, record the session outcome in Unimatrix:
+After returning artifacts to the human, close the feature cycle and record the session outcome:
 
 ```
+context_cycle(
+  type: "stop",
+  topic: "{feature-id}"
+)
+
 context_store(
   category: "outcome",
   feature_cycle: "{feature-id}",


### PR DESCRIPTION
## Summary

- Add `context_cycle(type: "start")` calls to design, delivery, and bugfix protocol initialization sections
- Add `context_cycle(type: "stop")` calls to outcome recording sections of all three protocols
- Add Feature Cycle Attribution section to SM agent definition documenting the requirement
- Update Quick Reference message maps in all protocols to show start/stop call placement

Closes #223

## Test plan

- [ ] Verify protocol markdown is well-formed
- [ ] Run a design/delivery session and confirm `context_cycle` calls execute at the expected points

🤖 Generated with [Claude Code](https://claude.com/claude-code)