### PR TITLE
fix: byte-based content size enforcement for context_store (#561)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -120,6 +120,19 @@ audit_log_retention_days = 180
 max_cycles_per_tick = 10
 
 # =============================================================================
+# [store] — Write-path limits for knowledge entry storage
+# =============================================================================
+
+[store]
+# Maximum byte length for content on context_store and context_correct calls.
+# The limit is byte-based (UTF-8), not character-based — multibyte characters
+# (e.g., emoji, CJK) count toward this limit by their byte width, not character count.
+# Entries should be focused and specific; large content should be split into
+# multiple targeted entries.
+# Range: [1000, 1048576]. Default: 8000
+# max_content_bytes = 8000
+
+# =============================================================================
 # [observation] — Domain pack registration
 # =============================================================================
 

--- a/crates/unimatrix-server/src/infra/config.rs
+++ b/crates/unimatrix-server/src/infra/config.rs
@@ -80,6 +80,8 @@ pub struct UnimatrixConfig {
     pub observation: ObservationConfig,
     #[serde(default)]
     pub retention: RetentionConfig,
+    #[serde(default)]
+    pub store: StoreConfig,
     // CycleConfig is intentionally absent (ADR-004: stub removed, rename is hardcoded).
 }
 
@@ -1570,6 +1572,60 @@ impl RetentionConfig {
 }
 
 // ---------------------------------------------------------------------------
+// StoreConfig (#561)
+// ---------------------------------------------------------------------------
+
+/// `[store]` section — write-path limits for knowledge entry storage.
+///
+/// All fields have compiled defaults via `#[serde(default)]` so an absent
+/// `[store]` block in config.toml applies defaults without error.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+#[serde(default)]
+pub struct StoreConfig {
+    /// Maximum byte length for `content` on context_store and context_correct calls.
+    ///
+    /// Enforced as a byte check (O(1)) before the character count check (O(n)).
+    /// Applies to both the MCP write path and the UDS path via validation.rs.
+    ///
+    /// Range: [1_000, 1_048_576]. Default: 8_000.
+    pub max_content_bytes: usize,
+}
+
+fn default_max_content_bytes() -> usize {
+    8_000
+}
+
+impl Default for StoreConfig {
+    fn default() -> Self {
+        StoreConfig {
+            max_content_bytes: default_max_content_bytes(),
+        }
+    }
+}
+
+impl StoreConfig {
+    /// Validate all StoreConfig fields against their documented ranges.
+    ///
+    /// Called during server startup alongside InferenceConfig::validate()
+    /// and RetentionConfig::validate(). An out-of-range value aborts startup
+    /// with a structured error naming the field.
+    ///
+    /// Checks:
+    ///   - max_content_bytes in [1_000, 1_048_576]
+    pub fn validate(&self, path: &Path) -> Result<(), ConfigError> {
+        if self.max_content_bytes < 1_000 || self.max_content_bytes > 1_048_576 {
+            return Err(ConfigError::StoreFieldOutOfRange {
+                path: path.to_path_buf(),
+                field: "max_content_bytes",
+                value: self.max_content_bytes.to_string(),
+                reason: "must be in range [1000, 1048576]",
+            });
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Preset enum
 // ---------------------------------------------------------------------------
 
@@ -1737,6 +1793,16 @@ pub enum ConfigError {
         /// Actual value that failed (displayed to operator).
         value: String,
         /// Human-readable valid range, e.g. "must be in range [1, 10000]".
+        reason: &'static str,
+    },
+    /// A `[store]` config field is outside its valid range (#561).
+    StoreFieldOutOfRange {
+        path: PathBuf,
+        /// Field name, e.g. "max_content_bytes".
+        field: &'static str,
+        /// Actual value that failed (displayed to operator).
+        value: String,
+        /// Human-readable valid range, e.g. "must be in range [1000, 1048576]".
         reason: &'static str,
     },
 }
@@ -1968,6 +2034,19 @@ impl fmt::Display for ConfigError {
             } => write!(
                 f,
                 "config error in {}: [retention] field '{}' = '{}' is invalid: {}",
+                path.display(),
+                field,
+                value,
+                reason
+            ),
+            ConfigError::StoreFieldOutOfRange {
+                path,
+                field,
+                value,
+                reason,
+            } => write!(
+                f,
+                "config error in {}: [store] field '{}' = '{}' is invalid: {}",
                 path.display(),
                 field,
                 value,
@@ -2247,6 +2326,9 @@ pub fn validate_config(config: &UnimatrixConfig, path: &Path) -> Result<(), Conf
 
     // --- Validate [retention] fields (crt-036) ---
     config.retention.validate(path)?;
+
+    // --- Validate [store] fields (#561) ---
+    config.store.validate(path)?;
 
     Ok(())
 }
@@ -2863,6 +2945,15 @@ fn merge_configs(global: UnimatrixConfig, project: UnimatrixConfig) -> Unimatrix
                 project.retention.max_cycles_per_tick
             } else {
                 global.retention.max_cycles_per_tick
+            },
+        },
+        // #561: per-field project-wins merge for store config
+        store: StoreConfig {
+            max_content_bytes: if project.store.max_content_bytes != default.store.max_content_bytes
+            {
+                project.store.max_content_bytes
+            } else {
+                global.store.max_content_bytes
             },
         },
     }
