### PR TITLE
fix(ci): download embedding model before tests (#245)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,9 @@ jobs:
             exit 1
           fi
 
+      - name: Download embedding model
+        run: target/release/unimatrix model-download
+
       - name: Test
         run: cargo test --release
         env:
@@ -155,6 +158,9 @@ jobs:
             echo "ERROR: Unexpected version output: $OUTPUT"
             exit 1
           fi
+
+      - name: Download embedding model
+        run: target/release/unimatrix model-download
 
       - name: Test
         run: cargo test --release


### PR DESCRIPTION
## Summary

Fixes #245 — `test_hash_validation_valid_chain` fails on CI because `run_import()` calls `reconstruct_embeddings()` which needs the ONNX model files. CI runners don't have the model cached.

Adds `target/release/unimatrix model-download` step after build but before `cargo test --release` in both x64 and arm64 jobs.

## Test plan

- [ ] Release pipeline tests pass (1180/1180)

🤖 Generated with [Claude Code](https://claude.com/claude-code)