### PR TITLE
fix(audit): atomic counter allocation eliminates UNIQUE constraint race (#584)

### DIFF
--- a/crates/unimatrix-store/src/audit.rs
+++ b/crates/unimatrix-store/src/audit.rs
@@ -22,9 +22,7 @@ impl SqlxStore {
             .await
             .map_err(|e| StoreError::Database(e.into()))?;
 
-        let current_id = counters::read_counter(&mut *txn, "next_audit_event_id").await?;
-        let id = if current_id == 0 { 1 } else { current_id };
-        counters::set_counter(&mut *txn, "next_audit_event_id", id + 1).await?;
+        let id = counters::next_counter(&mut txn, "next_audit_event_id").await?;
 
         let target_ids_json = serde_json::to_string(&event.target_ids)
             .map_err(|e| StoreError::Serialization(e.to_string()))?;

--- a/crates/unimatrix-store/src/counters.rs
+++ b/crates/unimatrix-store/src/counters.rs
@@ -61,18 +61,41 @@ pub async fn decrement_counter(conn: &mut SqliteConnection, name: &str, delta: u
     set_counter(&mut *conn, name, current.saturating_sub(delta)).await
 }
 
+/// Atomically allocate the next value for a named counter.
+///
+/// Uses an upsert-or-increment form that is atomic within SQLite regardless
+/// of transaction isolation level, eliminating the TOCTOU race present in
+/// the two-step read_counter + set_counter pattern (bugfix-584).
+///
+/// Seeds the counter at 1 on first call (row absent or value=0 handled by
+/// the upsert INSERT path which always starts at seed=1).
+///
+/// Takes `&mut SqliteConnection` directly to avoid "not general enough" lifetime
+/// errors when the caller's future must be `Send` (e.g., inside `tokio::spawn`).
+pub async fn next_counter(conn: &mut SqliteConnection, name: &str) -> Result<u64> {
+    let val: Option<i64> = sqlx::query_scalar(
+        "INSERT INTO counters (name, value) VALUES (?1, 1)
+         ON CONFLICT(name) DO UPDATE SET value = value + 1
+         RETURNING value",
+    )
+    .bind(name)
+    .fetch_optional(&mut *conn)
+    .await
+    .map_err(|e| StoreError::Database(e.into()))?;
+
+    val.map(|v| v as u64)
+        .ok_or_else(|| StoreError::Database("next_counter RETURNING returned no row".into()))
+}
+
 /// Allocate the next entry ID within an open transaction.
 ///
-/// Reads `next_entry_id`, increments it, returns the pre-increment value.
-/// The returned value is always >= 1 (0 → 1 bootstrap).
+/// Atomically increments the `next_entry_id` counter and returns the allocated
+/// value. The returned value is always >= 1 (first call returns 1).
 ///
 /// Takes `&mut SqliteConnection` directly to avoid "not general enough" lifetime
 /// errors when the caller's future must be `Send` (e.g., inside `tokio::spawn`).
 pub async fn next_entry_id(conn: &mut SqliteConnection) -> Result<u64> {
-    let current = read_counter(&mut *conn, "next_entry_id").await?;
-    let id = if current == 0 { 1 } else { current };
-    set_counter(&mut *conn, "next_entry_id", id + 1).await?;
-    Ok(id)
+    next_counter(conn, "next_entry_id").await
 }
 
 // ---------------------------------------------------------------------------
@@ -137,7 +160,8 @@ mod tests {
     #[tokio::test]
     async fn test_next_entry_id_sequential() {
         let pool = setup_pool().await;
-        sqlx::query("INSERT INTO counters (name, value) VALUES ('next_entry_id', 1)")
+        // Seed at 0 — matches db.rs init. First next_counter call returns 1.
+        sqlx::query("INSERT INTO counters (name, value) VALUES ('next_entry_id', 0)")
             .execute(&pool)
             .await
             .unwrap();
@@ -153,5 +177,63 @@ mod tests {
         set_counter(&pool, "next_entry_id", 0).await.unwrap();
         let mut conn = pool.acquire().await.unwrap();
         assert_eq!(next_entry_id(&mut conn).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_next_counter_sequential_allocations() {
+        let pool = setup_pool().await;
+        let mut conn = pool.acquire().await.unwrap();
+        assert_eq!(next_counter(&mut conn, "test_seq").await.unwrap(), 1);
+        assert_eq!(next_counter(&mut conn, "test_seq").await.unwrap(), 2);
+        assert_eq!(next_counter(&mut conn, "test_seq").await.unwrap(), 3);
+    }
+
+    /// Regression guard for bugfix-584: two concurrent next_counter calls on the
+    /// same counter name must produce distinct values even with max_connections=2.
+    ///
+    /// Reproduces the TOCTOU race: with BEGIN DEFERRED and read+write two-step,
+    /// both tasks could read the same snapshot. The atomic upsert form eliminates
+    /// this — SQLite serializes the upsert internally.
+    #[tokio::test]
+    async fn test_next_counter_concurrent_no_duplicate() {
+        use sqlx::sqlite::SqlitePoolOptions;
+        use std::collections::HashSet;
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(2)
+            .connect("sqlite::memory:")
+            .await
+            .expect("open in-memory pool with max_connections=2");
+
+        sqlx::query("CREATE TABLE counters (name TEXT PRIMARY KEY, value INTEGER NOT NULL)")
+            .execute(&pool)
+            .await
+            .expect("create counters table");
+
+        let pool1 = pool.clone();
+        let pool2 = pool.clone();
+
+        let t1 = tokio::spawn(async move {
+            let mut conn = pool1.acquire().await.expect("acquire conn 1");
+            next_counter(&mut conn, "concurrent_test")
+                .await
+                .expect("next_counter task 1")
+        });
+        let t2 = tokio::spawn(async move {
+            let mut conn = pool2.acquire().await.expect("acquire conn 2");
+            next_counter(&mut conn, "concurrent_test")
+                .await
+                .expect("next_counter task 2")
+        });
+
+        let id1 = t1.await.expect("task 1 joined");
+        let id2 = t2.await.expect("task 2 joined");
+
+        let ids: HashSet<u64> = [id1, id2].into_iter().collect();
+        assert_eq!(
+            ids.len(),
+            2,
+            "concurrent next_counter calls must return distinct values, got id1={id1} id2={id2}"
+        );
     }
 }

--- a/crates/unimatrix-store/src/db.rs
+++ b/crates/unimatrix-store/src/db.rs
@@ -1015,7 +1015,7 @@ pub(crate) async fn create_tables_if_needed(
         .bind(crate::migration::CURRENT_SCHEMA_VERSION as i64)
         .execute(&mut *conn)
         .await?;
-    sqlx::query("INSERT OR IGNORE INTO counters (name, value) VALUES ('next_entry_id', 1)")
+    sqlx::query("INSERT OR IGNORE INTO counters (name, value) VALUES ('next_entry_id', 0)")
         .execute(&mut *conn)
         .await?;
     sqlx::query("INSERT OR IGNORE INTO counters (name, value) VALUES ('next_signal_id', 0)")
@@ -1163,7 +1163,10 @@ mod tests {
             .await
             .expect("query next_entry_id");
 
-        assert_eq!(v, 1, "next_entry_id should initialize to 1");
+        assert_eq!(
+            v, 0,
+            "next_entry_id should initialize to 0 (first next_counter call returns 1)"
+        );
         store.close().await.unwrap();
     }
 

--- a/crates/unimatrix-store/src/pool_config.rs
+++ b/crates/unimatrix-store/src/pool_config.rs
@@ -219,6 +219,28 @@ mod tests {
         assert!(cfg.validate().is_ok(), "expected Ok for write_max=2");
     }
 
+    /// Regression guard (bugfix-584): write_max_connections=2 must remain valid
+    /// after the atomic counter fix.
+    ///
+    /// Before bugfix-584, pool serialization (write_max=1) was the only thing
+    /// preventing the audit_log UNIQUE constraint race. The atomic upsert fix makes
+    /// the code correct at write_max=2. This test documents that invariant: if
+    /// someone later lowers the hard cap to 1 thinking correctness requires it,
+    /// this test will fail and force them to re-examine the decision.
+    #[test]
+    fn test_pool_config_write_max_2_is_valid() {
+        let cfg = PoolConfig {
+            read_max_connections: 4,
+            write_max_connections: 2,
+            read_acquire_timeout: Duration::from_secs(1),
+            write_acquire_timeout: Duration::from_secs(2),
+        };
+        assert!(
+            cfg.validate().is_ok(),
+            "write_max_connections=2 must be valid: atomic counter fix (bugfix-584) makes code correct at this pool size"
+        );
+    }
+
     #[test]
     fn test_pool_config_validate_write_max_1_accepted() {
         let cfg = PoolConfig {

--- a/crates/unimatrix-store/tests/sqlite_parity.rs
+++ b/crates/unimatrix-store/tests/sqlite_parity.rs
@@ -1098,7 +1098,7 @@ async fn test_read_counter() {
     assert!(version >= 9, "schema_version should be >= 9, got {version}");
 
     let next = store.read_counter("next_entry_id").await.unwrap();
-    assert_eq!(next, 1);
+    assert_eq!(next, 0, "next_entry_id seeds at 0; first next_counter call returns 1");
 
     let missing = store.read_counter("nonexistent").await.unwrap();
     assert_eq!(missing, 0);


### PR DESCRIPTION
## Summary

- Replaces two-step counter read+write in `log_audit_event` and `next_entry_id` with a single atomic `INSERT ... ON CONFLICT DO UPDATE SET value = value + 1 RETURNING value`
- Eliminates the TOCTOU race that caused `UNIQUE constraint failed: audit_log.event_id` (SQLite error 1555) when `write_max_connections=2`
- Fixes the same latent race in `next_entry_id` (identical pattern, same pool config exposure)
- Corrects `next_entry_id` counter seed from 1 to 0 in `db.rs` (first upsert returns 1, preserving contract)

## Changed files

- `crates/unimatrix-store/src/counters.rs` — added `next_counter` (atomic upsert-or-increment)
- `crates/unimatrix-store/src/audit.rs` — replaced 3-line read+set with `next_counter`
- `crates/unimatrix-store/src/db.rs` — counter seed corrected from 1 to 0
- `crates/unimatrix-store/src/pool_config.rs` — regression guard test: `write_max=2` is valid after this fix
- `crates/unimatrix-store/tests/sqlite_parity.rs` — parity assertion updated for seed=0

## New tests

- `test_next_counter_sequential_allocations` — basic sequential behavior
- `test_next_counter_concurrent_no_duplicate` — spawns two tasks on `max_connections=2` pool; asserts returned IDs are distinct (would have caught the original bug)
- `test_pool_config_write_max_2_is_valid` — regression guard documenting that `write_max=2` is safe after this fix

## Test plan

- [x] `cargo test -p unimatrix-store` — 294 passed, 0 failed
- [x] `cargo test --workspace` — all green
- [x] `cargo clippy --workspace -- -D warnings` — clean (pre-existing error in `auth.rs` unrelated)
- [x] Integration smoke suite — 23/23 passed
- [x] Integration tools + lifecycle suites — 168 passed, 0 failed

Fixes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)