### PR TITLE
fix(security): add MAX_EDGES_UPPER debug_assert at fetch_edge_metadata call site (#611)

### DIFF
--- a/crates/unimatrix-server/src/mcp/graph_read_subgraph.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_subgraph.rs
@@ -35,6 +35,13 @@ const DEFAULT_MAX_DEPTH: u8 = 3;
 const MAX_DEPTH_UPPER: u8 = 10;
 const MAX_NODES_UPPER: u32 = 200;
 const DEFAULT_MAX_NODES: u32 = 200;
+/// Upper bound on the number of edges passed to `fetch_edge_metadata`.
+///
+/// `fetch_edge_metadata` builds a SQL OR-chain with one `(source_id = ? AND target_id = ? AND
+/// relation_type = ?)` clause per edge. SQLite's default `SQLITE_MAX_EXPR_DEPTH` is 1000; an
+/// OR-chain of N clauses builds an expression tree roughly N levels deep. Callers must ensure
+/// `collected_edges.len() <= MAX_EDGES_UPPER` before calling `fetch_edge_metadata`.
+const MAX_EDGES_UPPER: usize = 1000;
 
 // ---------------------------------------------------------------------------
 // Entry point
@@ -289,6 +296,12 @@ pub(super) async fn handle_subgraph(
         if collected_edges.is_empty() {
             HashMap::new()
         } else {
+            debug_assert!(
+                collected_edges.len() <= MAX_EDGES_UPPER,
+                "fetch_edge_metadata: OR-chain would exceed MAX_EDGES_UPPER ({} edges, limit {})",
+                collected_edges.len(),
+                MAX_EDGES_UPPER
+            );
             fetch_edge_metadata(store, &collected_edges).await?
         };
 
@@ -378,6 +391,9 @@ async fn fetch_nodes_batch(store: &Store, node_ids: &[u64]) -> Result<Vec<EntryR
 /// Fetches metadata for all collected edges in a single OR-chain SQL query.
 ///
 /// Must only be called when `collected_edges` is non-empty (R-04).
+/// Callers must ensure `edges.len() <= MAX_EDGES_UPPER` to stay within SQLite's
+/// expression depth limit (`SQLITE_MAX_EXPR_DEPTH` ≈ 1000); a `debug_assert!`
+/// at the call site in `handle_subgraph` enforces this contract.
 /// Metadata deserialization: `serde_json::from_str(...).ok()` returns `None`
 /// on malformed JSON without panic (SEC-05).
 async fn fetch_edge_metadata(

--- a/crates/unimatrix-server/src/mcp/graph_read_subgraph_bfs_tests.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_subgraph_bfs_tests.rs
@@ -68,6 +68,19 @@ fn make_supports_edge(source_id: u64, target_id: u64) -> GraphEdgeRow {
     }
 }
 
+fn make_edge(source_id: u64, target_id: u64, relation_type: &str) -> GraphEdgeRow {
+    GraphEdgeRow {
+        source_id,
+        target_id,
+        relation_type: relation_type.to_string(),
+        weight: 1.0,
+        created_at: 0,
+        created_by: String::new(),
+        source: String::new(),
+        bootstrap_only: false,
+    }
+}
+
 fn set_test_graph(handle: &Arc<std::sync::RwLock<TypedGraphState>>, graph: TypedRelationGraph) {
     let mut state = handle.write().expect("write lock");
     state.typed_graph = graph;
@@ -487,5 +500,70 @@ async fn test_bfs_not_truncated_under_cap() {
     assert!(
         !result.unwrap().truncated,
         "small graph must not be truncated"
+    );
+}
+
+#[tokio::test]
+async fn test_bfs_star_topology_near_cap_edges_within_bound() {
+    // Star topology: 1 center node connected to 199 leaf nodes via 3 relation types
+    // (Supports, Informs, RelatedTo) = 199 × 3 = 597 edges.
+    // Near ADR-003's documented ~600 typical density. Verifies:
+    //   - truncated=false (all 200 nodes fit within max_nodes=200)
+    //   - edges.len() <= MAX_EDGES_UPPER (597 << 1000, no OR-chain overflow)
+    //   - no panic from debug_assert at fetch_edge_metadata call site (#611)
+    const CENTER: u64 = 1;
+    const LEAF_COUNT: usize = 199;
+    const MAX_EDGES_UPPER: usize = 1000;
+
+    let (store, _dir) = open_test_store().await;
+    let handle = Arc::new(TypedGraphState::new_handle());
+
+    let mut entries: Vec<_> = vec![make_entry(CENTER)];
+    for leaf in 2u64..=(LEAF_COUNT as u64 + 1) {
+        entries.push(make_entry(leaf));
+    }
+
+    let mut edges: Vec<GraphEdgeRow> = Vec::with_capacity(LEAF_COUNT * 3);
+    for leaf in 2u64..=(LEAF_COUNT as u64 + 1) {
+        edges.push(make_edge(CENTER, leaf, "Supports"));
+        edges.push(make_edge(CENTER, leaf, "Informs"));
+        edges.push(make_edge(CENTER, leaf, "RelatedTo"));
+    }
+    assert_eq!(edges.len(), LEAF_COUNT * 3, "597 edges in fixture");
+
+    let graph = build_typed_relation_graph(&entries, &edges).expect("build star graph");
+    set_test_graph(&handle, graph);
+
+    let params = GraphParams {
+        mode: "subgraph".to_string(),
+        seed_ids: Some(vec![CENTER]),
+        max_nodes: Some(200),
+        max_depth: Some(1),
+        ..Default::default()
+    };
+    let result = handle_subgraph(&store, &handle, &params).await;
+    assert!(
+        result.is_ok(),
+        "star topology must succeed, got: {result:?}"
+    );
+    let resp = result.unwrap();
+
+    assert!(
+        !resp.truncated,
+        "all 200 nodes fit within max_nodes=200; truncated must be false"
+    );
+    assert!(
+        resp.edges.len() <= MAX_EDGES_UPPER,
+        "edges.len()={} must be <= MAX_EDGES_UPPER={}",
+        resp.edges.len(),
+        MAX_EDGES_UPPER
+    );
+    // 597 unique (center→leaf, rel_type) triples expected.
+    assert_eq!(
+        resp.edges.len(),
+        LEAF_COUNT * 3,
+        "expected {} edges, got {}",
+        LEAF_COUNT * 3,
+        resp.edges.len()
     );
 }


### PR DESCRIPTION
## Summary

- Introduces `MAX_EDGES_UPPER: usize = 1000` constant anchored to SQLite's default `SQLITE_MAX_EXPR_DEPTH` limit — makes the implicit OR-chain bound contract explicit and documented
- Adds `debug_assert!(collected_edges.len() <= MAX_EDGES_UPPER, ...)` in `handle_subgraph` before the `fetch_edge_metadata` call (call site, not inside the function — avoids test interference per Unimatrix lesson #4541)
- Updates `fetch_edge_metadata` doc comment to state the caller obligation
- Adds `test_bfs_star_topology_near_cap_edges_within_bound`: 1 center + 199 leaves × 3 relation types = 597 edges, exercises near-ADR-003 density, validates no panic and `edges.len() <= MAX_EDGES_UPPER`

Zero behavioral change in release builds (`debug_assert!` is a no-op). Catches future drift during development and testing.

Closes #611. Identified by security reviewer in vnc-019 PR #610.

## Test plan

- [x] New test `test_bfs_star_topology_near_cap_edges_within_bound` passes (597-edge star graph, no panic)
- [x] Full workspace unit tests: 5147 passed, 0 failed
- [x] Clippy clean (no new warnings in changed files)
- [x] Integration smoke: 23/23 passed
- [x] Integration tools suite: 185 passed, 3 xfailed (pre-existing), 0 failed
- [x] Gate 3 (bug fix validation): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)