### PR TITLE
fix(graph): reject resolve_supersessions on inverse/filter, add coverage tests (#616 #613)

### DIFF
--- a/crates/unimatrix-server/src/mcp/graph_read_inverse_integration_tests.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_inverse_integration_tests.rs
@@ -64,6 +64,19 @@ async fn deprecate_entry(store: &SqlxStore, entry_id: u64) {
         .expect("deprecate entry");
 }
 
+/// Deprecate an entry and record it as superseded by another entry.
+/// Sets status=1 (Deprecated) and superseded_by=successor_id directly in the DB.
+async fn set_superseded_by(store: &SqlxStore, deprecated_id: u64, successor_id: u64) {
+    sqlx::query(
+        "UPDATE entries SET status = 1, superseded_by = ?1, updated_at = 1700000002 WHERE id = ?2",
+    )
+    .bind(successor_id as i64)
+    .bind(deprecated_id as i64)
+    .execute(store.write_pool_test())
+    .await
+    .expect("set superseded_by");
+}
+
 fn inverse_params(
     category: Option<&str>,
     missing_edge_types: Option<Vec<&str>>,
@@ -249,5 +262,54 @@ async fn test_handle_inverse_empty_category_in_db_returns_empty_not_error() {
         .expect("handle_inverse");
     assert_eq!(resp.entries.len(), 0);
     assert_eq!(resp.total_returned, 0);
+    store.close().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// #616B — Deprecated-superseded entry absent from inverse results
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_handle_inverse_deprecated_superseded_entry_absent() {
+    // #616B: A deprecated entry (even one that is part of a supersession chain)
+    // must NOT appear in inverse results. The AND e.status = 0 guard excludes
+    // all non-active entries regardless of edge presence.
+    //
+    // Fixture:
+    //   entry_a — category="source", deprecated, superseded_by entry_b
+    //   entry_b — category="source", active, has an incoming Cites edge
+    //   donor   — category="decision", active, provides the Cites edge to entry_b
+    //
+    // Expected:
+    //   entry_a absent — deprecated (status=1), excluded by status guard.
+    //   entry_b absent — active but has an incoming Cites edge, excluded by antijoin.
+    let (store, _dir) = open_test_store().await;
+
+    let donor_id = insert_entry(&store, "decision").await;
+    let id_a = insert_entry(&store, "source").await;
+    let id_b = insert_entry(&store, "source").await;
+
+    // Give entry_b an incoming Cites edge so it's excluded by the antijoin.
+    insert_edge(&store, donor_id, id_b, "Cites").await;
+
+    // Deprecate entry_a and mark it as superseded_by entry_b.
+    set_superseded_by(&store, id_a, id_b).await;
+
+    let params = inverse_params(Some("source"), Some(vec!["Cites"]), None);
+    let resp = handle_inverse(&store, &params)
+        .await
+        .expect("handle_inverse");
+
+    let ids: Vec<u64> = resp.entries.iter().map(|e| e.id).collect();
+
+    assert!(
+        !ids.contains(&id_a),
+        "deprecated-superseded entry_a must not appear (status guard); ids={ids:?}"
+    );
+    assert!(
+        !ids.contains(&id_b),
+        "active entry_b (has Cites edge) must not appear (antijoin); ids={ids:?}"
+    );
+
     store.close().await.unwrap();
 }

--- a/crates/unimatrix-server/src/mcp/graph_read_tests.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_tests.rs
@@ -299,6 +299,87 @@ fn test_node_index_for_unknown_node_returns_none() {
 }
 
 // -----------------------------------------------------------------------
+// #616: resolve_supersessions rejected on inverse and filter modes
+// Only active entries are returned by both modes; the parameter has no effect.
+// -----------------------------------------------------------------------
+
+#[test]
+fn test_validate_inverse_rejects_resolve_supersessions() {
+    // #616A: resolve_supersessions on inverse mode must return an error explaining
+    // it has no effect — inverse always returns only active (status=0) entries.
+    let params = GraphParams {
+        mode: "inverse".to_string(),
+        resolve_supersessions: Some(true),
+        ..Default::default()
+    };
+    let result = validate_no_unsupported_params(&params);
+    assert!(result.is_err());
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("resolve_supersessions"),
+        "error must name the rejected field, got: {msg}"
+    );
+    assert!(
+        msg.contains("no effect"),
+        "error must explain 'no effect', got: {msg}"
+    );
+    assert!(
+        msg.contains("inverse"),
+        "error must name the mode, got: {msg}"
+    );
+    assert!(
+        msg.contains("only active entries are returned"),
+        "error must explain why, got: {msg}"
+    );
+}
+
+#[test]
+fn test_validate_filter_rejects_resolve_supersessions() {
+    // #616A: resolve_supersessions on filter mode must return an error explaining
+    // it has no effect — filter always returns only active (status=0) entries.
+    let params = GraphParams {
+        mode: "filter".to_string(),
+        resolve_supersessions: Some(true),
+        ..Default::default()
+    };
+    let result = validate_no_unsupported_params(&params);
+    assert!(result.is_err());
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("resolve_supersessions"),
+        "error must name the rejected field, got: {msg}"
+    );
+    assert!(
+        msg.contains("no effect"),
+        "error must explain 'no effect', got: {msg}"
+    );
+    assert!(
+        msg.contains("filter"),
+        "error must name the mode, got: {msg}"
+    );
+    assert!(
+        msg.contains("only active entries are returned"),
+        "error must explain why, got: {msg}"
+    );
+}
+
+#[test]
+fn test_validate_inverse_resolve_supersessions_false_also_rejected() {
+    // #616A: resolve_supersessions=Some(false) must also be rejected — the parameter
+    // itself is meaningless in inverse mode regardless of its value.
+    let params = GraphParams {
+        mode: "inverse".to_string(),
+        resolve_supersessions: Some(false),
+        ..Default::default()
+    };
+    let result = validate_no_unsupported_params(&params);
+    assert!(
+        result.is_err(),
+        "resolve_supersessions=false must also be rejected on inverse, got Ok"
+    );
+}
+
+// -----------------------------------------------------------------------
 // vnc-019 tests (graph_read.rs changes: subgraph mode, max_depth, SubgraphResponse)
 // Declared in a child module to keep this file under 500 lines (500-line rule).
 // -----------------------------------------------------------------------

--- a/crates/unimatrix-server/src/mcp/graph_read_validation.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_validation.rs
@@ -195,6 +195,14 @@ fn validate_inverse_params(params: &GraphParams) -> Result<(), String> {
             "max_edge_count is not supported in inverse mode — use filter mode".to_string(),
         );
     }