@@ -7285,6 +7376,89 @@ max_cycles_per_tick = 20
         assert!(
             matches!(err, ConfigError::RetentionFieldOutOfRange { .. }),
             "must be RetentionFieldOutOfRange variant; got: {err:?}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #561: StoreConfig validation tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_store_config_default_is_8000() {
+        let cfg = StoreConfig::default();
+        assert_eq!(cfg.max_content_bytes, 8_000);
+    }
+
+    #[test]
+    fn test_store_config_validate_below_min_fails() {
+        let cfg = StoreConfig {
+            max_content_bytes: 999,
+        };
+        let err = cfg.validate(Path::new("config.toml")).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ConfigError::StoreFieldOutOfRange {
+                    field: "max_content_bytes",
+                    ..
+                }
+            ),
+            "must be StoreFieldOutOfRange for max_content_bytes; got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_store_config_validate_above_max_fails() {
+        let cfg = StoreConfig {
+            max_content_bytes: 1_048_577,
+        };
+        let err = cfg.validate(Path::new("config.toml")).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ConfigError::StoreFieldOutOfRange {
+                    field: "max_content_bytes",
+                    ..
+                }
+            ),
+            "must be StoreFieldOutOfRange for max_content_bytes; got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_store_config_validate_at_min_passes() {
+        let cfg = StoreConfig {
+            max_content_bytes: 1_000,
+        };
+        assert!(cfg.validate(Path::new("config.toml")).is_ok());
+    }
+
+    #[test]
+    fn test_store_config_validate_at_default_passes() {
+        let cfg = StoreConfig {
+            max_content_bytes: 8_000,
+        };
+        assert!(cfg.validate(Path::new("config.toml")).is_ok());
+    }
+
+    #[test]
+    fn test_store_config_validate_at_max_passes() {
+        let cfg = StoreConfig {
+            max_content_bytes: 1_048_576,
+        };
+        assert!(cfg.validate(Path::new("config.toml")).is_ok());
+    }
+
+    #[test]
+    fn test_store_config_validate_called_by_validate_config() {
+        // validate_config must propagate StoreConfig validation errors.
+        let mut config = UnimatrixConfig::default();
+        config.store.max_content_bytes = 999;
+        let err = validate_config(&config, Path::new("/fake"))
+            .expect_err("validate_config must reject store.max_content_bytes = 999");
+        assert!(
+            matches!(err, ConfigError::StoreFieldOutOfRange { .. }),
+            "must be StoreFieldOutOfRange variant; got: {err:?}"
         );
     }
 

--- a/crates/unimatrix-server/src/infra/validation.rs
+++ b/crates/unimatrix-server/src/infra/validation.rs
@@ -181,7 +181,21 @@ pub fn validate_lookup_params(params: &LookupParams) -> Result<(), ServerError> 
 }
 
 /// Validate context_store parameters.
