### PR TITLE
chore: commit outstanding agent reports from prior sessions

### DIFF
--- a/product/features/bugfix-228/agents/bugfix-228-security-reviewer-report.md
+++ b/product/features/bugfix-228/agents/bugfix-228-security-reviewer-report.md
@@ -1,0 +1,68 @@
+# Security Review: bugfix-228-security-reviewer
+
+## Risk Level: low
+
+## Summary
+
+The change is minimal, well-scoped, and intentional. It adds a compile-time const `PERMISSIVE_AUTO_ENROLL` that grants Write capability to auto-enrolled (unknown) agents. Admin capability remains gated behind explicit enrollment. No new inputs, no new dependencies, no injection surfaces. The primary concern is the deliberate weakening of the access control model, which is acknowledged and documented as a temporary measure.
+
+## Findings
+
+### Finding 1: Intentional Access Control Relaxation
+- **Severity**: low
+- **Location**: `crates/unimatrix-server/src/infra/registry.rs:27`
+- **Description**: `PERMISSIVE_AUTO_ENROLL = true` grants Write to every unknown agent_id, including arbitrary strings from MCP tool parameters. Any caller can store, correct, and deprecate entries simply by providing any agent_id. This is a deliberate design choice per #228, not a bug. The issue correctly notes that agents were already bypassing this by falling back to "human", so the practical security posture is unchanged.
+- **Recommendation**: When agent naming stabilizes, flip to `false`. Consider making this a runtime config (env var) rather than a compile-time const so the transition does not require a rebuild. Not blocking -- this is a known tradeoff documented in the issue.
+- **Blocking**: no
+
+### Finding 2: Admin Capability Correctly Excluded
+- **Severity**: informational
+- **Location**: `crates/unimatrix-server/src/infra/registry.rs:190-194`
+- **Description**: Verified that Admin is never included in the permissive path. Quarantine (`tools.rs:772`), enroll (`tools.rs:932`), and status-maintain (`tools.rs:1038`) all require Admin, which unknown agents do not receive. The security boundary for destructive operations is preserved.
+- **Recommendation**: None.
+- **Blocking**: no
+
+### Finding 3: Test Coverage Correctly Updated
+- **Severity**: informational
+- **Location**: `product/test/infra-001/suites/test_security.py:121-152`
+- **Description**: S-21, S-22, S-23 were flipped from `assert_tool_error` to `assert_tool_success`. S-24 (quarantine rejected for restricted agent) remains unchanged, confirming Admin-gated operations are still tested as denied. The test changes accurately reflect the new behavior. No negative security tests were removed without replacement.
+- **Recommendation**: None.
+- **Blocking**: no
+
+### Finding 4: No Runtime Configuration Path
+- **Severity**: low
+- **Location**: `crates/unimatrix-server/src/infra/registry.rs:27`
+- **Description**: The const is compile-time only. Switching to strict mode requires recompilation. This is fine for development but limits operational flexibility. Not a security risk per se, but worth noting for the production hardening plan.
+- **Recommendation**: Future work -- consider `std::env::var("UNIMATRIX_PERMISSIVE_ENROLL")` or a server config option.
+- **Blocking**: no
+
+## OWASP Assessment
+
+| Check | Result |
+|-------|--------|
+| Input validation | No new inputs. `agent_id` still goes through `extract_agent_id` (trim, empty-to-anonymous). No change to validation. |
+| Injection | No shell commands, SQL injection (parameterized queries throughout), or format string issues. |
+| Access control | Intentionally relaxed for Write; Admin boundary intact. |
+| Deserialization | `serialize_capabilities` uses the existing `serde_json` path with `Capability as u8`. No new deserialization of untrusted data. |
+| Error handling | No new error paths. Existing `ServerError::Registry` propagation unchanged. |
+| Secrets | No hardcoded secrets, keys, or credentials in the diff. |
+| Dependencies | No new dependencies introduced. |
+
+## Blast Radius Assessment
+
+Worst case if this fix has a subtle bug: an unknown agent could write, correct, or deprecate knowledge entries. This is exactly the intended behavior of the change. The worst case is already the design goal.
+
+If the const were accidentally left as `true` in a production deployment where strict access control was desired, any MCP client could modify knowledge entries. However, Admin operations (quarantine, enroll, status-maintain) would remain protected. Data corruption risk is low because all mutations are audited with agent_id attribution, and corrections/deprecations create new entries rather than destroying originals.
+
+## Regression Risk
+
+Low. The change modifies one code path (`resolve_or_enroll` for unknown agents) and preserves the `false` branch for future use. Explicitly enrolled agents are unaffected (they take the early-return path at line 184-186). Bootstrap agents (system, human, cortical-implant) are unaffected (they exist before `resolve_or_enroll` is called for them).
+
+The only regression scenario: code that previously relied on restricted agents being denied Write would now see those operations succeed. The integration tests (S-21, S-22, S-23) were correctly updated to reflect this.
+
+## PR Comments
+- Posted 1 review comment on PR #231
+- Blocking findings: no
+
+## Knowledge Stewardship
+- Stored: nothing novel to store -- standard access control relaxation pattern with compile-time toggle, no recurring anti-pattern observed