+    // resolve_supersessions has no meaning in inverse mode: only active entries (status=0)
+    // are returned by definition — there are no deprecated entries to resolve.
+    if params.resolve_supersessions.is_some() {
+        return Err(
+            "resolve_supersessions has no effect in inverse mode — only active entries are returned"
+                .to_string(),
+        );
+    }
     // category, missing_edge_types, limit: accepted — range validation inside handle_inverse.
     Ok(())
 }
@@ -228,6 +236,14 @@ fn validate_filter_params(params: &GraphParams) -> Result<(), String> {
     }
     if params.max_depth.is_some() {
         return Err("max_depth is not supported in filter mode — use subgraph mode".to_string());
+    }
+    // resolve_supersessions has no meaning in filter mode: only active entries (status=0)
+    // are returned by definition — there are no deprecated entries to resolve.
+    if params.resolve_supersessions.is_some() {
+        return Err(
+            "resolve_supersessions has no effect in filter mode — only active entries are returned"
+                .to_string(),
+        );
     }
     // category, edge_types, limit, min_age_days, min_confidence, max_confidence,
     // min_edge_count, max_edge_count: accepted — range/required validation inside handle_filter.

--- a/product/test/infra-001/suites/test_tools.py
+++ b/product/test/infra-001/suites/test_tools.py
@@ -4780,7 +4780,7 @@ def test_context_graph_filter_min_edge_count_gte2(server):
 def test_context_graph_filter_min_age_days(server):
     """#613 / R-06: filter mode min_age_days returns only entries older than the threshold.
 
-    Fixture: 3 "goal" entries.
+    Fixture: 3 "pattern" entries.
       - id_old_1, id_old_2: created_at backdated 40 days ago (older than 30-day threshold).
       - id_new: created_at is now (younger than 30-day threshold).
 
@@ -4803,19 +4803,19 @@ def test_context_graph_filter_min_age_days(server):
         server,
         "Kubernetes pod disruption budget limits voluntary disruptions during rollouts",
         topic="k8s-reliability",
-        category="goal",
+        category="pattern",
     )
     id_old_2 = _store_vnc020_entry(
         server,
         "Terraform remote state locking prevents concurrent plan and apply conflicts",
         topic="iac-patterns",
-        category="goal",
+        category="pattern",
     )
     id_new = _store_vnc020_entry(
         server,
         "ArgoCD GitOps sync ensures cluster state matches the git repository HEAD",
         topic="gitops",
-        category="goal",
+        category="pattern",
     )
 
     # ---- backdate id_old_1 and id_old_2 to 40 days ago via direct SQL ----
@@ -4834,10 +4834,10 @@ def test_context_graph_filter_min_age_days(server):
     conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
     conn.close()
 
-    # ---- call filter mode: category=goal, min_age_days=30, max_edge_count=0, edge_types=Advances ----
+    # ---- call filter mode: category=pattern, min_age_days=30, max_edge_count=0, edge_types=Advances ----
     resp = server.context_graph(
         "filter",
-        category="goal",
+        category="pattern",
         min_age_days=30,
         max_edge_count=0,
         edge_types=["Advances"],

--- a/product/test/infra-001/suites/test_tools.py
+++ b/product/test/infra-001/suites/test_tools.py
@@ -4777,6 +4777,94 @@ def test_context_graph_filter_min_edge_count_gte2(server):
     )
 
 
+def test_context_graph_filter_min_age_days(server):
+    """#613 / R-06: filter mode min_age_days returns only entries older than the threshold.
+
+    Fixture: 3 "goal" entries.
+      - id_old_1, id_old_2: created_at backdated 40 days ago (older than 30-day threshold).
+      - id_new: created_at is now (younger than 30-day threshold).
+
+    All entries have no Advances edges (max_edge_count=0 included to keep results narrow).
+
+    SQL used by filter mode: strftime('%s','now') - created_at >= min_age_days * 86400
+    i.e.  created_at <= strftime('%s','now') - min_age_days * 86400
+
+    This test backdates two entries via direct SQLite UPDATE to bypass the server API
+    (which always writes current timestamp), then calls filter mode and asserts only the
+    two old entries are returned.
+    """
+    import hashlib as _hashlib
+    import os as _os
+    import sqlite3 as _sqlite3
+    import time as _time
+
+    # ---- store 3 entries via MCP ----
+    id_old_1 = _store_vnc020_entry(
+        server,
+        "Kubernetes pod disruption budget limits voluntary disruptions during rollouts",
+        topic="k8s-reliability",
+        category="goal",
+    )
+    id_old_2 = _store_vnc020_entry(
+        server,
+        "Terraform remote state locking prevents concurrent plan and apply conflicts",
+        topic="iac-patterns",
+        category="goal",
+    )
+    id_new = _store_vnc020_entry(
+        server,
+        "ArgoCD GitOps sync ensures cluster state matches the git repository HEAD",
+        topic="gitops",
+        category="goal",
+    )
+
+    # ---- backdate id_old_1 and id_old_2 to 40 days ago via direct SQL ----
+    canonical = _os.path.realpath(server.project_dir)
+    digest = _hashlib.sha256(canonical.encode()).hexdigest()[:16]
+    db_path = _os.path.join(_os.path.expanduser("~"), ".unimatrix", digest, "unimatrix.db")
+
+    forty_days_ago = int(_time.time()) - 40 * 86400
+    conn = _sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        "UPDATE entries SET created_at = ? WHERE id IN (?, ?)",
+        (forty_days_ago, id_old_1, id_old_2),
+    )
+    conn.commit()
+    conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    conn.close()
+
+    # ---- call filter mode: category=goal, min_age_days=30, max_edge_count=0, edge_types=Advances ----
+    resp = server.context_graph(
+        "filter",
+        category="goal",
+        min_age_days=30,
+        max_edge_count=0,
+        edge_types=["Advances"],
+        agent_id="human",
+        format="json",
+    )
+    result = assert_tool_success(resp)
+    data = _json_vnc020.loads(result.text)
+
+    assert "entries" in data, f"filter response missing 'entries': {list(data.keys())}"
+    assert "total_returned" in data, f"filter response missing 'total_returned': {list(data.keys())}"
+    returned_ids = {e["id"] for e in data["entries"]}
+
+    assert id_old_1 in returned_ids, (
+        f"Old entry (id={id_old_1}, 40 days) must appear with min_age_days=30; got: {returned_ids}"
+    )
+    assert id_old_2 in returned_ids, (
+        f"Old entry (id={id_old_2}, 40 days) must appear with min_age_days=30; got: {returned_ids}"
+    )
+    assert id_new not in returned_ids, (
+        f"New entry (id={id_new}, created now) must NOT appear with min_age_days=30; got: {returned_ids}"
+    )
+    assert data["total_returned"] == 2, (
+        f"Exactly 2 old entries must be returned; got total_returned={data['total_returned']}"
+    )
+
+
 def test_context_graph_path_found(server):
     """AC-31 / R-12: path mode returns a 2-hop path with correct hops content.
 


