### PR TITLE
fix(nan-013): correct npm package metadata and add README (#549)

### DIFF
--- a/packages/test-package-structure.js
+++ b/packages/test-package-structure.js
@@ -53,8 +53,8 @@ assert(
 );
 
 assert(
-  "test_root_package_version_is_0_5_0",
-  rootPkg.version === "0.5.0",
+  "test_root_package_version_is_0_6_2",
+  rootPkg.version === "0.6.2",
   `got "${rootPkg.version}"`
 );
 
@@ -68,14 +68,14 @@ assert(
 assert(
   "test_root_package_has_optional_dependencies_x64",
   rootPkg.optionalDependencies &&
-    rootPkg.optionalDependencies["@dug-21/unimatrix-linux-x64"] === "0.5.0",
+    rootPkg.optionalDependencies["@dug-21/unimatrix-linux-x64"] === "0.6.2",
   `got ${JSON.stringify(rootPkg.optionalDependencies)}`
 );
 
 assert(
   "test_root_package_has_optional_dependencies_arm64",
   rootPkg.optionalDependencies &&
-    rootPkg.optionalDependencies["@dug-21/unimatrix-linux-arm64"] === "0.5.0",
+    rootPkg.optionalDependencies["@dug-21/unimatrix-linux-arm64"] === "0.6.2",
   `got ${JSON.stringify(rootPkg.optionalDependencies)}`
 );
 
@@ -108,6 +108,24 @@ assert(
   rootPkg.engines &&
     rootPkg.engines.node === ">=18",
   `got ${JSON.stringify(rootPkg.engines)}`
+);
+
+assert(
+  "test_root_package_repository_url",
+  rootPkg.repository && rootPkg.repository.url === "https://github.com/dug-21/unimatrix",
+  `got ${JSON.stringify(rootPkg.repository)}`
+);
+
+assert(
+  "test_root_package_has_homepage",
+  typeof rootPkg.homepage === "string" && rootPkg.homepage.length > 0,
+  `got ${JSON.stringify(rootPkg.homepage)}`
+);
+
+assert(
+  "test_root_package_readme_exists",
+  fs.existsSync(path.join(PACKAGES_DIR, "unimatrix", "README.md")),
+  `path: ${path.join(PACKAGES_DIR, "unimatrix", "README.md")}`
 );
 
 // --- Platform package tests ---

--- a/packages/unimatrix-linux-arm64/package.json
+++ b/packages/unimatrix-linux-arm64/package.json
@@ -12,6 +12,11 @@
     "bin/"
   ],
   "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dug-21/unimatrix"
+  },
+  "homepage": "https://github.com/dug-21/unimatrix#readme",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/unimatrix-linux-x64/package.json
+++ b/packages/unimatrix-linux-x64/package.json
@@ -12,6 +12,11 @@
     "bin/"
   ],
   "license": "MIT OR Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dug-21/unimatrix"
+  },
+  "homepage": "https://github.com/dug-21/unimatrix#readme",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/unimatrix/README.md
+++ b/packages/unimatrix/README.md
@@ -1,0 +1,9 @@
+# Unimatrix
+
+Self-learning context engine for multi-agent development orchestration.
+
+```
+npm install -g @dug-21/unimatrix
+```
+
+https://github.com/dug-21/unimatrix

--- a/packages/unimatrix/package.json
+++ b/packages/unimatrix/package.json
@@ -22,8 +22,9 @@
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/anthropics/unimatrix"
+    "url": "https://github.com/dug-21/unimatrix"
   },
+  "homepage": "https://github.com/dug-21/unimatrix#readme",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## Summary

- Corrects `repository.url` in `packages/unimatrix/package.json` from `anthropics/unimatrix` to `dug-21/unimatrix`
- Adds `repository` block and `homepage` field to `packages/unimatrix-linux-x64/package.json` and `packages/unimatrix-linux-arm64/package.json`
- Creates `packages/unimatrix/README.md` with minimal content for npmjs.com display
- Fixes stale `0.5.0` version assertions in `packages/test-package-structure.js` (now `0.6.2`)
- Adds 3 new test assertions: `test_root_package_repository_url`, `test_root_package_has_homepage`, `test_root_package_readme_exists`

Closes #549

## Test plan

- [x] `node packages/test-package-structure.js` — 28 pass, 2 pre-existing failures (skills trim from nan-013, unrelated)
- [x] JSON validity confirmed on all 3 modified package.json files
- [x] README.md exists and non-empty
- [x] Field values spot-checked: correct URL and homepage on all 3 packages
- [x] Gate: Bug Fix Validation — PASS (comment on #549)

🤖 Generated with [Claude Code](https://claude.com/claude-code)