--- a/product/features/bugfix-236/agents/bugfix-236-security-reviewer-report.md
+++ b/product/features/bugfix-236/agents/bugfix-236-security-reviewer-report.md
@@ -1,0 +1,78 @@
+# Security Review: bugfix-236-security-reviewer
+
+## Risk Level: low
+
+## Summary
+The bugfix addresses three server reliability issues (ghost process, tick contention, handler timeouts) with well-scoped changes. No new attack surface, no input validation regressions, no new dependencies. One non-blocking observation about unrelated commits bundled into the PR, and one informational note about remaining bare spawn_blocking calls outside the retrospective handler.
+
+## Findings
+
+### Finding 1: Unrelated commits bundled in bugfix PR
+- **Severity**: low
+- **Location**: commits eaaad10 and f8007ff (skill rename, #232)
+- **Description**: The PR branch contains two commits for a skill rename refactor (#232) that are unrelated to the bugfix (#236). These commits touch only documentation and skill definition files (.claude/ directory), not Rust code. They carry no security risk but have not been through this bugfix's design review pipeline.
+- **Recommendation**: Consider rebasing so that the bugfix PR only contains #236 changes, or acknowledge in the PR description that the skill rename is an intentional inclusion.
+- **Blocking**: no
+
+### Finding 2: Timeout does not cancel the in-flight spawn_blocking task
+- **Severity**: low
+- **Location**: crates/unimatrix-server/src/infra/timeout.rs:33
+- **Description**: When `spawn_blocking_with_timeout` times out, the tokio timeout fires but the underlying `spawn_blocking` task continues running on the blocking thread pool. This is by design (tokio does not support cancelling blocking tasks), and the code correctly returns an error to the client. However, the abandoned task still holds the Store mutex until completion, meaning subsequent requests may also time out until the long-running operation finishes. This is an inherent limitation of the approach, not a bug.
+- **Recommendation**: Document this behavior (the task continues after timeout) in the function's doc comment. The current doc says "Returns ServerError if the task panics or the timeout expires" but does not mention the task continues. This helps future maintainers understand the failure cascade.
+- **Blocking**: no
+
+### Finding 3: SIGKILL escalation is properly guarded
+- **Severity**: informational
+- **Location**: crates/unimatrix-server/src/infra/pidfile.rs:214-229
+- **Description**: Verified that the SIGKILL escalation is safe. The PID originates from a PID file (read_pid_file parses u32), is validated as alive (is_process_alive), and is confirmed to be a unimatrix process (is_unimatrix_process checks /proc/{pid}/cmdline on Linux) before terminate_and_wait is called. There is no PID injection vector. The SIGKILL is a last resort after the SIGTERM timeout expires.
+- **Recommendation**: None needed. The guard chain is sound.
+- **Blocking**: no
+
+### Finding 4: Remaining bare spawn_blocking calls in tools.rs
+- **Severity**: low
+- **Location**: crates/unimatrix-server/src/mcp/tools.rs lines 1346, 1405, 1441, 1659, 1686, 1764, 1787, 1827, 1841, 1855
+- **Description**: The fix applies spawn_blocking_with_timeout to 5 calls in the context_retrospective handler (the ones that previously used .unwrap()). However, approximately 10 other spawn_blocking calls remain in tools.rs without timeout wrappers. Some are fire-and-forget (correctly excluded per the doc comment). Others (lines 1346, 1405, 1441, 1659, 1686, 1827, 1841, 1855) could theoretically block indefinitely. The fix report acknowledges this scope limitation ("Applied to 5 direct spawn_blocking calls in context_retrospective handler"). This is not a regression (these calls existed before the fix) but is worth noting for a follow-up pass.
+- **Recommendation**: Consider filing a follow-up issue to audit all spawn_blocking calls in tools.rs for timeout coverage.
+- **Blocking**: no
+
+## OWASP Assessment
+
+| Check | Result |
+|-------|--------|
+| Input validation | No new external inputs added. PID comes from internal PID file, not user input. Timeout durations are compile-time constants. |
+| Path traversal | No file path operations added or modified. |
+| Injection | PID is passed as a string argument to the `kill` command via std::process::Command (no shell injection). The pid.to_string() conversion from u32 is safe. |
+| Deserialization | No new deserialization of untrusted data. |
+| Error handling | Errors return ServerError to the MCP client. No internal state leakage. No panics in production paths (the .unwrap() calls on spawn_blocking results have been replaced with proper error handling). |
+| Access control | No changes to trust boundaries or capability checks. |
+| Dependencies | No new dependencies (Cargo.toml unchanged). |
+| Secrets | No hardcoded secrets, API keys, or credentials. |
+
+## Blast Radius Assessment
+
+**Worst case if the fix has a subtle bug:**
+
+1. **Cancellation token race**: If the cancellation token is cancelled before the rmcp service loop fully starts, the server could exit immediately on startup. This is very unlikely since the signal handler task only fires on actual SIGTERM/SIGINT. The failure mode is safe (clean exit, not corruption).
+
+2. **Tick timeout too aggressive**: If the 120-second tick timeout is too short for legitimate large-database operations, ticks would be repeatedly aborted. This degrades background maintenance quality but does not affect data integrity (work is idempotent). The failure mode is degraded performance, not corruption.
+
+3. **Handler timeout cascading**: If the 30-second MCP handler timeout fires while the Store mutex is contended, the client gets an error but the blocking task continues. Multiple concurrent requests could all time out while the background tick holds the mutex. This is a denial-of-service scenario but is strictly better than the pre-fix behavior (indefinite hang).
+
+4. **SIGKILL data corruption**: If SIGKILL hits a process while it is writing to SQLite, the database could be left in an inconsistent state. However, SQLite uses WAL journaling and is designed to survive process crashes. The SIGKILL only fires after SIGTERM + timeout, and only against verified unimatrix processes. This is an acceptable last resort.
+
+## Regression Risk
+
+1. **graceful_shutdown signature change**: The function no longer accepts a server future parameter. Any caller that passes the old signature would fail at compile time. Since this is internal API (not exposed via MCP), the blast radius is contained to this crate.
+
+2. **shutdown_signal made pub**: Previously private, now public. This is additive and cannot break existing callers.
+
+3. **spawn_blocking .unwrap() removal**: The 5 calls that previously used .unwrap() now return errors via ? operator. This changes behavior from "panic on JoinError" to "return error to client." This is strictly better but could theoretically change observable behavior if any downstream code relied on the panic (extremely unlikely in an MCP handler context).
+
+4. **xfail marker on test_multi_agent_interaction**: This test was already failing due to bugfix-228's permissive auto-enroll. Adding the xfail marker with a GH issue reference (#238) is correct practice.
+
+## PR Comments
+- Posted 1 comment on PR #239
+- Blocking findings: no
+
+## Knowledge Stewardship
+- nothing novel to store -- all findings are specific to this PR's code changes. The timeout-not-cancelling-task pattern is a well-known tokio limitation, not a project-specific anti-pattern worth storing.

--- a/product/features/col-022/agents/col-022-retro-architect-report.md
+++ b/product/features/col-022/agents/col-022-retro-architect-report.md
@@ -1,0 +1,135 @@
+# Retrospective Architect Report: col-022
+
+**Agent ID:** col-022-retro-architect
+**Feature:** col-022 (Explicit Feature Cycle Lifecycle)
+**Date:** 2026-03-13
+
+---
+
+## 1. Patterns
+
+### New Patterns Stored
+
+| ID | Title | Reason |
+|----|-------|--------|
+| #1265 | Dual-Path Validation: Shared Pure Function for MCP Tool + Hook Handler | col-022 established a reusable pattern: single `validate_cycle_params()` in validation.rs called by both MCP tool and hook handler, with different error handling per caller. Generalizable to any future MCP tool that also has a hook-side path. |
+| #1266 | Specialized Event-Type Handler Before Generic RecordEvent Dispatch | col-022 added `handle_cycle_start` before the generic #198 RecordEvent handler. This "specialize-before-generic" dispatch structure is reusable for any future event_type that needs custom handling while preserving generic observation persistence. |
+
+### Updated Patterns
+
+| Original ID | New ID | Title | Change |
+|-------------|--------|-------|--------|
+| #620 | #1264 | Idempotent ALTER TABLE Guard via pragma_table_info | Added table-existence guard for tables created after migration (sessions table case from col-022). |
+
+### Skipped
+
+- **Server-Side Observation Intercept (#763)**: col-022 does not follow this exact pattern (it uses RecordEvent dispatch, not side-effect observation in a non-RecordEvent arm). No update needed.
+- **Safety-Guard Validation (#604)**: col-022's `validate_cycle_params` follows this pattern correctly (permissive safety guard, not format enforcement). Still accurate.
+- **ToolContext Pattern (#317)**: col-022's `context_cycle` handler follows the existing tool handler pattern. No drift detected.
+
+---
+
+## 2. Procedures
+
+### Updated Procedures
+
+| Original ID | New ID | Title | Change |
+|-------------|--------|-------|--------|
+| #619 | #1263 | How to add new fields to the v6+ normalized schema | Added step for table-existence guard (step 2d), step for updating *_COLUMNS constants (step 8), and added col-022 (v11->v12) to validated list. |
+
+### No New Procedures
+
+No new build/test/integration procedures emerged. The schema migration, MCP tool addition, and hook handler extension all followed existing procedures.
+
+---
+
+## 3. ADR Status
+
+### Validated ADRs (all 5)
+
+| ADR | Unimatrix ID | Status | Notes |
+|-----|-------------|--------|-------|
+| ADR-001: Reuse RecordEvent wire protocol | #1273 | Validated | Implementation confirmed: zero new HookRequest variants, cycle events flow through RecordEvent with shared CYCLE_START_EVENT/CYCLE_STOP_EVENT constants. 99 tests pass. |
+| ADR-002: Force-set for explicit attribution | #1274 | Validated | `set_feature_force` implemented with `SetFeatureResult` enum. 11 tests cover all three variants (Set, AlreadyMatches, Overridden). Security review noted `Set` returned for unregistered sessions is misleading (Finding 2) but not functionally broken. |
+| ADR-003: JSON column for keywords | #1275 | Validated | `keywords: Option<String>` on SessionRecord, stored as JSON array string. Round-trip tests pass including unicode and special characters. |
+| ADR-004: Shared validation function | #1276 | Validated | Single `validate_cycle_params()` used by both MCP tool and hook handler. 33 validation tests. Split-brain risk (SR-07) fully mitigated. |
+| ADR-005: Schema v12 keywords migration | #1277 | Validated | ALTER TABLE with pragma_table_info idempotency guard and table-existence guard. 16 migration integration tests pass. |
+
+### Flagged for Supersession
+
+None. All 5 ADRs were validated by successful implementation with no revealed inaccuracies.
+
+### Implementation-Revealed Issues (not ADR-level)
+
+- **ADR-002 edge case**: `set_feature_force` returns `Set` for unregistered sessions (security review Finding 2). This is a minor API design issue, not an ADR-level decision error. The ADR's decision is correct; the implementation detail of the return value for unregistered sessions could be improved with a `SessionNotFound` variant. Deferred to follow-up.
+- **ADR-001 consequence materialized**: The `.to_string()` vs `.as_str()` keywords bug (Gate 3b WARN) is exactly the "implicit coupling via string constants" consequence ADR-001 predicted, but manifested in the data layer rather than the event_type layer. The event_type constants were shared correctly; the keywords Value extraction was not.
+
+---
+
+## 4. Lessons
+
+### New Lessons Stored
+
+| ID | Title | Source |
+|----|-------|--------|
+| #1267 | Agent reports omit Knowledge Stewardship section unless structurally enforced | Gate 3a REWORKABLE FAIL |
+| #1268 | Test payloads must match real producer serialization to catch .to_string() vs .as_str() bugs | Gate 3b WARN |
+| #1271 | Context load and cold restart hotspots scale with component count -- normalize before flagging | Hotspot analysis |
+| #1272 | Mutation spread hotspot inflated by design artifacts -- separate code vs artifact mutation counts | Hotspot analysis |
+
+### Updated Lessons
+
+| Original ID | New ID | Title | Change |
+|-------------|--------|-------|--------|
+| #1165 | #1269 | High Compile Cycles Signal Need for Targeted Test Invocations | Added col-022 evidence (106 cycles), multi-crate targeted build tip, recurrence confirmation. |
+| #1164 | #1270 | Bash Permission Retries Indicate Missing Allowlist Entries | Added col-022 evidence (28 total retries across 3 tools), MCP tool retry context, recurrence note. |
+
+---
+
+## 5. Retrospective Findings
+
+### Hotspot-Derived Lessons
+
+| Hotspot | Severity | Action |
+|---------|----------|--------|
+| permission_retries (Bash 9, Read 7, context_store 12) | Warning | Updated existing lesson #1164 -> #1270. Bash allowlist fix still not applied after 2 features. MCP tool retries are inherent to approval model. |
+| compile_cycles (106) | Warning | Updated existing lesson #1165 -> #1269. Confirmed systemic: nan-002 had 60, col-022 has 106. Targeted builds not adopted. |
+| cold_restart (46-min gap, 18 re-reads) | Warning | Stored #1271. Acceptable for 5-component feature. Per-component load ~50KB is within bounds. |
+| context_load (251KB before first write) | Warning | Covered by #1271. 251KB / 5 components = ~50KB each, proportional. |
+| file_breadth (86 files) / mutation_spread (62 files) | Warning | Stored #1272. ~75% of mutations are design artifacts, not code churn. Code-only mutation spread is 7 files across 2 crates, well-contained for 5 components. |
+
+### Recommendation Actions
+
+| Recommendation | Action Taken |
+|----------------|-------------|
+| Add common build/test commands to settings.json allowlist | Reinforced in lesson #1270. This has been recommended twice (nan-002, col-022) without being applied. Escalating as a persistent issue. |
+| Consider incremental compilation or targeted cargo test invocations | Reinforced in lesson #1269 with specific multi-crate command examples. |
+
+### Baseline Outliers
+
+None detected (baselines empty).
+
+### Security Review Follow-ups
+
+All 3 findings are low severity and non-blocking:
+1. Duplicate `update_session_keywords` (listener vs store) -- the Store method appears unused. Should be removed or consolidated in a follow-up.
+2. `set_feature_force` returns `Set` for unregistered sessions -- misleading return value, consider `SessionNotFound` variant.
+3. Keywords stored without JSON validation at listener level -- defense-in-depth is adequate, upstream validation covers it.
+
+---
+
+## Knowledge Stewardship
+
+### Queried
+- Searched patterns: MCP tool handler, hook handler dispatch, schema migration, shared validation (4 searches)
+- Searched procedures: schema migration, MCP tool addition (1 search)
+- Searched lessons: permission retries, compile cycles, cold restart, serialization bugs (3 searches)
+- Searched decisions: RecordEvent wire protocol, force-set attribution, JSON column keywords (3 searches)
+- Looked up related features: col-022 decisions (1 lookup)
+- Read 6 existing entries in full: #763, #620, #619, #604, #1164, #886
+
+### Stored
+- 2 new patterns: #1265 (dual-path validation), #1266 (specialized event dispatch)
+- 5 ADRs: #1273-#1277 (were file-only from design phase, now in Unimatrix)
+- 4 new lessons: #1267 (stewardship enforcement), #1268 (serialization test fidelity), #1271 (context load normalization), #1272 (mutation spread normalization)
+- 3 corrections: #619->#1263 (procedure), #620->#1264 (pattern), #1165->#1269 (lesson), #1164->#1270 (lesson) -- 4 total corrections

--- a/product/features/col-022/agents/col-022-security-reviewer-report.md
+++ b/product/features/col-022/agents/col-022-security-reviewer-report.md
@@ -1,0 +1,70 @@
+# Security Review: col-022-security-reviewer
+
+## Risk Level: low
+
+## Summary
+
+The col-022 changeset introduces an explicit feature cycle lifecycle mechanism (`context_cycle` MCP tool) with hook-based attribution and a schema migration (v11->v12). The code demonstrates strong security practices: shared validation between MCP and hook paths (ADR-004), parameterized SQL throughout, proper capability checks, sanitization of all untrusted inputs, and defensive error handling. No blocking findings. Two informational observations noted below.
+
+## Findings
+
+### Finding 1: Duplicate `update_session_keywords` implementations
+- **Severity**: low
+- **Location**: `crates/unimatrix-server/src/uds/listener.rs:2069` and `crates/unimatrix-store/src/sessions.rs:275`
+- **Description**: Two `update_session_keywords` functions exist. The listener's version uses `store.update_session()` (read-modify-write pattern), while `Store::update_session_keywords()` uses a direct `UPDATE` SQL statement. The listener calls its own local version, not the Store method. The Store method (`sessions.rs:275`) appears unused in production code. This is not a vulnerability, but dead code in the store layer could cause future confusion if someone calls the wrong version.
+- **Recommendation**: Remove `Store::update_session_keywords` if unused, or consolidate to one implementation. The read-modify-write pattern in the listener is safer for data integrity.
+- **Blocking**: no
+
+### Finding 2: `set_feature_force` returns `Set` for unregistered sessions
+- **Severity**: low
+- **Location**: `crates/unimatrix-server/src/infra/session.rs:257-261`
+- **Description**: When `set_feature_force` is called with a `session_id` not in the registry, it returns `SetFeatureResult::Set` even though no state was actually modified. The caller (`handle_cycle_start`) then proceeds to spawn a fire-and-forget `update_session_feature_cycle` which will attempt to persist to SQLite. If the session row also does not exist in SQLite, this is silently swallowed. The return value `Set` is misleading -- it implies the feature was set when in fact nothing happened. The logging at `debug` level helps, but the caller's control flow is based on the return value.
+- **Recommendation**: Consider returning a new variant like `SessionNotFound` or at minimum changing the log level to `warn`. This is not a security issue but could mask attribution failures during debugging.
+- **Blocking**: no
+
+### Finding 3: Keywords stored without JSON validation
+- **Severity**: low
+- **Location**: `crates/unimatrix-server/src/uds/listener.rs:2069-2076`
+- **Description**: The `update_session_keywords` function stores the keywords string as-is without verifying it is valid JSON. The test `test_update_session_keywords_malformed_json` confirms that `"not-json"` is accepted and stored. While `validate_cycle_params` in the hook handler produces a proper `Vec<String>` which is then serialized to JSON by `serde_json::to_string`, the listener's `handle_cycle_start` calls `keywords_val.to_string()` on the `serde_json::Value`, which will produce valid JSON. So in practice, malformed JSON cannot reach this path through normal code flow. The concern is only if future code paths bypass validation.
+- **Recommendation**: No immediate action needed. The defense-in-depth is adequate -- validation happens upstream and the JSON value is serialized by serde_json.
+- **Blocking**: no
+
+### Finding 4: Input validation is thorough and correctly shared
+- **Severity**: informational
+- **Location**: `crates/unimatrix-server/src/infra/validation.rs:321-424`
+- **Description**: Positive finding. The `validate_cycle_params` function is correctly shared between the MCP tool handler and the hook handler (ADR-004). The `CYCLE_START_EVENT`/`CYCLE_STOP_EVENT` constants eliminate the magic string divergence risk (R-04). Topic validation includes control character stripping, length limits, and structural validation via `is_valid_feature_id`. Keywords are truncated to 5 items and 64 chars each. This is well-designed input validation.
+- **Recommendation**: None.
+- **Blocking**: no
+
+## OWASP Assessment
+
+| Check | Result |
+|-------|--------|
+| Input validation | Strong. All three parameters (type, topic, keywords) validated. Control chars stripped, length enforced, structural check on topic. |
+| Injection (SQL) | Not applicable. All SQL uses parameterized queries (`rusqlite::params!`, `named_params!`). No string interpolation in SQL. |
+| Injection (command) | Not applicable. No shell commands executed. |
+| Path traversal | Not applicable. No file path operations in the new code. |
+| Deserialization | Safe. `serde_json::from_str` with typed structs. Hook handler uses defensive `.get()/.as_str()` chains with fallback to generic event on parse failure. |
+| Error handling | Good. Hook always exits 0 (FR-03.7). MCP tool returns validation errors to caller. No panics in production paths. Mutex poisoning handled via `unwrap_or_else(\|e\| e.into_inner())`. |
+| Access control | Correct. `context_cycle` requires `Capability::Write`. Hook connections have SessionWrite. MCP-connected agents must have Write capability. |
+| Secrets | None. No hardcoded credentials, tokens, or keys in the diff. |
+| Dependencies | No new dependencies introduced. |
+
+## Blast Radius Assessment
+
+**Worst case if the fix has a subtle bug**: A race condition in `set_feature_force` could attribute a session to the wrong feature cycle. This would cause retrospective data to be associated with the wrong feature -- incorrect but not dangerous. No data corruption, no information disclosure, no privilege escalation. The failure mode is incorrect attribution metadata, which is observable via `context_retrospective`.
+
+**Schema migration failure**: If v11->v12 migration fails, the server refuses to start (standard migration error path). `ALTER TABLE ADD COLUMN` is atomic in SQLite, so no partial corruption. The migration has an idempotency guard (`pragma_table_info` check), handling re-run after partial failure.
+
+## Regression Risk
+
+- **SESSION_COLUMNS / session_from_row alignment**: The `keywords` column is appended to both `SESSION_COLUMNS` and `session_from_row`, using named column access (`row.get("keywords")`), which is immune to column ordering bugs. This is a positive design choice that eliminates the R-03 risk.
+- **Existing session operations**: `insert_session`, `update_session`, `get_session` all updated consistently. The `#[serde(default)]` on `keywords` ensures backward compatibility with any serialized `SessionRecord` that lacks the field.
+- **Formatter changes**: The majority of the diff (~60%) is `rustfmt` reformatting (import ordering, line wrapping). These are cosmetic and carry zero regression risk.
+
+## PR Comments
+- Posted 1 comment on PR #225
+- Blocking findings: no
+
+## Knowledge Stewardship
+- Stored: nothing novel to store -- the validation patterns (shared validation function, parameterized SQL, defensive deserialization in hook handlers) are already well-established in this codebase. The `is_valid_feature_id` duplication pattern (choosing to duplicate a small private function rather than promote visibility across crates) is a reasonable trade-off documented in the code comment.

--- a/product/features/nan-004/agents/nan-004-retro-architect-report.md
+++ b/product/features/nan-004/agents/nan-004-retro-architect-report.md
@@ -1,0 +1,103 @@
+# nan-004 Retrospective Architect Report
+
+Agent: nan-004-retro-architect
+Mode: retrospective (post-shipment knowledge extraction)
+Feature: nan-004 -- Versioning & Packaging
+PR: #221 (merged 2026-03-12)
+
+## 1. Patterns
+
+### Updated (stale entries corrected)
+
+| Original ID | New ID | Title | Change |
+|-------------|--------|-------|--------|
+| #1160 | #1191 | Sync CLI Subcommand Pattern for unimatrix | Binary renamed unimatrix-server -> unimatrix. Added thin-subcommand variant (version, model-download in main.rs). Added nan-004 instances. |
+| #1104 | #1192 | Procedure: Adding a Sync CLI Subcommand to unimatrix | Updated binary name, added thin subcommand path, added main_tests.rs extraction note, added 500-line limit warning. |
+
+### New patterns stored
+
+| ID | Title | Reason |
+|----|-------|--------|
+| #1193 | npm optionalDependencies Pattern for Platform-Specific Rust Binary Distribution | New infrastructure pattern -- first npm packaging in the project. Reusable for future platform targets. |
+| #1194 | JS Shim Routing Pattern: JS-Handled Commands vs Native Binary Passthrough | New pattern for hybrid JS/native CLI routing. Reusable if more JS-handled commands are added. |
+| #1195 | Prefix-Match Settings Merge Pattern for Shared JSON Config Files | Generic pattern for merging tool config into shared JSON files. Reusable for any tool that writes to settings.json. |
+| #1196 | Workspace Version Synchronization Pattern (Cargo.toml as Single Source of Truth) | Cross-domain versioning (Rust + npm). Reusable for any multi-package release. |
+| #1197 | Tag-Triggered Release Pipeline Pattern (Rust + npm via GitHub Actions) | CI/CD pattern for hybrid Rust+npm projects. Reusable as-is for future platform targets. |
+
+### Skipped (one-off, not stored)
+
+| Component | Reason |
+|-----------|--------|
+| C6 Postinstall (ONNX model download) | One-off: specific to ONNX model caching. No generic pattern beyond "postinstall exits 0 unconditionally." |
+| C4 Init command (project wiring) | The init command's overall flow is project-specific. The reusable parts (settings merge, binary resolution) are stored as separate patterns. |
+| C11 /release skill | The skill file is the procedure itself. Stored as procedure #1208. |
+
+## 2. Procedures
+
+| ID | Title | Status |
+|----|-------|--------|
+| #1192 | Procedure: Adding a Sync CLI Subcommand to unimatrix | Updated (corrected from #1104) |
+| #1208 | Procedure: Creating a Unimatrix Release | New -- documents the /release skill workflow and CI pipeline |
+
+No schema migration changes in nan-004. No new build/test process changes beyond the binary rename (handled in pattern corrections).
+
+## 3. ADR Status
+
+All 5 ADRs validated by successful implementation. None flagged for supersession.
+
+| ADR | File | Unimatrix ID | Validated | Notes |
+|-----|------|-------------|-----------|-------|
+| ADR-001: Absolute Paths for Hook Command Resolution | ADR-001-hook-path-resolution.md | #1198 | Yes | All 7 hooks use absolute paths. Integration tests pass. |
+| ADR-002: Binary Rename | ADR-002-binary-rename.md | #1199 | Yes | Rename complete. Operational lesson: broke hooks mid-delivery (see lesson #1205). |
+| ADR-003: Init in JavaScript | ADR-003-init-in-javascript.md | #1200 | Yes | JS/Rust delegation model worked cleanly. 20 unit tests pass. |
+| ADR-004: Settings Merge Strategy | ADR-004-settings-merge-strategy.md | #1201 | Yes | 22 unit tests. Note: ADR text has stale tee pipeline reference for UserPromptSubmit (implementation correctly omits tee). |
+| ADR-005: Version Source of Truth | ADR-005-version-source-of-truth.md | #1202 | Yes | All 9 crates + 2 npm packages at 0.5.0. Static verification passes. |
+
+Note on ADR-004 stale text: The ADR file (line 42) and ARCHITECTURE.md (lines 316-320) retain a reference to `UserPromptSubmit` retaining a tee pipeline. The implementation correctly does NOT use tee. This was flagged as WARN in gate 3a but not corrected because the pseudocode (the binding artifact) was correct. The stale text remains in the file but the Unimatrix ADR entry (#1201) documents the correct behavior.
+
+## 4. Lessons
+
+| ID | Title | Source |
+|----|-------|--------|
+| #1203 | Gate Validators Must Check All Files in One Pass to Prevent Cascading Rework | Gate 3b cascading file-size failure (main.rs then init.test.js) |
+| #1204 | Test Plan Must Cross-Reference Pseudocode for Edge-Case Behavior Assertions | Gate 3a C3 pseudocode/test-plan contradiction |
+| #1205 | Binary Renames Must Be Atomic with Hook/Config Infrastructure Updates | Binary rename broke hook feeds mid-delivery (human-reported) |
+| #1206 | MCP Tool Permission Errors on context_store Block Knowledge Stewardship | 5 failed ADR store attempts during delivery (-32003 permission) |
+| #1207 | Node.js Built-in Test Runner Requires Explicit Imports (Not Globals Like Mocha/Jest) | Gate 3b merge-settings.test.js missing node:test import |
+
+## 5. Retrospective Findings
+
+### Hotspot-derived analysis
+
+| Hotspot | Assessment | Action |
+|---------|-----------|--------|
+| permission_retries (context_store, 5 retries) | Confirms #1164 lesson from nan-002. Same root cause: missing allowlist entry. | Stored lesson #1206 with MCP-specific guidance. |
+| compile_cycles (16 cycles, 9 clusters) | Lower than nan-002 (60 cycles) despite larger feature. Confirms #1165 lesson is being partially adopted. | No new lesson -- existing #1165 covers this. |
+| sleep_workarounds (4 instances) | Agents used sleep to wait for file operations (git index.lock, package creation). | No new lesson -- existing retrospective recommendation (use run_in_background) is sufficient. |
+| context_load (156KB before first write) | Expected for a design session. Protocol and agent definition files must be read before any design work. 115 distinct files is high but justified by 11-component feature touching 94 files. | Not a problem -- design sessions have inherently high context load. |
+| cold_restart (302min gap, 34 re-reads) | Session timeouts forced context reconstruction. | No actionable lesson -- session timeouts are environmental. |
+| session_timeout (5h, 2.5h gaps) | Long gaps between sessions. | Environmental -- not actionable. |
+
+### Baseline outlier notes
+
+| Metric | Value | Assessment |
+|--------|-------|-----------|
+| total_tool_calls: 742 (1.7 sigma) | High but proportional to 11-component feature (largest yet). ~67 calls per component is reasonable. | Expected for scope. |
+| parallel_call_rate: 0.7 (1.7 sigma positive) | Good. Agents used parallel tool calls effectively. | Positive signal. |
+| context_load: 155.7KB (1.7 sigma) | Design session with 11 components requires reading many files up front. | Expected for scope. |
+| session_hotspot_count: 4 (1.7 sigma) | More hotspots than usual, but most are environmental (timeouts, cold restarts). | Acceptable. |
+
+### Recommendation actions
+
+| Recommendation | Action Taken |
+|----------------|-------------|
+| Add common build/test commands to settings.json allowlist | Already documented in lesson #1164 (nan-002). nan-004 confirms the need -- 15 Bash permission retries. Not actioned here (infrastructure change, not knowledge). |
+| Use run_in_background instead of sleep polling | Documented in retrospective #1190. No new lesson needed. |
+| Consider incremental compilation or targeted cargo test | Already documented in lesson #1165 (nan-002). nan-004 shows improvement (16 vs 60 cycles). |
+
+## Knowledge Stewardship
+
+- Queried: 8 searches across pattern, procedure, convention, lesson-learned, and decision categories
+- Found and corrected: #1160 -> #1191 (pattern), #1104 -> #1192 (procedure) -- stale binary name
+- Stored: 5 new patterns (#1193-#1197), 1 new procedure (#1208), 5 ADRs (#1198-#1202), 5 lessons (#1203-#1207)
+- Total: 16 new Unimatrix entries, 2 corrections

--- a/product/features/nan-004/agents/nan-004-security-reviewer-report.md
+++ b/product/features/nan-004/agents/nan-004-security-reviewer-report.md
@@ -1,0 +1,80 @@
+# Security Review: nan-004-security-reviewer
+
+## Risk Level: low
+
+## Summary
+
+nan-004 introduces npm packaging, binary rename, init command, and release pipeline. The changes are primarily distribution infrastructure with minimal security surface. No new external inputs are processed by the Rust server itself. The JS init command operates on local project files with appropriate validation. No blocking findings.
+
+## Findings
+
+### Finding 1: Skill directory name not checked for path traversal
+- **Severity**: low
+- **Location**: packages/unimatrix/lib/init.js:133-134
+- **Description**: The `copySkills` function checks file names within skill directories for `..` traversal, but does not check the skill directory names themselves (`skillDir` variable from `readdirSync`). If a malicious skill directory name contained `..`, the `path.join(targetDir, skillDir)` destination could escape `.claude/skills/`. However, the source directory is `packages/unimatrix/skills/` which is package-controlled content, so exploitation requires a compromised package -- at which point the attacker already has arbitrary code execution via postinstall.
+- **Recommendation**: For defense-in-depth, add the same `includes("..")` check for `skillDir` names. Low priority since the threat model requires a compromised npm package.
+- **Blocking**: no
+
+### Finding 2: is_unimatrix_process broadened match could match unrelated binaries
+- **Severity**: low
+- **Location**: crates/unimatrix-server/src/infra/pidfile.rs:161
+- **Description**: The `is_unimatrix_process` check now matches any process whose binary filename is `"unimatrix"`. This is broader than the previous `"unimatrix-server"` match. A process from a different project named `unimatrix` would be incorrectly identified, potentially receiving SIGTERM during stale PID cleanup. The legacy `"unimatrix-server"` fallback is correctly preserved.
+- **Recommendation**: Acceptable risk. The PID file path is project-specific (`~/.unimatrix/{hash}/`), making collisions extremely unlikely. No action needed.
+- **Blocking**: no
+
+### Finding 3: Postinstall correctly exits 0 on all error paths
+- **Severity**: informational
+- **Location**: packages/unimatrix/postinstall.js
+- **Description**: Verified that all error paths in postinstall exit with code 0, as required by R-08 in the risk strategy. This prevents npm install failures in firewalled environments. The outer try-catch and final `process.exit(0)` ensure this.
+- **Recommendation**: None -- this is correct.
+- **Blocking**: no
+
+### Finding 4: No command injection in hook commands
+- **Severity**: informational
+- **Location**: packages/unimatrix/lib/merge-settings.js:111, packages/unimatrix/bin/unimatrix.js:32
+- **Description**: Hook commands are constructed via string concatenation (`binaryPath + " hook " + event`). The `binaryPath` comes from `require.resolve` or `UNIMATRIX_BINARY` env var, and `event` comes from a hardcoded constant array. The JS shim uses `execFileSync` (not shell execution), which prevents shell injection. The settings.json hook commands are interpreted by Claude Code's shell, but the binary path and event names are controlled by the init process, not user input.
+- **Recommendation**: None -- command construction is safe.
+- **Blocking**: no
+
+### Finding 5: NPM_TOKEN handled via GitHub secrets
+- **Severity**: informational
+- **Location**: .github/workflows/release.yml:128,134
+- **Description**: The NPM_TOKEN is properly referenced via `${{ secrets.NPM_TOKEN }}` and not hardcoded. The workflow uses `--access restricted` for both packages, limiting exposure.
+- **Recommendation**: None -- secrets handling is correct.
+- **Blocking**: no
+
+### Finding 6: Release workflow permissions are appropriately scoped
+- **Severity**: informational
+- **Location**: .github/workflows/release.yml:10-11
+- **Description**: The workflow has `contents: write` permission at the top level, which is needed for creating GitHub releases. This is the minimum permission needed. The workflow is triggered only on `v*` tags, limiting when it runs.
+- **Recommendation**: None -- appropriate scope.
+- **Blocking**: no
+
+### Finding 7: No new Rust dependencies introduced
+- **Severity**: informational
+- **Location**: Cargo.lock diff
+- **Description**: The Cargo.lock changes are version bumps only (0.1.0 to 0.5.0 across all workspace crates). No new external dependencies were added. The `unimatrix_embed::ensure_model` was already implemented -- it is only newly re-exported as `pub`.
+- **Recommendation**: None.
+- **Blocking**: no
+
+## Blast Radius Assessment
+
+**Worst case if the init command has a subtle bug**: Corrupted `.claude/settings.json` or `.mcp.json` causing all Claude Code hooks and the MCP server to stop working for the project. Recovery is manual editing or deleting the corrupted file and re-running init. This is a local-only impact -- no data loss, no remote exposure.
+
+**Worst case if the binary rename has a subtle bug**: The `is_unimatrix_process` check might fail to identify a stale process, leading to a lock contention error on database open. The retry logic (3 attempts with exponential backoff) mitigates this. Worst case is a failed server start requiring manual PID cleanup.
+
+**Worst case if the release pipeline has a bug**: Incorrect package published to npm. Mitigated by version validation step and restricted access scope. Recovery is `npm unpublish` within 72 hours or a corrective publish.
+
+## Regression Risk
+
+- **Binary rename**: The binary name changes from `unimatrix-server` to `unimatrix`. All internal references (.mcp.json, .claude/settings.json, hook commands, error messages, PID check) are updated. The `is_unimatrix_process` check retains backward compatibility by matching both names. Regression risk is low.
+- **Version workspace inheritance**: All 9 crates move from hardcoded `version = "0.1.0"` to `version.workspace = true`. This is a Cargo-level change that does not affect runtime behavior. Cargo.lock confirms all crates resolve to 0.5.0. No regression risk.
+- **New subcommands (version, model-download)**: Additive changes to the CLI that do not affect existing subcommands (hook, export, import, server mode). The `None` arm (default server mode) is unchanged. No regression risk.
+- **ensure_model re-export**: `pub use download::ensure_model` adds a public API surface to `unimatrix-embed`. This is additive and does not change existing behavior.
+
+## PR Comments
+- Posted 1 review comment on PR #221
+- Blocking findings: no
+
+## Knowledge Stewardship
+- Stored: nothing novel to store -- findings are feature-specific, no generalizable anti-pattern detected across multiple features

--- a/product/features/nan-005/agents/nan-005-retro-architect-report.md
+++ b/product/features/nan-005/agents/nan-005-retro-architect-report.md
@@ -1,0 +1,85 @@
+# Agent Report: nan-005-retro-architect
+
+> Agent: uni-architect (retrospective mode)
+> Feature: nan-005 (Documentation & Onboarding)
+> Date: 2026-03-13
+
+## Task Summary
+
+Retrospective review of shipped nan-005 feature to extract reusable knowledge: validate ADRs, update/create patterns, review procedures, extract lessons.
+
+---
+
+## 1. Patterns
+
+### Updated Entries
+
+| Entry | Action | Reason |
+|-------|--------|--------|
+| #550 -> #1258 | Corrected | "Workflow-Only Scope: Markdown-Only Delivery Pattern" -- original claimed single-pass/no parallel agents. nan-005 used 3 parallel agents + 71 shell tests. Updated to reflect that multi-component markdown features benefit from parallel agents and fact verification. |
+| #554 -> #1259 | Corrected | "How to design and deliver a workflow-only scope" -- original said "human edits all files directly (no per-component agent spawns needed)." Corrected to recommend parallel agents for 3+ component markdown scopes, added fact verification step, updated agent def line budget to ~160. |
+
+### New Entries
+
+| Entry | Description |
+|-------|-------------|
+| #1260 | "Conditional Protocol Step with Deterministic Trigger Criteria Table" -- reusable pattern for adding conditional steps to delivery protocol phases. Deterministic MANDATORY/SKIP table, decision rule, spawn template, no-gate advisory, clear positional anchors. Extracted from nan-005 ADR-003. |
+
+### Skipped (with reason)
+
+| Candidate | Reason |
+|-----------|--------|
+| uni-docs agent structure | Follows existing agent definition pattern (#1009 Three-Tier Agent Classification). No new structural contribution -- frontmatter, role, inputs, outputs, behavioral rules, self-check all match established template. |
+| README capability-first section ordering | One-off decision specific to Unimatrix README. The ordering (hero -> why -> capabilities -> getting started -> reference -> architecture -> security) is logical but not a generalizable pattern -- it depends on the product and audience. Captured in ADR-001. |
+| Shell-based content verification testing | Standard grep/wc/line-number checking. The approach is straightforward and already implied by the corrected markdown-only delivery pattern (#1258). Not worth a standalone pattern entry. |
+
+---
+
+## 2. Procedures
+
+### Updated Entries
+
+| Entry | Action | Reason |
+|-------|--------|--------|
+| #554 -> #1259 | Corrected (see Patterns above) | Procedure for workflow-only scope delivery updated with parallel agent guidance and fact verification step. |
+
+### New Entries
+
+None. The delivery protocol modification itself serves as the procedure for documentation updates -- it is embedded in `uni-delivery-protocol.md` Phase 4 and does not need a separate Unimatrix procedure entry. The protocol IS the procedure.
+
+---
+
+## 3. ADR Status
+
+All 4 ADRs validated by successful implementation. All gates passed first try. No rework required.
+
+| ADR | Unimatrix ID | Status | Notes |
+|-----|-------------|--------|-------|
+| ADR-001: README single file structure | #1254 | Validated | Delivered at 380 lines (below 450-650 estimate but all content present). Split threshold of 800 lines remains valid with significant headroom. |
+| ADR-002: Documentation step placement | #1255 | Validated | Correct positioning confirmed by gate 3c line-number tests. After gh pr create, before /review-pr. |
+| ADR-003: Trigger criteria mandatory vs optional | #1256 | Validated | 9-row decision table implemented exactly as designed. Deterministic -- no judgment calls needed. |
+| ADR-004: Content boundary README vs CLAUDE.md | #1257 | Validated | Clean separation held throughout implementation. No content leakage detected in any direction. |
+
+Flagged for supersession: None.
+
+---
+
+## 4. Lessons
+
+### Gate 3b WARN: README line count (380 vs 450-650 target)
+
+**Assessment**: Not worth storing as a lesson. The 450-650 estimate was a pre-authoring projection in ADR-001 based on section count multiplied by average lines. The actual implementation was more concise without omitting content. This is normal estimation variance, not a systematic problem. The ADR correctly set the split threshold at 800 (actionable boundary) separate from the estimate (informational). No future action needed.
+
+### Gate 3a WARN: MCP unavailable during pseudocode/architect subagent context
+
+**Assessment**: Known operational constraint, not a nan-005 issue. Subagents spawned via Task() do not have MCP server access. The architect and pseudocode agents correctly documented this limitation and deferred ADR storage to the coordinator. This is already understood behavior -- no lesson to store.
+
+---
+
+## Knowledge Stewardship
+
+- Queried: context_search for patterns (documentation, agent definition, protocol modification, markdown-only delivery, fact verification, trigger criteria) -- 7 searches across pattern/convention/procedure/decision categories
+- Queried: context_lookup for nan-005 ADRs (none found -- confirmed they were never stored), and entries #550, #551, #554, #1009
+- Stored: #1254 (ADR-001), #1255 (ADR-002), #1256 (ADR-003), #1257 (ADR-004) -- all 4 nan-005 ADRs with validation notes
+- Corrected: #550 -> #1258 (markdown-only delivery pattern), #554 -> #1259 (workflow-only procedure)
+- Stored: #1260 (conditional protocol step pattern)

--- a/product/research/ass-017/KB-HEALTH-ANALYSIS.md
+++ b/product/research/ass-017/KB-HEALTH-ANALYSIS.md
@@ -1,0 +1,208 @@
+# ASS-017: Knowledge Base Health Analysis
+
+**Date:** 2026-03-13
+**Snapshot:** 1,166 active entries, 188 deprecated, 5,263 co-access pairs, 136 outcomes
+**Lambda:** 0.7097
+
+---
+
+## 1. Confidence System Analysis
+
+### 1.1 Score Distribution: Collapsed to Noise
+
+The confidence calibration data shows severe clustering:
+
+| Confidence Bucket | Injections | % of Total |
+|-------------------|------------|------------|
+| 0.4-0.5 | 3 | 2.3% |
+| 0.5-0.6 | 117 | 87.9% |
+| 0.6-0.7 | 13 | 9.8% |
+| All other buckets | 0 | 0% |
+
+**88% of all injected entries score between 0.5 and 0.6.** The confidence dimension produces a ~0.08 range across the entire knowledge base.
+
+### 1.2 Root Cause: Three Neutral Defaults
+
+The confidence formula is a weighted composite of 6 factors summing to 0.92:
+
+| Factor | Weight | Typical Value | Why It's Stuck |
+|--------|--------|--------------|----------------|
+| Base (status) | 0.18 | 0.5 | All active entries = 0.5. No differentiation within active entries. |
+| Helpfulness | 0.14 | 0.5 (neutral) | Wilson score requires 5+ votes. Almost nothing reaches this threshold. |
+| Corrections | 0.14 | 0.5 | 88 correction chains across 1,166 entries. Most entries have 0 corrections. |
+| Trust | 0.14 | 0.35-0.50 | agent=0.5 (693 entries), auto=0.35 (604 entries). Binary split, not a gradient. |
+| Usage | 0.14 | variable | Log-transformed access count. Some variance, but compressed by log. |
+| Freshness | 0.18 | decaying | Exponential decay (168h half-life). Only factor with real movement. |
+
+**Three factors (base, helpfulness, corrections) collectively contribute 0.46 weight but return the same value (0.5) for nearly every entry.** This collapses 50% of the formula to a constant.
+
+### 1.3 Worked Example
+
+Typical active entry with 10 accesses, 1 day old, agent-created, no votes, no corrections:
+
+```
+confidence = 0.18*0.5    (base: active)
+           + 0.14*0.61   (usage: ln(11)/ln(51))
+           + 0.18*0.88   (freshness: exp(-24/168))
+           + 0.14*0.5    (helpfulness: neutral, <5 votes)
+           + 0.14*0.5    (corrections: 0 corrections)
+           + 0.14*0.5    (trust: agent)
+           = 0.09 + 0.085 + 0.158 + 0.07 + 0.07 + 0.07
+           = 0.543
+```
+
+Compare with a 7-day-old entry with 50 accesses:
+
+```
+confidence = 0.18*0.5 + 0.14*1.0 + 0.18*0.37 + 0.14*0.5 + 0.14*0.5 + 0.14*0.5
+           = 0.09 + 0.14 + 0.067 + 0.07 + 0.07 + 0.07
+           = 0.507
+```
+
+**A 5x usage difference and 7-day age difference produces a 0.036 score delta.** The compressed factors dominate.
+
+### 1.4 Impact on Search Ranking
+
+Search re-ranking formula: `final_score = 0.85 * similarity + 0.15 * confidence`
+
+With confidence range of ~0.08 (0.52 to 0.60):
+- Maximum ranking impact: `0.15 * 0.08 = 0.012`
+- This is smaller than the co-access boost cap (0.03) and the provenance boost (0.02)
+- **Confidence is the weakest signal in re-ranking despite being the most complex to compute**
+
+### 1.5 The Feedback Loop That Never Fires
+
+The helpfulness factor was designed as the primary quality signal. It uses Wilson score lower bound at 95% confidence, which is a sound statistical approach. But the minimum sample size is 5 votes, and almost no entry reaches this threshold because:
+
+1. Helpful/unhelpful feedback is opt-in (agents pass `helpful: true/false` on retrieval)
+2. Most entries are accessed by automated flows that don't provide feedback
+3. Even frequently-accessed entries rarely accumulate 5+ explicit votes
+
+The result: the most discriminating factor in the formula is permanently disabled.
+
+---
+
+## 2. Co-Access Pair Analysis
+
+### 2.1 Volume and Growth
+
+- 5,263 active pairs across 1,166 active + 188 deprecated entries
+- Theoretical maximum pairs for 1,354 entries: ~916,000
+- Actual density: 0.57% — sparse, as expected
+
+### 2.2 Top Pairs Assessment
+
+| Pair | Count | Relationship | Assessment |
+|------|-------|-------------|------------|
+| #296 (Service Extraction) ↔ #301 (Crate Restructuring) | 11 | Both `unimatrix-server` procedures, used during vnc-008 | True signal |
+| #141 (Glass Box Validation) ↔ #167 (Gate Result Handling) | 9 | Both validation/gate workflow concepts | True signal, but both deprecated |
+| #239 (Feature Naming) ↔ #241 (Knowledge Categories) | 9 | Both project conventions, human-authored | True signal |
+| #261 (AuditSource Security) ↔ #315 (Test Gateway Pattern) | 9 | Security pattern + its test pattern | Strong signal |
+| #262 (ServiceError Conversion) ↔ #281 (Caller-Parameterized Service) | 9 | Both service-layer architecture patterns | Strong signal |
+
+**Verdict: Co-access pairs are semantically meaningful.** The system correctly identifies entries that belong together.
+
+### 2.3 Deprecated Entry Accumulation
+
+Co-access pairs involving deprecated entries continue to accumulate counts because:
+- Recording layer (`record_co_access_pairs`) has no status filter
+- Session dedup (`filter_co_access_pairs`) is status-unaware
+- Status filtering only happens at boost computation time (crt-010)
+
+This means:
+1. Deprecated entries inflate the "top pairs" view in status reports
+2. Co-access counts between deprecated entries are wasted storage writes
+3. If a deprecated entry is later quarantined, its co-access counts persist but are fully excluded from boost
+
+**Not a correctness bug** — deprecated entries are excluded from search boost. But it's a hygiene issue that creates misleading status output.
+
+### 2.4 Search Boost Effectiveness
+
+Co-access boost formula: `boost = ln(1 + count) / ln(21) * 0.03`
+
+| Co-Access Count | Boost |
+|-----------------|-------|
+| 1 | 0.0068 |
+| 5 | 0.0176 |
+| 9 (top pairs) | 0.0227 |
+| 11 (highest) | 0.0245 |
+| 20 (saturation) | 0.0300 |
+
+The boost cap of 0.03 is **2.5x larger than the effective confidence range** (0.012). Co-access is a stronger ranking signal than confidence despite being a simpler mechanism.
+
+---
+
+## 3. Coherence (Lambda) Breakdown
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| Freshness | 0.295 | 0.35 | 0.103 |
+| Graph Quality | 1.000 | 0.30 | 0.300 |
+| Embedding Consistency | 1.000 | 0.15 | 0.150 |
+| Contradiction Density | 1.000 | 0.20 | 0.200 |
+
+**Lambda = 0.710** (dragged down entirely by confidence freshness)
+
+822 of 1,166 entries (70.5%) have stale confidence scores (oldest: 14 days). Running `maintain: true` would refresh these and push lambda toward ~0.85+. But given the confidence clustering analysis above, refreshing stale confidence scores updates values that don't meaningfully differentiate entries anyway.
+
+---
+
+## 4. Effectiveness Analysis
+
+| Category | Count | % |
+|----------|-------|---|
+| Effective | 1,034 | 88.7% |
+| Settled | 62 | 5.3% |
+| Unmatched | 70 | 6.0% |
+| Ineffective | 0 | 0% |
+| Noisy | 0 | 0% |
+
+**88.7% effective with 0% ineffective is a strong signal** — the knowledge base is delivering value. The 70 unmatched entries (mostly base-004 and col-020 ADRs) haven't been retrieved in any tracked session. These may be too specialized or their topics don't match common queries.
+
+### 4.1 Source Utility
+
+| Source | Effective | Settled | Unmatched | Utility |
+|--------|-----------|---------|-----------|---------|
+| agent | 391 | 57 | 70 | 1.00 |
+| auto | 604 | 0 | 0 | 0.00 |
+| system | 39 | 5 | 0 | 1.00 |
+
+**`auto` source has 0.00 utility** — 604 entries (52% of the KB) sourced from automated processes show zero effectiveness signal. These are likely observation-pipeline entries that get stored but never retrieved through search. They may be dragging down confidence freshness without contributing to agent workflows.
+
+---
+
+## 5. Summary of Findings
+
+### What's Working
+
+1. **Co-access pairs** — semantically meaningful, correctly identifies related entries
+2. **Effectiveness tracking** — 88.7% effective rate demonstrates the KB delivers value
+3. **Correction chains** — 101 supersession relationships creating clean knowledge evolution
+4. **Zero contradictions** — knowledge consistency is maintained
+5. **Search re-ranking** — vector similarity (0.85 weight) carries the ranking correctly; supplementary signals add real value
+
+### What's Broken or Weak
+
+1. **Confidence differentiation** — scores collapse to 0.52-0.60 range, providing ~0.012 max ranking impact
+2. **Helpfulness feedback loop** — 5-vote minimum never reached, disabling the primary quality signal
+3. **Trust factor granularity** — binary split (agent 0.5 vs auto 0.35) with 97% of entries in two buckets
+4. **Auto-sourced entry utility** — 604 entries (52% of KB) with zero effectiveness signal
+5. **Deprecated co-access accumulation** — misleading status output, wasted writes
+
+### Systemic Issue
+
+The confidence system was designed around a feedback-rich environment where entries would accumulate votes, corrections, and varied trust signals over time. In practice, the knowledge base operates in a **low-feedback, high-automation environment** where:
+- Entries are created by agents and auto-processes, not humans
+- Retrieval happens in automated pipelines that don't provide quality feedback
+- Most entries are young (project is ~2 weeks of active knowledge accumulation)
+- The correction mechanism works well but affects a small percentage of entries
+
+The confidence formula needs to be re-evaluated for the actual operating environment, not the theoretical one it was designed for.
+
+---
+
+## 6. Relationship to ASS-017 petgraph Analysis
+
+The petgraph analysis (companion document) proposes graph-derived penalties to replace hardcoded `DEPRECATED_PENALTY` and `SUPERSEDED_PENALTY`. This is complementary — graph topology would add structural signal where confidence currently provides noise. The recommendation to start with supersession graph traversal (petgraph Phase 1) addresses one specific weakness without requiring a full confidence system redesign.
+
+However, the confidence clustering problem identified here is **upstream** of petgraph — even with graph-derived penalties, the base confidence score fed into re-ranking will remain in a narrow band unless the formula itself is restructured.


### PR DESCRIPTION
## Summary
- Commits 8 untracked agent reports left over from prior sessions (bugfix-228, bugfix-236, col-022, nan-004, nan-005, ass-017)
- Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)