### PR TITLE
fix(ci): switch npm packages to public access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,13 +154,13 @@ jobs:
 
       - name: Publish @dug-21/unimatrix-linux-arm64
         working-directory: packages/unimatrix-linux-arm64
-        run: npm publish --access restricted
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @dug-21/unimatrix
         working-directory: packages/unimatrix
-        run: npm publish --access restricted
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/packages/test-package-structure.js
+++ b/packages/test-package-structure.js
@@ -99,7 +99,7 @@ assert(
 assert(
   "test_root_package_publish_config_restricted",
   rootPkg.publishConfig &&
-    rootPkg.publishConfig.access === "restricted",
+    rootPkg.publishConfig.access === "public",
   `got ${JSON.stringify(rootPkg.publishConfig)}`
 );
 
@@ -140,7 +140,7 @@ assert(
 assert(
   "test_platform_package_publish_config_restricted",
   platformPkg.publishConfig &&
-    platformPkg.publishConfig.access === "restricted",
+    platformPkg.publishConfig.access === "public",
   `got ${JSON.stringify(platformPkg.publishConfig)}`
 );
 
@@ -240,7 +240,7 @@ assert(
 assert(
   "test_arm64_platform_package_publish_config_restricted",
   platformArm64Pkg.publishConfig &&
-    platformArm64Pkg.publishConfig.access === "restricted",
+    platformArm64Pkg.publishConfig.access === "public",
   `got ${JSON.stringify(platformArm64Pkg.publishConfig)}`
 );
 

--- a/packages/unimatrix-linux-arm64/package.json
+++ b/packages/unimatrix-linux-arm64/package.json
@@ -13,6 +13,6 @@
   ],
   "license": "MIT OR Apache-2.0",
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/unimatrix-linux-x64/package.json
+++ b/packages/unimatrix-linux-x64/package.json
@@ -13,6 +13,6 @@
   ],
   "license": "MIT OR Apache-2.0",
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/unimatrix/package.json
+++ b/packages/unimatrix/package.json
@@ -27,6 +27,6 @@
     "node": ">=18"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

Free npm accounts cannot publish scoped packages as restricted. Switch all packages and workflow to `--access public`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)