### PR TITLE
docs(protocols): add agent_id to context_cycle calls (#230)

### DIFF
--- a/.claude/protocols/uni/uni-bugfix-protocol.md
+++ b/.claude/protocols/uni/uni-bugfix-protocol.md
@@ -67,7 +67,8 @@ The Bugfix Manager:
    context_cycle(
      type: "start",
      topic: "{issue-number}-{short-description}",
-     keywords: ["{keyword-1}", "{keyword-2}", ...]  // 3-5 semantic terms for the bug area
+     keywords: ["{keyword-1}", "{keyword-2}", ...],  // 3-5 semantic terms for the bug area
+     agent_id: "{issue-number}-bugfix-leader"
    )
    ```
 5. Passes relevant findings to the investigator in Phase 1
@@ -376,7 +377,7 @@ NEVER pipe full cargo output into context.
 ```
 BUGFIX LEADER (you):
   Init:       /query-patterns + /knowledge-search — prior knowledge
-              context_cycle(type: "start", topic: "{issue-number}-{desc}", keywords: [...])
+              context_cycle(type: "start", topic: "{issue-number}-{desc}", keywords: [...], agent_id: "{issue-number}-bugfix-leader")
   Phase 1:    Task(uni-bug-investigator) — diagnose root cause → GH Issue comment
               ...present diagnosis to human...
               ★ HUMAN CHECKPOINT — human approves diagnosis ★
@@ -390,7 +391,7 @@ BUGFIX LEADER (you):
               git commit + push + gh pr create
   Phase 4:    /review-pr — security review + merge readiness → GH Issue comment
               ...wait...
-  Phase 5:    context_cycle(type: "stop", topic: "{issue-number}-{desc}")
+  Phase 5:    context_cycle(type: "stop", topic: "{issue-number}-{desc}", agent_id: "{issue-number}-bugfix-leader")
               /record-outcome + /store-lesson (if generalizable)
               Present PR + security assessment to human — SESSION ENDS
 ```
@@ -404,7 +405,8 @@ After presenting the PR to the human, close the feature cycle and record the bug
 ```
 context_cycle(
   type: "stop",
-  topic: "{issue-number}-{short-description}"
+  topic: "{issue-number}-{short-description}",
+  agent_id: "{issue-number}-bugfix-leader"
 )
 ```
 

--- a/.claude/protocols/uni/uni-delivery-protocol.md
+++ b/.claude/protocols/uni/uni-delivery-protocol.md
@@ -59,7 +59,8 @@ The Delivery Leader:
    context_cycle(
      type: "start",
      topic: "{feature-id}",
-     keywords: ["{keyword-1}", "{keyword-2}", ...]  // 3-5 semantic terms for the feature
+     keywords: ["{keyword-1}", "{keyword-2}", ...],  // 3-5 semantic terms for the feature
+     agent_id: "{feature-id}-delivery-leader"
    )
    ```
 6. Spawns worker agents with `isolation: "worktree"` for parallel workstreams (see `/uni-git` Worktree Isolation)
@@ -482,7 +483,7 @@ NEVER pipe full cargo output into context.
 ```
 DELIVERY LEADER (you):
   Init:       Read IMPLEMENTATION-BRIEF.md + ACCEPTANCE-MAP.md
-              context_cycle(type: "start", topic: "{feature-id}", keywords: [...])
+              context_cycle(type: "start", topic: "{feature-id}", keywords: [...], agent_id: "{feature-id}-delivery-leader")
   Stage 3a:   Task(uni-pseudocode) + Task(uni-tester) — parallel, ONE message
               ...wait for both to complete...
               UPDATE Component Map in IMPLEMENTATION-BRIEF.md with actual file paths
@@ -501,7 +502,7 @@ DELIVERY LEADER (you):
   Phase 4:    git commit + push + gh pr create
               [CONDITIONAL] uni-docs — documentation update (if trigger criteria met)
               /review-pr — security review + merge readiness
-              context_cycle(type: "stop", topic: "{feature-id}")
+              context_cycle(type: "stop", topic: "{feature-id}", agent_id: "{feature-id}-delivery-leader")
               Combined return — SESSION 2 ENDS
 ```
 
@@ -527,7 +528,8 @@ After Phase 4, close the feature cycle and record the session outcome:
 ```
 context_cycle(
   type: "stop",
-  topic: "{feature-id}"
+  topic: "{feature-id}",
+  agent_id: "{feature-id}-delivery-leader"
 )
 
 context_store(

--- a/.claude/protocols/uni/uni-design-protocol.md
+++ b/.claude/protocols/uni/uni-design-protocol.md
@@ -57,7 +57,8 @@ After creating the branch — before spawning any agents — call `context_cycle
 context_cycle(
   type: "start",
   topic: "{feature-id}",
-  keywords: ["{keyword-1}", "{keyword-2}", ...]  // 3-5 semantic terms for the feature
+  keywords: ["{keyword-1}", "{keyword-2}", ...],  // 3-5 semantic terms for the feature
+  agent_id: "{feature-id}-design-leader"
 )
 ```
 
@@ -315,7 +316,7 @@ Do NOT paste full documents into agent prompts. Agents read files themselves.
 ```
 DESIGN LEADER (you):
   Init:       git checkout -b feature/{feature-id}
-              context_cycle(type: "start", topic: "{feature-id}", keywords: [...])
+              context_cycle(type: "start", topic: "{feature-id}", keywords: [...], agent_id: "{feature-id}-design-leader")
   Phase 1:    Task(uni-researcher) — scope exploration with human
               ...human approves SCOPE.md...
   Phase 1b:   Task(uni-risk-strategist, MODE: scope-risk) — scope risk assessment
@@ -327,7 +328,7 @@ DESIGN LEADER (you):
   Phase 2b:   Task(uni-vision-guardian) — alignment check
   Phase 2c:   Task(uni-synthesizer) — brief + maps + GH Issue (fresh context)
   Phase 2d:   git commit + push + gh pr create --draft
-              context_cycle(type: "stop", topic: "{feature-id}") — SESSION 1 ENDS
+              context_cycle(type: "stop", topic: "{feature-id}", agent_id: "{feature-id}-design-leader") — SESSION 1 ENDS
 ```
 
 ---
@@ -339,7 +340,8 @@ After returning artifacts to the human, close the feature cycle and record the s
 ```
 context_cycle(
   type: "stop",
-  topic: "{feature-id}"
+  topic: "{feature-id}",
+  agent_id: "{feature-id}-design-leader"
 )
 
 context_store(


### PR DESCRIPTION
## Summary
- Adds `agent_id` parameter to all 12 `context_cycle` call sites across design, delivery, and bugfix protocols
- Ensures future sessions pass identity correctly, preventing the permission denied error fixed in PR #234

Follow-up to #230 / PR #234.

## Test plan
- [x] Protocol-only change — no code affected
- [x] Verified all 12 call sites updated (6 code blocks + 6 quick-reference maps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)