-pub fn validate_store_params(params: &StoreParams) -> Result<(), ServerError> {
+pub fn validate_store_params(
+    params: &StoreParams,
+    max_content_bytes: usize,
+) -> Result<(), ServerError> {
+    // O(1) byte check before O(n) char scan — common rejection exits early
+    let byte_len = params.content.len();
+    if byte_len > max_content_bytes {
+        return Err(ServerError::InvalidInput {
+            field: "content".to_string(),
+            reason: format!(
+                "Content exceeds configured maximum of {max_content_bytes} bytes \
+                 (received {byte_len} bytes). Consider breaking this into multiple focused entries."
+            ),
+        });
+    }
     if let Some(title) = &params.title {
         validate_string_field("title", title, MAX_TITLE_LEN, true)?;
     }
@@ -205,8 +219,22 @@ pub fn validate_get_params(params: &GetParams) -> Result<(), ServerError> {
 }
 
 /// Validate context_correct parameters.
-pub fn validate_correct_params(params: &CorrectParams) -> Result<(), ServerError> {
+pub fn validate_correct_params(
+    params: &CorrectParams,
+    max_content_bytes: usize,
+) -> Result<(), ServerError> {
     validated_id(params.original_id)?;
+    // O(1) byte check before O(n) char scan — common rejection exits early
+    let byte_len = params.content.len();
+    if byte_len > max_content_bytes {
+        return Err(ServerError::InvalidInput {
+            field: "content".to_string(),
+            reason: format!(
+                "Content exceeds configured maximum of {max_content_bytes} bytes \
+                 (received {byte_len} bytes). Consider breaking this into multiple focused entries."
+            ),
+        });
+    }
     validate_string_field("content", &params.content, MAX_CONTENT_LEN, true)?;
     if let Some(reason) = &params.reason {
         validate_string_field("reason", reason, MAX_REASON_LEN, true)?;
@@ -816,7 +844,7 @@ mod tests {
             feature_cycle: None,
             session_id: None,
         };
-        assert!(validate_store_params(&params).is_ok());
+        assert!(validate_store_params(&params, 50_000).is_ok());
     }
 
     #[test]
@@ -833,7 +861,7 @@ mod tests {
             feature_cycle: Some("col-001".to_string()),
             session_id: None,
         };
-        assert!(validate_store_params(&params).is_ok());
+        assert!(validate_store_params(&params, 50_000).is_ok());
     }
 
     #[test]
@@ -850,7 +878,7 @@ mod tests {
             feature_cycle: Some("a".repeat(129)),
             session_id: None,
         };
-        assert!(validate_store_params(&params).is_err());
+        assert!(validate_store_params(&params, 50_000).is_err());
     }
 
     #[test]
@@ -867,7 +895,117 @@ mod tests {
             feature_cycle: Some("a".repeat(128)),
             session_id: None,
         };
-        assert!(validate_store_params(&params).is_ok());
+        assert!(validate_store_params(&params, 50_000).is_ok());
+    }
+
+    // -- #561: byte-limit tests for validate_store_params --
+
+    #[test]
+    fn test_validate_store_params_content_byte_limit() {
+        // 8001 ASCII bytes, passes 50,000 char check → must fail byte limit of 8000
+        let params_over = StoreParams {
+            content: "a".repeat(8001),
+            topic: "t".to_string(),
+            category: "convention".to_string(),
+            tags: None,
+            title: None,
+            source: None,
+            agent_id: None,
+            format: None,
+            feature_cycle: None,
+            session_id: None,
+        };
+        let err = validate_store_params(&params_over, 8_000).unwrap_err();
+        let reason = match &err {
+            ServerError::InvalidInput { reason, .. } => reason.clone(),
+            _ => panic!("expected InvalidInput, got {err:?}"),
+        };
+        assert!(
+            reason.contains("configured maximum of 8000 bytes"),
+            "error must mention configured maximum of 8000 bytes; got: {reason}"
+        );
+        assert!(
+            reason.contains("received 8001 bytes"),
+            "error must mention received 8001 bytes; got: {reason}"
+        );
+
+        // 8000 bytes → must pass
+        let params_at = StoreParams {
+            content: "a".repeat(8000),
+            topic: "t".to_string(),
+            category: "convention".to_string(),
+            tags: None,
+            title: None,
+            source: None,
+            agent_id: None,
+            format: None,
+            feature_cycle: None,
+            session_id: None,
+        };
+        assert!(validate_store_params(&params_at, 8_000).is_ok());
+
+        // "🟩".repeat(2001) → 8004 bytes, only 2001 chars (well under 50,000) → must fail
+        // This is the critical multibyte correctness case.
+        let params_multibyte_over = StoreParams {
+            content: "🟩".repeat(2001),
+            topic: "t".to_string(),
+            category: "convention".to_string(),
+            tags: None,
+            title: None,
+            source: None,
+            agent_id: None,
+            format: None,
+            feature_cycle: None,
+            session_id: None,
+        };
+        assert_eq!("🟩".repeat(2001).len(), 8004, "each 🟩 is 4 bytes");
+        assert!(validate_store_params(&params_multibyte_over, 8_000).is_err());
+
+        // "🟩".repeat(2000) → 8000 bytes → must pass
+        let params_multibyte_at = StoreParams {
+            content: "🟩".repeat(2000),
+            topic: "t".to_string(),
+            category: "convention".to_string(),
+            tags: None,
+            title: None,
+            source: None,
+            agent_id: None,
+            format: None,
+            feature_cycle: None,
+            session_id: None,
+        };
+        assert_eq!("🟩".repeat(2000).len(), 8000, "each 🟩 is 4 bytes");
+        assert!(validate_store_params(&params_multibyte_at, 8_000).is_ok());
+    }
+
+    #[test]
+    fn test_validate_store_params_byte_check_fires_before_char_check() {
+        // Content that is over byte limit but under char limit — byte error must fire.
+        // 8001 ASCII bytes = 8001 chars (well under MAX_CONTENT_LEN=50000).
+        // With limit=8000, byte check fires first and returns byte error, not char error.
+        let params = StoreParams {
+            content: "a".repeat(8001),
+            topic: "t".to_string(),
+            category: "convention".to_string(),
+            tags: None,
+            title: None,
+            source: None,
+            agent_id: None,
+            format: None,
+            feature_cycle: None,
+            session_id: None,
+        };
+        let err = validate_store_params(&params, 8_000).unwrap_err();
+        match err {
+            ServerError::InvalidInput { field, reason } => {
+                assert_eq!(field, "content");
+                assert!(
+                    reason.contains("configured maximum"),
+                    "byte error must mention 'configured maximum'; got: {reason}"
+                );
+            }
+            _ => panic!("expected InvalidInput"),
+        }
     }
 
     #[test]
@@ -898,7 +1036,7 @@ mod tests {
             agent_id: None,
             format: None,
         };
-        assert!(validate_correct_params(&params).is_ok());
+        assert!(validate_correct_params(&params, 50_000).is_ok());
     }
 
     #[test]