### PR DESCRIPTION
## Summary

Closes #616 · Closes #613

**#616 — inverse/filter: deprecated entries false positive (won't-fix + hardening)**

The alleged bug does not exist: `handle_inverse` and `handle_filter` already enforce `AND e.status = 0`, which excludes deprecated entries before the antijoin runs. No false positive is possible.

Two additions close the correctness gap and prevent future confusion:

- **Behavioral change**: `validate_inverse_params` and `validate_filter_params` now reject `resolve_supersessions=Some(_)` with an explanatory error. Previously accepted as a silent no-op; this was inconsistent with chain mode which already rejects it explicitly. Error message follows chain mode's explanatory style: `"resolve_supersessions has no effect in {mode} mode — only active entries are returned"`.
- **Regression test**: `test_handle_inverse_deprecated_superseded_entry_absent` — inserts an entry, supersedes it to an active successor that has an incoming Cites edge, calls `inverse`, and asserts the deprecated entry is absent. Includes a new `set_superseded_by` helper (no such helper existed). Three validation unit tests also cover the new rejection behavior.

**#613 — filter mode: `min_age_days` end-to-end integration test**

`max_edge_count=0` was already integration-tested (AC-29). `min_age_days` had no end-to-end path through infra-001. Adds `test_context_graph_filter_min_age_days`: backdates two entries via direct SQLite UPDATE, calls `filter(min_age_days=30, max_edge_count=0)`, and asserts only the old entries are returned.

## Changed files

| File | Change |
|------|--------|
| `crates/unimatrix-server/src/mcp/graph_read_validation.rs` | Reject `resolve_supersessions` in inverse + filter validators |
| `crates/unimatrix-server/src/mcp/graph_read_tests.rs` | 3 validation unit tests for rejection behavior |
| `crates/unimatrix-server/src/mcp/graph_read_inverse_integration_tests.rs` | `set_superseded_by` helper + `test_handle_inverse_deprecated_superseded_entry_absent` |
| `product/test/infra-001/suites/test_tools.py` | `test_context_graph_filter_min_age_days` (#613) |

## Test plan

- [x] 5,146 unit tests pass (0 failed)
- [x] 23/23 integration smoke tests pass
- [x] 185 tools suite tests pass (0 failed, 3 xfailed pre-existing)
- [x] Clippy clean
- [x] Gate 3 validation: PASS (13/13 checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)