### PR TITLE
fix: validate min/max_confidence are finite before SQL binding in filter mode (#615)

### DIFF
--- a/crates/unimatrix-server/src/mcp/graph_read_filter.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_filter.rs
@@ -85,10 +85,31 @@ pub(super) async fn handle_filter(
         }
     };
 
-    // Step 4: Build parameterized correlated subquery SQL.
+    // Step 4: Validate confidence bounds (must be finite; NaN/±Infinity produce
+    // silent wrong results in SQLite comparisons).
+    if let Some(min_c) = params.min_confidence {
+        if !min_c.is_finite() {
+            return Err(ErrorData::new(
+                ERROR_INVALID_PARAMS,
+                "min_confidence must be a finite number",
+                None,
+            ));
+        }
+    }
+    if let Some(max_c) = params.max_confidence {
+        if !max_c.is_finite() {
+            return Err(ErrorData::new(
+                ERROR_INVALID_PARAMS,
+                "max_confidence must be a finite number",
+                None,
+            ));
+        }
+    }
+
+    // Step 5: Build parameterized correlated subquery SQL.
     // All caller values bound via push_bind — no string interpolation (ADR-007, NFR-06, SR-A).
 
-    // 4a. Base query: active entries in the specified category.
+    // 5a. Base query: active entries in the specified category.
     let mut qb: QueryBuilder<sqlx::Sqlite> = QueryBuilder::new(
         "SELECT e.id, e.title, e.content, e.topic, e.category, e.source, e.status, \
          e.confidence, e.created_at, e.updated_at, e.last_accessed_at, e.access_count, \
@@ -102,7 +123,7 @@ pub(super) async fn handle_filter(
     qb.push_bind(category);
     qb.push(" AND e.status = 0");
 
-    // 4b. Optional: min_age_days — entries created at least N days ago.
+    // 5b. Optional: min_age_days — entries created at least N days ago.
     // created_at is INTEGER (Unix epoch seconds). Use integer arithmetic, NOT datetime().
     if let Some(days) = params.min_age_days {
         // CAST(strftime('%s','now') AS INTEGER) returns current epoch as integer.
@@ -112,22 +133,24 @@ pub(super) async fn handle_filter(
         qb.push(")");
     }
 
-    // 4c. Optional: min_confidence — entries where confidence >= N.
+    // 5c. Optional: min_confidence — entries where confidence >= N.
     if let Some(min_c) = params.min_confidence {
         qb.push(" AND e.confidence >= ");
         qb.push_bind(min_c);
     }
 
-    // 4d. Optional: max_confidence — entries where confidence <= N.
+    // 5d. Optional: max_confidence — entries where confidence <= N.
     if let Some(max_c) = params.max_confidence {
         qb.push(" AND e.confidence <= ");
         qb.push_bind(max_c);
     }
 
-    // 4e. Optional: min_edge_count — entries with >= N outgoing edges of edge_types.
+    // 5e. Optional: min_edge_count — entries with >= N outgoing edges of edge_types.
     // edge_types is guaranteed Some and non-empty when has_edge_count=true (Step 2 guard).
     if let Some(min_n) = params.min_edge_count {
-        let et = edge_types.as_ref().expect("edge_types guaranteed non-empty by Step 2 validation");
+        let et = edge_types
+            .as_ref()
+            .expect("edge_types guaranteed non-empty by Step 2 validation");
         qb.push(
             " AND (SELECT COUNT(*) FROM graph_edges g \
              WHERE g.source_id = e.id AND g.relation_type IN (",
@@ -137,12 +160,14 @@ pub(super) async fn handle_filter(
         qb.push_bind(min_n as i64);
     }
 
-    // 4f. Optional: max_edge_count — entries with <= N outgoing edges of edge_types.
+    // 5f. Optional: max_edge_count — entries with <= N outgoing edges of edge_types.
     // CRITICAL: max_edge_count=0 is valid and must work correctly (R-02).
     // Use `<= ?` unconditionally — never special-case zero.
     // Two SEPARATE subqueries when both min and max are present (R-08 — not a BETWEEN).
     if let Some(max_n) = params.max_edge_count {
-        let et = edge_types.as_ref().expect("edge_types guaranteed non-empty by Step 2 validation");
+        let et = edge_types
+            .as_ref()
+            .expect("edge_types guaranteed non-empty by Step 2 validation");
         qb.push(
             " AND (SELECT COUNT(*) FROM graph_edges g \
              WHERE g.source_id = e.id AND g.relation_type IN (",
@@ -152,11 +177,11 @@ pub(super) async fn handle_filter(
         qb.push_bind(max_n as i64);
     }
 
-    // 4g. LIMIT clause.
+    // 5g. LIMIT clause.
     qb.push(" LIMIT ");
     qb.push_bind(limit as i64);
 
-    // Step 5: Execute query and hydrate EntryRecord rows.
+    // Step 6: Execute query and hydrate EntryRecord rows.
     // EntryRecord does not implement sqlx::FromRow — use entry_from_row for hydration.
     use unimatrix_store::read::{apply_tags, entry_from_row, load_tags_for_entries};
 
@@ -184,7 +209,7 @@ pub(super) async fn handle_filter(
         apply_tags(&mut entries, &tag_map);
     }
 
-    // Step 6: Return response.
+    // Step 7: Return response.
     let total_returned = entries.len();
     Ok(FilterResponse {
         entries,
@@ -243,3 +268,7 @@ fn push_relation_type_list(qb: &mut QueryBuilder<sqlx::Sqlite>, types: &[Relatio
 #[cfg(test)]
 #[path = "graph_read_filter_tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "graph_read_filter_validation_tests.rs"]
+mod validation_tests;

--- a/crates/unimatrix-server/src/mcp/graph_read_filter_tests.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_filter_tests.rs
@@ -1,7 +1,10 @@
-//! Unit tests for `graph_read_filter.rs`.
+//! Unit tests for `graph_read_filter.rs` — behavioral and fixture tests.
 //!
 //! Extracted to a separate file to keep `graph_read_filter.rs` under the 500-line limit.
 //! Covers: AC-07 through AC-12, AC-29, AC-30, R-02, R-08, R-10, R-11, IR-04.
+//!
+//! Early-return validation tests (AC-09, AC-10, AC-11, and confidence finiteness)
+//! live in `graph_read_filter_validation_tests.rs`.
 
 use super::super::GraphParams;
 use super::*;
@@ -18,14 +21,6 @@ async fn open_test_store() -> (SqlxStore, tempfile::TempDir) {
         .await
         .expect("open test store");
     (store, dir)
-}
-
-fn filter_params(category: Option<&str>) -> GraphParams {
-    GraphParams {
-        mode: "filter".to_string(),
-        category: category.map(|s| s.to_string()),
-        ..Default::default()
-    }
 }
 
 /// Insert an entry via the standard SqlxStore API; returns the assigned ID.
@@ -62,248 +57,8 @@ async fn add_edge(store: &SqlxStore, source_id: u64, target_id: u64, rel_type: &
     .expect("insert edge");
 }
 
-// -----------------------------------------------------------------------
-// AC-10 — category required
-// -----------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_handle_filter_missing_category_returns_error() {
-    // AC-10: category=None must return exact error text.
-    let (store_impl, _dir) = open_test_store().await;
-    let params = filter_params(None);
-    let result = handle_filter(&store_impl, &params).await;
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert_eq!(
-        err.message, "filter mode requires category",
-        "exact error text required, got: {}",
-        err.message
-    );
-    store_impl.close().await.unwrap();
-}
-
-#[tokio::test]
-async fn test_handle_filter_empty_category_returns_error() {
-    // AC-10: category="" (empty) must return the same error.
-    let (store_impl, _dir) = open_test_store().await;
-    let params = GraphParams {
-        mode: "filter".to_string(),
-        category: Some("".to_string()),
-        ..Default::default()
-    };
-    let result = handle_filter(&store_impl, &params).await;
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert_eq!(
-        err.message, "filter mode requires category",
-        "empty string must also trigger error, got: {}",
-        err.message
-    );
-    store_impl.close().await.unwrap();
-}
-
-// -----------------------------------------------------------------------
-// AC-09 — edge_types required when edge-count constraints present
-// -----------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_handle_filter_min_edge_count_without_edge_types_returns_error() {
-    // AC-09: min_edge_count present, edge_types=None → error.
-    let (store_impl, _dir) = open_test_store().await;
-    let params = GraphParams {
-        mode: "filter".to_string(),
-        category: Some("goal".to_string()),
-        min_edge_count: Some(1),
-        edge_types: None,
-        ..Default::default()
-    };
-    let result = handle_filter(&store_impl, &params).await;
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert_eq!(
-        err.message, "filter mode requires edge_types when edge_count constraints are specified",
-        "exact error text required, got: {}",
-        err.message
-    );
-    store_impl.close().await.unwrap();
-}
-
-#[tokio::test]
-async fn test_handle_filter_min_edge_count_with_empty_edge_types_returns_error() {
-    // AC-09: min_edge_count present, edge_types=Some(vec![]) → same error.
-    let (store_impl, _dir) = open_test_store().await;
-    let params = GraphParams {
-        mode: "filter".to_string(),
-        category: Some("goal".to_string()),
-        min_edge_count: Some(1),
-        edge_types: Some(vec![]),
-        ..Default::default()
-    };
-    let result = handle_filter(&store_impl, &params).await;
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert_eq!(
-        err.message, "filter mode requires edge_types when edge_count constraints are specified",
-        "empty edge_types must trigger error, got: {}",
-        err.message
-    );
-    store_impl.close().await.unwrap();
-}
-
-#[tokio::test]
-async fn test_handle_filter_max_edge_count_without_edge_types_returns_error() {
-    // AC-09: max_edge_count=0, edge_types=None → error.
-    let (store_impl, _dir) = open_test_store().await;
-    let params = GraphParams {
-        mode: "filter".to_string(),
-        category: Some("goal".to_string()),
-        max_edge_count: Some(0),
-        edge_types: None,
-        ..Default::default()
-    };
-    let result = handle_filter(&store_impl, &params).await;
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert_eq!(
-        err.message, "filter mode requires edge_types when edge_count constraints are specified",
-        "exact error text required, got: {}",
-        err.message
-    );
-    store_impl.close().await.unwrap();
-}
-
-// -----------------------------------------------------------------------
-// AC-11 — limit boundary validation
-// -----------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_handle_filter_limit_zero_returns_error() {
-    // AC-11: limit=0 is out of range.
-    let (store_impl, _dir) = open_test_store().await;
-    let params = GraphParams {
-        mode: "filter".to_string(),
-        category: Some("goal".to_string()),
-        limit: Some(0),
-        ..Default::default()
-    };
-    let result = handle_filter(&store_impl, &params).await;
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(
-        err.message.contains("1..=500"),
-        "error must state range [1,500], got: {}",
-        err.message
-    );
-    assert!(
-        err.message.contains("got 0"),
-        "error must include the bad value, got: {}",
-        err.message
-    );
-    store_impl.close().await.unwrap();
-}
-
-#[tokio::test]
-async fn test_handle_filter_limit_501_returns_error() {
-    // AC-11: limit=501 is out of range.
-    let (store_impl, _dir) = open_test_store().await;
-    let params = GraphParams {
-        mode: "filter".to_string(),
-        category: Some("goal".to_string()),
-        limit: Some(501),
-        ..Default::default()
-    };
-    let result = handle_filter(&store_impl, &params).await;
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(
-        err.message.contains("1..=500"),
-        "error must state range [1,500], got: {}",
-        err.message
-    );
-    store_impl.close().await.unwrap();
-}
-
-#[tokio::test]
-async fn test_handle_filter_limit_default_is_100() {
-    // AC-11: limit=None → default 100; with exactly 3 entries we get 3 back.
-    let (store_impl, _dir) = open_test_store().await;
-    store_entry(&store_impl, "goal", "Goal A").await;
-    store_entry(&store_impl, "goal", "Goal B").await;
-    store_entry(&store_impl, "goal", "Goal C").await;
-
-    let params = GraphParams {
-        mode: "filter".to_string(),
-        category: Some("goal".to_string()),
-        limit: None,
-        ..Default::default()
-    };
-    let result = handle_filter(&store_impl, &params).await;
-    assert!(result.is_ok(), "expected Ok, got: {:?}", result);
-    let resp = result.unwrap();
-    // Default limit=100 means all 3 are returned.
-    assert_eq!(
-        resp.entries.len(),
-        3,
-        "expected 3 entries with default limit=100"
-    );
-    store_impl.close().await.unwrap();
-}
-
-// -----------------------------------------------------------------------
-// R-11 — category-only query (no other filters) is valid
-// -----------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_handle_filter_category_only_no_validation_error() {
-    // R-11: category-only query returns all active entries in category.
-    let (store_impl, _dir) = open_test_store().await;
-    store_entry(&store_impl, "goal", "Goal 1").await;
-    store_entry(&store_impl, "goal", "Goal 2").await;
-    store_entry(&store_impl, "goal", "Goal 3").await;
-
-    let params = GraphParams {
-        mode: "filter".to_string(),
-        category: Some("goal".to_string()),
-        ..Default::default()
-    };
-    let result = handle_filter(&store_impl, &params).await;
-    assert!(
-        result.is_ok(),
-        "category-only filter must succeed, got: {:?}",
-        result
-    );
-    let resp = result.unwrap();
-    assert_eq!(resp.entries.len(), 3);
-    assert_eq!(resp.total_returned, 3);
-    store_impl.close().await.unwrap();
-}
-
-// -----------------------------------------------------------------------
-// AC-12 — total_returned == entries.len()
-// -----------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_handle_filter_total_returned_matches_len() {
-    // AC-12: total_returned must equal entries.len() in every response.
-    let (store_impl, _dir) = open_test_store().await;
-    for i in 0..5 {
-        store_entry(&store_impl, "goal", &format!("Goal {i}")).await;
-    }
-    let params = GraphParams {
-        mode: "filter".to_string(),
-        category: Some("goal".to_string()),
-        ..Default::default()
-    };
-    let result = handle_filter(&store_impl, &params).await;
-    assert!(result.is_ok());
-    let resp = result.unwrap();
-    assert_eq!(
-        resp.total_returned,
-        resp.entries.len(),
-        "total_returned must equal entries.len()"
-    );
-    store_impl.close().await.unwrap();
-}
+// R-11 (category-only) and AC-12 (total_returned) tests live in
+// graph_read_filter_validation_tests.rs (lightweight, no edge fixtures).
 
 // -----------------------------------------------------------------------
 // R-02 — max_edge_count=0 uses <= binding, not special-cased (AC-29)
@@ -638,36 +393,6 @@ async fn test_filter_multi_type_edge_types_push_bind_pattern() {
         "entry with only RelatedTo edges must appear for max_edge_count=0 \
          filtering on Advances/Supports — got: {:?}",
         returned_ids
-    );
-    store_impl.close().await.unwrap();
-}
-
-// -----------------------------------------------------------------------
-// Unrecognized edge type
-// -----------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_filter_unrecognized_edge_type_returns_error() {
-    let (store_impl, _dir) = open_test_store().await;
-    let params = GraphParams {
-        mode: "filter".to_string(),
-        category: Some("goal".to_string()),
-        min_edge_count: Some(1),
-        edge_types: Some(vec!["BogusType".to_string()]),
-        ..Default::default()
-    };
-    let result = handle_filter(&store_impl, &params).await;
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(
-        err.message.contains("BogusType"),
-        "error must name the unrecognized type, got: {}",
-        err.message
-    );
-    assert!(
-        err.message.contains("recognized types"),
-        "error must list recognized types, got: {}",
-        err.message
     );
     store_impl.close().await.unwrap();
 }

--- a/crates/unimatrix-server/src/mcp/graph_read_filter_validation_tests.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_filter_validation_tests.rs
@@ -1,0 +1,428 @@
+//! Early-return validation tests for `graph_read_filter.rs`.
+//!
+//! These tests cover input validation that fires before SQL construction:
+//! AC-09 (edge_types required), AC-10 (category required), AC-11 (limit range),
+//! and confidence finiteness (NaN/±Infinity guard added in #615).
+//!
+//! Declared as `validation_tests` sub-module of `graph_read_filter` via `#[path]`.
+
+use super::super::GraphParams;
+use super::*;
+use unimatrix_store::{NewEntry, PoolConfig, SqlxStore, Status};
+
+// -----------------------------------------------------------------------
+// Test helpers
+// -----------------------------------------------------------------------
+
+async fn open_test_store() -> (SqlxStore, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("test.db");
+    let store = SqlxStore::open(&path, PoolConfig::test_default())
+        .await
+        .expect("open test store");
+    (store, dir)
+}
+
+/// Insert an entry via the standard SqlxStore API; returns the assigned ID.
+async fn store_entry(store: &SqlxStore, category: &str, title: &str) -> u64 {
+    let entry = NewEntry {
+        title: title.to_string(),
+        content: format!("content for {title}"),
+        topic: "test".to_string(),
+        category: category.to_string(),
+        tags: vec![],
+        source: "test".to_string(),
+        status: Status::Active,
+        created_by: String::new(),
+        feature_cycle: "vnc-020".to_string(),
+        trust_source: "agent".to_string(),
+    };
+    store.insert(entry).await.expect("insert entry")
+}
+
+// -----------------------------------------------------------------------
+// AC-10 — category required
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_handle_filter_missing_category_returns_error() {
+    // AC-10: category=None must return exact error text.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: None,
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.message, "filter mode requires category",
+        "exact error text required, got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_handle_filter_empty_category_returns_error() {
+    // AC-10: category="" (empty) must return the same error.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("".to_string()),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.message, "filter mode requires category",
+        "empty string must also trigger error, got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+// -----------------------------------------------------------------------
+// AC-09 — edge_types required when edge-count constraints present
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_handle_filter_min_edge_count_without_edge_types_returns_error() {
+    // AC-09: min_edge_count present, edge_types=None → error.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        min_edge_count: Some(1),
+        edge_types: None,
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.message, "filter mode requires edge_types when edge_count constraints are specified",
+        "exact error text required, got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_handle_filter_min_edge_count_with_empty_edge_types_returns_error() {
+    // AC-09: min_edge_count present, edge_types=Some(vec![]) → same error.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        min_edge_count: Some(1),
+        edge_types: Some(vec![]),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.message, "filter mode requires edge_types when edge_count constraints are specified",
+        "empty edge_types must trigger error, got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_handle_filter_max_edge_count_without_edge_types_returns_error() {
+    // AC-09: max_edge_count=0, edge_types=None → error.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        max_edge_count: Some(0),
+        edge_types: None,
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert_eq!(
+        err.message, "filter mode requires edge_types when edge_count constraints are specified",
+        "exact error text required, got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+// -----------------------------------------------------------------------
+// AC-11 — limit boundary validation
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_handle_filter_limit_zero_returns_error() {
+    // AC-11: limit=0 is out of range.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        limit: Some(0),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.message.contains("1..=500"),
+        "error must state range [1,500], got: {}",
+        err.message
+    );
+    assert!(
+        err.message.contains("got 0"),
+        "error must include the bad value, got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_handle_filter_limit_501_returns_error() {
+    // AC-11: limit=501 is out of range.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        limit: Some(501),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.message.contains("1..=500"),
+        "error must state range [1,500], got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+// -----------------------------------------------------------------------
+// AC-11 — limit default (lightweight fixture, no edges)
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_handle_filter_limit_default_is_100() {
+    // AC-11: limit=None → default 100; with exactly 3 entries we get 3 back.
+    let (store_impl, _dir) = open_test_store().await;
+    store_entry(&store_impl, "goal", "Goal A").await;
+    store_entry(&store_impl, "goal", "Goal B").await;
+    store_entry(&store_impl, "goal", "Goal C").await;
+
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        limit: None,
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+    let resp = result.unwrap();
+    assert_eq!(
+        resp.entries.len(),
+        3,
+        "expected 3 entries with default limit=100"
+    );
+    store_impl.close().await.unwrap();
+}
+
+// -----------------------------------------------------------------------
+// R-11 — category-only query (no other filters) is valid
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_handle_filter_category_only_no_validation_error() {
+    // R-11: category-only query returns all active entries in category.
+    let (store_impl, _dir) = open_test_store().await;
+    store_entry(&store_impl, "goal", "Goal 1").await;
+    store_entry(&store_impl, "goal", "Goal 2").await;
+    store_entry(&store_impl, "goal", "Goal 3").await;
+
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(
+        result.is_ok(),
+        "category-only filter must succeed, got: {:?}",
+        result
+    );
+    let resp = result.unwrap();
+    assert_eq!(resp.entries.len(), 3);
+    assert_eq!(resp.total_returned, 3);
+    store_impl.close().await.unwrap();
+}
+
+// -----------------------------------------------------------------------
+// AC-12 — total_returned == entries.len()
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_handle_filter_total_returned_matches_len() {
+    // AC-12: total_returned must equal entries.len() in every response.
+    let (store_impl, _dir) = open_test_store().await;
+    for i in 0..5 {
+        store_entry(&store_impl, "goal", &format!("Goal {i}")).await;
+    }
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_ok());
+    let resp = result.unwrap();
+    assert_eq!(
+        resp.total_returned,
+        resp.entries.len(),
+        "total_returned must equal entries.len()"
+    );
+    store_impl.close().await.unwrap();
+}
+
+// -----------------------------------------------------------------------
+// Unrecognized edge type — parse_relation_types fires before SQL
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_filter_unrecognized_edge_type_returns_error() {
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        min_edge_count: Some(1),
+        edge_types: Some(vec!["BogusType".to_string()]),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        err.message.contains("BogusType"),
+        "error must name the unrecognized type, got: {}",
+        err.message
+    );
+    assert!(
+        err.message.contains("recognized types"),
+        "error must list recognized types, got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+// -----------------------------------------------------------------------
+// Confidence finiteness guard (#615)
+// -----------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_filter_nan_min_confidence_returns_error() {
+    // NaN passed as min_confidence must be rejected before SQL construction.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        min_confidence: Some(f64::NAN),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err(), "NaN min_confidence must return Err");
+    let err = result.unwrap_err();
+    assert!(
+        err.message.contains("finite"),
+        "error must mention 'finite', got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_filter_nan_max_confidence_returns_error() {
+    // NaN passed as max_confidence must be rejected before SQL construction.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        max_confidence: Some(f64::NAN),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err(), "NaN max_confidence must return Err");
+    let err = result.unwrap_err();
+    assert!(
+        err.message.contains("finite"),
+        "error must mention 'finite', got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_filter_inf_min_confidence_returns_error() {
+    // +Infinity passed as min_confidence must be rejected before SQL construction.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        min_confidence: Some(f64::INFINITY),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err(), "+Infinity min_confidence must return Err");
+    let err = result.unwrap_err();
+    assert!(
+        err.message.contains("finite"),
+        "error must mention 'finite', got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_filter_neg_inf_max_confidence_returns_error() {
+    // -Infinity passed as max_confidence must be rejected before SQL construction.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        max_confidence: Some(f64::NEG_INFINITY),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(result.is_err(), "-Infinity max_confidence must return Err");
+    let err = result.unwrap_err();
+    assert!(
+        err.message.contains("finite"),
+        "error must mention 'finite', got: {}",
+        err.message
+    );
+    store_impl.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_filter_valid_finite_confidence_does_not_trigger_guard() {
+    // A valid finite value (0.5) must not be rejected by the finiteness guard.
+    let (store_impl, _dir) = open_test_store().await;
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        category: Some("goal".to_string()),
+        min_confidence: Some(0.5),
+        ..Default::default()
+    };
+    let result = handle_filter(&store_impl, &params).await;
+    assert!(
+        result.is_ok(),
+        "finite min_confidence=0.5 must not be rejected, got: {:?}",
+        result
+    );
+    store_impl.close().await.unwrap();
+}


### PR DESCRIPTION
## Summary

- Adds `is_finite()` guard in `handle_filter` (step 4, after limit check, before SQL construction) for `min_confidence` and `max_confidence` parameters
- NaN and ±Infinity now return `ERROR_INVALID_PARAMS` before any SQL executes, preventing silent wrong-result failures in SQLite
- Splits `graph_read_filter_tests.rs` (was 733 lines) into behavioral tests (457 lines) and a new `graph_read_filter_validation_tests.rs` (428 lines) to stay within the 500-line workspace limit

## Test plan

- [x] `test_filter_nan_min_confidence_returns_error`
- [x] `test_filter_nan_max_confidence_returns_error`
- [x] `test_filter_inf_min_confidence_returns_error`
- [x] `test_filter_neg_inf_max_confidence_returns_error`
- [x] `test_filter_valid_finite_confidence_does_not_trigger_guard`
- [x] Full workspace: 5142 passed, 0 failed
- [x] Clippy: no new warnings
- [x] Integration smoke: 23/23 PASS
- [x] vnc-020 filter integration: 6/6 PASS

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)