@@ -914,7 +1052,7 @@ mod tests {
             agent_id: Some("agent".to_string()),
             format: Some("json".to_string()),
         };
-        assert!(validate_correct_params(&params).is_ok());
+        assert!(validate_correct_params(&params, 50_000).is_ok());
     }
 
     #[test]
@@ -930,7 +1068,7 @@ mod tests {
             agent_id: None,
             format: None,
         };
-        assert!(validate_correct_params(&params).is_err());
+        assert!(validate_correct_params(&params, 50_000).is_err());
     }
 
     #[test]
@@ -946,7 +1084,7 @@ mod tests {
             agent_id: None,
             format: None,
         };
-        assert!(validate_correct_params(&params).is_err());
+        assert!(validate_correct_params(&params, 50_000).is_err());
     }
 
     #[test]
@@ -962,7 +1100,7 @@ mod tests {
             agent_id: None,
             format: None,
         };
-        assert!(validate_correct_params(&params).is_err());
+        assert!(validate_correct_params(&params, 50_000).is_err());
     }
 
     #[test]
@@ -978,7 +1116,107 @@ mod tests {
             agent_id: None,
             format: None,
         };
-        assert!(validate_correct_params(&params).is_ok());
+        assert!(validate_correct_params(&params, 50_000).is_ok());
+    }
+
+    // -- #561: byte-limit tests for validate_correct_params --
+
+    #[test]
+    fn test_validate_correct_params_content_byte_limit() {
+        // 8001 ASCII bytes → must fail byte limit of 8000
+        let params_over = CorrectParams {
+            original_id: 1,
+            content: "a".repeat(8001),
+            reason: None,
+            topic: None,
+            category: None,
+            tags: None,
+            title: None,
+            agent_id: None,
+            format: None,
+        };
+        let err = validate_correct_params(&params_over, 8_000).unwrap_err();
+        let reason = match &err {
+            ServerError::InvalidInput { reason, .. } => reason.clone(),
+            _ => panic!("expected InvalidInput, got {err:?}"),
+        };
+        assert!(
+            reason.contains("configured maximum of 8000 bytes"),
+            "error must mention configured maximum of 8000 bytes; got: {reason}"
+        );
+        assert!(
+            reason.contains("received 8001 bytes"),
+            "error must mention received 8001 bytes; got: {reason}"
+        );
+
+        // 8000 bytes → must pass
+        let params_at = CorrectParams {
+            original_id: 1,
+            content: "a".repeat(8000),
+            reason: None,
+            topic: None,
+            category: None,
+            tags: None,
+            title: None,
+            agent_id: None,
+            format: None,
+        };
+        assert!(validate_correct_params(&params_at, 8_000).is_ok());
+
+        // "🟩".repeat(2001) → 8004 bytes, only 2001 chars → must fail
+        let params_multibyte_over = CorrectParams {
+            original_id: 1,
+            content: "🟩".repeat(2001),
+            reason: None,
+            topic: None,
+            category: None,
+            tags: None,
+            title: None,
+            agent_id: None,
+            format: None,
+        };
+        assert!(validate_correct_params(&params_multibyte_over, 8_000).is_err());
+
+        // "🟩".repeat(2000) → 8000 bytes → must pass
+        let params_multibyte_at = CorrectParams {
+            original_id: 1,
+            content: "🟩".repeat(2000),
+            reason: None,
+            topic: None,
+            category: None,
+            tags: None,
+            title: None,
+            agent_id: None,
+            format: None,
+        };
+        assert!(validate_correct_params(&params_multibyte_at, 8_000).is_ok());
+    }
+
+    #[test]
+    fn test_validate_correct_params_byte_check_fires_before_char_check() {
+        // Content over byte limit but under char limit — byte error must fire.
+        let params = CorrectParams {
+            original_id: 1,
+            content: "a".repeat(8001),
+            reason: None,
+            topic: None,
+            category: None,
+            tags: None,
+            title: None,
+            agent_id: None,
+            format: None,
+        };
+        let err = validate_correct_params(&params, 8_000).unwrap_err();
+        match err {
+            ServerError::InvalidInput { field, reason } => {
+                assert_eq!(field, "content");
+                assert!(
+                    reason.contains("configured maximum"),
+                    "byte error must mention 'configured maximum'; got: {reason}"
+                );
+            }
+            _ => panic!("expected InvalidInput"),
+        }
     }
 
     // -- vnc-003: validate_deprecate_params --

--- a/crates/unimatrix-server/src/main.rs
+++ b/crates/unimatrix-server/src/main.rs
@@ -704,6 +704,8 @@ async fn tokio_main_daemon(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     server.observation_registry = Arc::clone(&observation_registry);
     // crt-046: thread inference config for goal-cluster blending weights in context_briefing.
     server.inference_config = Arc::clone(&inference_config);
+    // #561: thread store config for content byte limit enforcement.
+    server.store_config = Arc::new(config.store.clone());
 
     // Extract state handles before services is moved.
     let confidence_state_handle = services.confidence_state_handle();
@@ -1101,6 +1103,8 @@ async fn tokio_main_stdio(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     server.observation_registry = Arc::clone(&observation_registry);
     // crt-046: thread inference config for goal-cluster blending weights in context_briefing.
     server.inference_config = Arc::clone(&inference_config);
+    // #561: thread store config for content byte limit enforcement.
+    server.store_config = Arc::new(config.store.clone());
 
     // crt-019: extract ConfidenceStateHandle before services is moved.
     let confidence_state_handle = services.confidence_state_handle();

--- a/crates/unimatrix-server/src/mcp/tools.rs
+++ b/crates/unimatrix-server/src/mcp/tools.rs
@@ -565,7 +565,7 @@ impl UnimatrixServer {
 
     #[tool(
         name = "context_store",
-        description = "Store a new context entry. Use to record patterns, conventions, architectural decisions, or other reusable knowledge discovered during work."
+        description = "Store a new context entry. Use to record patterns, conventions, architectural decisions, or other reusable knowledge discovered during work. Entries should be focused and specific — a single decision, pattern, or lesson. Content is subject to a configured size limit; an error is returned if exceeded."
     )]
     async fn context_store(
         &self,
@@ -578,7 +578,8 @@ impl UnimatrixServer {
         self.require_cap(&ctx.agent_id, Capability::Write).await?;
 
         // 2. Validation
-        validate_store_params(&params).map_err(rmcp::ErrorData::from)?;
+        validate_store_params(&params, self.store_config.max_content_bytes)
+            .map_err(rmcp::ErrorData::from)?;
 
         // 3. Category validation
         self.categories
@@ -793,7 +794,8 @@ impl UnimatrixServer {
         self.require_cap(&ctx.agent_id, Capability::Write).await?;
 
         // 2. Validation (includes original_id range check)
-        validate_correct_params(&params).map_err(rmcp::ErrorData::from)?;
+        validate_correct_params(&params, self.store_config.max_content_bytes)
+            .map_err(rmcp::ErrorData::from)?;
 
         // 3. Extract validated original_id (range already checked by validate_correct_params)
         let original_id = params.original_id as u64;
@@ -921,7 +923,7 @@ impl UnimatrixServer {
 
     #[tool(
         name = "context_status",
-        description = "Get the health status of the knowledge base. Shows entry counts, category/topic distributions, correction chains, and security metrics. Requires Read capability."
+        description = "Get the health status of the knowledge base. Shows entry counts, category/topic distributions, correction chains, and security metrics. Requires Read capability. Response size scales with corpus size; format: json responses may be large on large corpora."
     )]
     async fn context_status(
         &self,

--- a/crates/unimatrix-server/src/server.rs
+++ b/crates/unimatrix-server/src/server.rs
@@ -19,7 +19,7 @@ use crate::background::TickMetadata;
 use crate::error::ServerError;
 use crate::infra::audit::{AuditEvent, AuditLog};
 use crate::infra::categories::CategoryAllowlist;
-use crate::infra::config::InferenceConfig;
+use crate::infra::config::{InferenceConfig, StoreConfig};
 use crate::infra::embed_handle::EmbedServiceHandle;
 use crate::infra::registry::{AgentRegistry, TrustLevel};
 use crate::infra::session::SessionRegistry;
@@ -236,6 +236,10 @@ pub struct UnimatrixServer {
     /// the context_briefing handler. Initialized to default in `new()` (for tests).
     /// Overwritten from `main.rs` with the startup-resolved config (daemon/stdio paths).
     pub inference_config: Arc<InferenceConfig>,
+    /// #561: store config snapshot for content byte limit enforcement in
+    /// validate_store_params and validate_correct_params. Initialized to default
+    /// in `new()` (for tests). Overwritten from `main.rs` with the startup config.
+    pub store_config: Arc<StoreConfig>,
 }
 
 impl UnimatrixServer {
@@ -333,6 +337,8 @@ impl UnimatrixServer {
             observation_registry: Arc::new(DomainPackRegistry::with_builtin_claude_code()),
             // crt-046: default for test server; overwritten in main.rs daemon/stdio paths.
             inference_config: Arc::new(InferenceConfig::default()),
+            // #561: default for test server; overwritten in main.rs daemon/stdio paths.
+            store_config: Arc::new(StoreConfig::default()),
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `StoreConfig` with `max_content_bytes` (default 8,000 bytes, configurable range [1,000, 1 MiB]) to `UnimatrixConfig`
- Enforce byte cap at write time in `validate_store_params` and `validate_correct_params` — O(1) `str::len()` check fires before the O(n) `chars().count()` scan so oversized content exits early
- `StoreConfig::validate()` enforces bounds at startup; `merge_configs()` arm added (mandatory 5th site per established pattern)
- `context_store` description updated: focused-entry guidance, size limit exists without publishing the value
- `context_status` description updated: `format:json` response size scales with corpus size (no hard cap implied)
- `config.toml` documents new `[store]` section

## Test plan

- [x] `test_validate_store_params_content_byte_limit` — over-limit ASCII and multibyte emoji (🟩×2001 = 8,004 bytes, 2,001 chars — critical case: passes char limit, fails byte limit)
- [x] `test_validate_store_params_byte_check_fires_before_char_check` — byte error fires before char error
- [x] `test_validate_correct_params_content_byte_limit` — same for correct path
- [x] `test_validate_correct_params_byte_check_fires_before_char_check`
- [x] `StoreConfig::validate()` bounds tests (below min, above max, at boundaries)
- [x] 2926/2926 workspace unit tests passing
- [x] 23/23 integration smoke tests passing
- [x] 14/14 context_store integration suite passing
- [x] 10/10 input validation integration suite passing
- [x] No new clippy warnings

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)