### PR TITLE
fix(graph): subgraph and neighbors depth>1 fall back to DB on cold-start (#623)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3483,7 +3483,7 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unimatrix-adapt"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bincode 2.0.1",
  "ndarray",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "unimatrix-core"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "unimatrix-embed"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "approx",
  "dirs",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "unimatrix-engine"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "dirs",
  "nix 0.31.2",
@@ -3542,7 +3542,7 @@ dependencies = [
 
 [[package]]
 name = "unimatrix-learn"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bincode 2.0.1",
  "ndarray",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "unimatrix-observe"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bincode 2.0.1",
  "serde",
@@ -3570,7 +3570,7 @@ dependencies = [
 
 [[package]]
 name = "unimatrix-server"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bincode 2.0.1",
  "clap",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "unimatrix-store"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.1",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "unimatrix-vector"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anndists",
  "hnsw_rs",

--- a/crates/unimatrix-server/src/mcp/graph_read_neighbors.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_neighbors.rs
@@ -1,7 +1,9 @@
 //! Neighbors mode handler for context_graph (vnc-018, ADR-005).
 //!
 //! depth=1 → live SQL on GRAPH_EDGES (always fresh).
-//! depth>1 → BFS over in-memory TypedRelationGraph (tick-window staleness).
+//! depth>1 → BFS over in-memory TypedRelationGraph (tick-window staleness) when warm;
+//!           falls back to live SQL via `neighbors_via_db` when `use_fallback=true`
+//!           (cold-start or cycle-detected) — GH #623.
 //!
 //! Declared as a sub-module of `graph_read.rs` via `#[path]`.
 
@@ -171,6 +173,8 @@ pub(super) async fn handle_neighbors(
         )
         .await?
     };
+    // Note: neighbors_bfs reads use_fallback inside the lock guard and delegates to
+    // neighbors_via_db when use_fallback=true (cold-start / cycle-detected) — GH #623.
 
     Ok(NeighborsResponse { edges })
 }
@@ -224,7 +228,8 @@ async fn neighbors_sql(
 /// depth>1 in-memory BFS path (ADR-005).
 ///
 /// Uses `std::sync::RwLock` (NOT tokio) — TypedGraphStateHandle is std::sync::Arc<RwLock<_>>.
-/// Graph is cloned out from under the lock before any async work (poison-recovered).
+/// Graph and use_fallback are cloned/read out from under the lock before any async work.
+/// When use_fallback=true, delegates to `neighbors_via_db` (GH #623).
 /// Visited set is `HashSet<u64>` keyed by node_id only (AC-11a, R-18).
 async fn neighbors_bfs(
     store: &Store,
@@ -237,18 +242,25 @@ async fn neighbors_bfs(
 ) -> Result<Vec<EdgeRecord>, ErrorData> {
     use petgraph::Direction;
 
-    // Acquire std::sync::RwLock and clone the graph to release the lock before async work.
-    // TypedGraphStateHandle uses std::sync::RwLock — do NOT use .read().await.
-    let graph: TypedRelationGraph = {
+    // Acquire std::sync::RwLock and clone graph + use_fallback to release the lock before
+    // async work. Extract both fields in the same lock guard (GH #623 fix).
+    let (graph, use_fallback): (TypedRelationGraph, bool) = {
         let guard = typed_graph_state.read().unwrap_or_else(|e| e.into_inner());
-        guard.typed_graph.clone()
+        (guard.typed_graph.clone(), guard.use_fallback)
     };
+
+    // When use_fallback=true (cold-start or cycle-detected), typed_graph is empty.
+    // node_index_for(id) returns None, BFS never starts, depth_reached=0 for all seeds.
+    // Delegate to live DB path instead (GH #623).
+    if use_fallback {
+        return neighbors_via_db(store, id, types, direction, depth, resolve_supersessions).await;
+    }
 
     // Find anchor node in the in-memory graph (ADR-008).
     let start_node = match graph.node_index_for(id) {
         Some(idx) => idx,
         None => {
-            // Anchor ID not in current tick's graph (cold-start or genuinely absent).
+            // Anchor ID not in current tick's graph (genuinely absent after warm start).
             // Return empty result — no error (consistent with depth=1 behavior).
             return Ok(vec![]);
         }
@@ -339,6 +351,106 @@ async fn neighbors_bfs(
                         }
                     }
                     // Already visited: skip. Shallowest depth wins (node_id keying invariant).
+                }
+            }
+        }
+    }
+
+    Ok(result_edges)
+}
+
+// ---------------------------------------------------------------------------
+// DB-fallback BFS: neighbors_via_db (GH #623)
+// ---------------------------------------------------------------------------
+
+/// Per-node fan-out cap for DB-fallback BFS (neighbors_via_db).
+///
+/// After each `query_direct_neighbors` call the returned Vec is truncated to this
+/// limit before enqueuing. Mirrors `MAX_DB_NEIGHBORS_PER_NODE` in `graph_read_path.rs`.
+const MAX_DB_NEIGHBORS_PER_NODE: usize = 1000;
+
+/// BFS over live SQL when `use_fallback = true` (cold-start or cycle-detected).
+///
+/// `direction` is forwarded from the caller as-is — never hard-coded to Outgoing
+/// (hard requirement: callers specifying direction="incoming" must get correct results).
+///
+/// Mirrors `path_via_db` in graph_read_path.rs. Key differences:
+/// - Multi-direction support (`direction` parameter forwarded).
+/// - Records both source_id/target_id and direction string on each EdgeRecord.
+/// - Visited set keyed by node_id only (AC-11a, R-18): first encounter wins.
+async fn neighbors_via_db(
+    store: &Store,
+    id: u64,
+    types: &[RelationType],
+    direction: NeighborDirection,
+    depth: u8,
+    resolve_supersessions: bool,
+) -> Result<Vec<EdgeRecord>, ErrorData> {
+    let type_strs: Vec<&str> = types.iter().map(|t| t.as_str()).collect();
+
+    let mut result_edges: Vec<EdgeRecord> = Vec::new();
+    // Visited set keyed by node_id only (AC-11a, R-18).
+    let mut visited: HashSet<u64> = HashSet::new();
+    // Queue: (current_entry_id, current_depth)
+    let mut frontier: VecDeque<(u64, u8)> = VecDeque::new();
+
+    visited.insert(id);
+    frontier.push_back((id, 0));
+
+    while let Some((current_id, current_depth)) = frontier.pop_front() {
+        if current_depth >= depth {
+            continue;
+        }
+
+        // Query live DB — direction is forwarded as-is (hard requirement).
+        let mut raw_neighbors =
+            query_direct_neighbors(store.read_pool_server(), current_id, &type_strs, direction)
+                .await
+                .map_err(|e| {
+                    tracing::error!(current_id, error = %e, "neighbors_via_db: query_direct_neighbors failed");
+                    ErrorData::new(ERROR_INTERNAL, format!("graph query failed: {e}"), None)
+                })?;
+
+        // Fan-out cap: prevent runaway BFS on high-degree nodes.
+        raw_neighbors.truncate(MAX_DB_NEIGHBORS_PER_NODE);
+
+        for row in raw_neighbors {
+            // Determine neighbor_id and direction string from the raw row.
+            let (neighbor_id, edge_dir_str, record_src, record_tgt) = if row.source_id == current_id
+            {
+                // outgoing edge: current_id → row.target_id
+                (row.target_id, "outgoing", current_id, row.target_id)
+            } else {
+                // incoming edge: row.source_id → current_id
+                (row.source_id, "incoming", row.source_id, current_id)
+            };
+
+            // Supersession resolution (ADR-005, R-10).
+            let effective_id = if resolve_supersessions {
+                follow_to_current(store, neighbor_id)
+                    .await
+                    .unwrap_or(neighbor_id)
+            } else {
+                neighbor_id
+            };
+
+            // Visited set keyed by node_id only (AC-11a, R-18).
+            if !visited.contains(&effective_id) {
+                visited.insert(effective_id);
+                let hop_depth = current_depth + 1;
+
+                result_edges.push(EdgeRecord {
+                    source_id: record_src,
+                    target_id: record_tgt,
+                    relation_type: row.relation_type.clone(),
+                    direction: edge_dir_str.to_string(),
+                    depth: hop_depth,
+                    metadata: None,
+                });
+
+                // Enqueue for further expansion if not at max depth.
+                if hop_depth < depth {
+                    frontier.push_back((effective_id, hop_depth));
                 }
             }
         }

--- a/crates/unimatrix-server/src/mcp/graph_read_neighbors_tests.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_neighbors_tests.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use super::super::GraphParams;
 use super::*;
-use unimatrix_store::{PoolConfig, SqlxStore, Status};
+use unimatrix_store::{NewEntry, PoolConfig, SqlxStore, Status};
 
 async fn open_test_store() -> (SqlxStore, tempfile::TempDir) {
     let dir = tempfile::tempdir().expect("temp dir");
@@ -149,6 +149,114 @@ async fn test_handle_neighbors_depth_out_of_range() {
     };
     let result = handle_neighbors(&store_impl, &handle, &params_one, 999_999).await;
     assert!(result.is_ok(), "depth=1 is valid boundary");
+
+    store_impl.close().await.unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// GH #623: neighbors_bfs depth>1 falls back to DB when use_fallback=true
+// ---------------------------------------------------------------------------
+
+/// GH #623 regression: neighbors_bfs depth>1 returns empty when use_fallback=true.
+///
+/// Real SqlxStore, entries A and B with A→B Supports edge in GRAPH_EDGES.
+/// TypedGraphState::new() directly (use_fallback=true, no rebuild).
+/// handle_neighbors(id=A, depth=2) must return at least one edge (B at depth 1).
+#[tokio::test]
+async fn test_neighbors_bfs_use_fallback_true_depth_gt1_falls_back_to_db() {
+    use unimatrix_store::NewEntry;
+
+    let (store_impl, _dir) = open_test_store().await;
+
+    // Step 1: Insert entries A and B.
+    let id_a = store_impl
+        .insert(NewEntry {
+            title: "Entry A".to_string(),
+            content: "content-a".to_string(),
+            topic: "test".to_string(),
+            category: "pattern".to_string(),
+            tags: vec![],
+            source: "test".to_string(),
+            status: Status::Active,
+            created_by: "test".to_string(),
+            feature_cycle: "bugfix-623".to_string(),
+            trust_source: "agent".to_string(),
+        })
+        .await
+        .expect("insert A");
+
+    let id_b = store_impl
+        .insert(NewEntry {
+            title: "Entry B".to_string(),
+            content: "content-b".to_string(),
+            topic: "test".to_string(),
+            category: "pattern".to_string(),
+            tags: vec![],
+            source: "test".to_string(),
+            status: Status::Active,
+            created_by: "test".to_string(),
+            feature_cycle: "bugfix-623".to_string(),
+            trust_source: "agent".to_string(),
+        })
+        .await
+        .expect("insert B");
+
+    // Step 2: Insert A→B Supports edge directly into GRAPH_EDGES.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    sqlx::query(
+        "INSERT OR IGNORE INTO graph_edges
+             (source_id, target_id, relation_type, weight, created_at,
+              created_by, source, bootstrap_only)
+         VALUES (?1, ?2, 'Supports', 1.0, ?3, 'test', '', 0)",
+    )
+    .bind(id_a as i64)
+    .bind(id_b as i64)
+    .bind(now as i64)
+    .execute(store_impl.write_pool_server())
+    .await
+    .expect("insert Supports edge A→B");
+
+    // Step 3: Cold-start state — TypedGraphState::new(), use_fallback=true.
+    let handle = Arc::new(std::sync::RwLock::new(
+        crate::services::typed_graph::TypedGraphState::new(),
+    ));
+    {
+        let guard = handle.read().unwrap_or_else(|e| e.into_inner());
+        assert!(
+            guard.use_fallback,
+            "TypedGraphState::new() must have use_fallback=true"
+        );
+    }
+
+    // Step 4: Call handle_neighbors with id=A, depth=2 — exercises neighbors_bfs path.
+    let params = GraphParams {
+        mode: "neighbors".to_string(),
+        id: Some(id_a),
+        depth: Some(2),
+        edge_types: Some(vec!["Supports".to_string()]),
+        ..Default::default()
+    };
+    let result = handle_neighbors(&store_impl, &handle, &params, id_a).await;
+    assert!(
+        result.is_ok(),
+        "DB-fallback neighbors (depth=2) must return Ok, got: {result:?}"
+    );
+    let resp = result.unwrap();
+
+    // Step 5: Assert at least one edge found (B at depth 1).
+    assert!(
+        !resp.edges.is_empty(),
+        "DB-fallback neighbors_bfs depth>1 must discover A→B Supports edge \
+         when use_fallback=true; got empty. GH #623 regression guard."
+    );
+    let edge = &resp.edges[0];
+    assert_eq!(edge.source_id, id_a, "edge source must be A");
+    assert_eq!(edge.target_id, id_b, "edge target must be B");
+    assert_eq!(edge.relation_type, "Supports");
+    assert_eq!(edge.depth, 1, "B is at depth 1 from A");
 
     store_impl.close().await.unwrap();
 }

--- a/crates/unimatrix-server/src/mcp/graph_read_subgraph.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_subgraph.rs
@@ -4,7 +4,8 @@
 //! for `context_graph` subgraph mode. See IMPLEMENTATION-BRIEF.md §BFS Algorithm Contract.
 //!
 //! # Key invariants (ARCHITECTURE.md, IMPLEMENTATION-BRIEF.md)
-//! - BFS uses `TypedRelationGraph` (in-memory); no SQL fallback for depth > 1 (C-05).
+//! - BFS uses `TypedRelationGraph` (in-memory) when warm; falls back to live SQL when
+//!   `use_fallback=true` (cold-start or cycle-detected) via `subgraph_via_db` (GH #623).
 //! - `visited` set keyed on `effective_id` (post-supersession), not original (R-01).
 //! - Edge dedup uses canonical stored direction `(source_id -> target_id)` (R-02).
 //! - `direction` on all returned `EdgeRecord`s is always `"outgoing"` (FR-12, R-02).
@@ -20,6 +21,7 @@ use petgraph::visit::EdgeRef;
 use rmcp::model::ErrorData;
 use unimatrix_core::{EntryRecord, Store};
 use unimatrix_engine::graph::RelationType;
+use unimatrix_store::{NeighborDirection, query_direct_neighbors};
 
 use crate::error::{ERROR_INTERNAL, ERROR_INVALID_PARAMS};
 use crate::services::typed_graph::TypedGraphState;
@@ -35,6 +37,12 @@ const DEFAULT_MAX_DEPTH: u8 = 3;
 const MAX_DEPTH_UPPER: u8 = 10;
 const MAX_NODES_UPPER: u32 = 200;
 const DEFAULT_MAX_NODES: u32 = 200;
+/// Per-node fan-out cap for DB-fallback BFS (subgraph_via_db).
+///
+/// After each `query_direct_neighbors` call the returned Vec is truncated to this
+/// limit before enqueuing. Mirrors `MAX_DB_NEIGHBORS_PER_NODE` in `graph_read_path.rs`.
+const MAX_DB_NEIGHBORS_PER_NODE: usize = 1000;
+
 /// Upper bound on the number of edges passed to `fetch_edge_metadata`.
 ///
 /// `fetch_edge_metadata` builds a SQL OR-chain with one `(source_id = ? AND target_id = ? AND
@@ -149,11 +157,31 @@ pub(super) async fn handle_subgraph(
 
     let resolve_supersessions = params.resolve_supersessions.unwrap_or(false);
 
-    // Step 2: Acquire graph (lock -> clone -> release before any async work).
-    let graph = {
+    // Step 2: Acquire graph snapshot (lock -> clone -> release) BEFORE any async work.
+    // Extract both typed_graph AND use_fallback in the same lock guard (GH #623).
+    // When use_fallback=true (cold-start or cycle-detected), typed_graph is empty —
+    // node_index_for(seed_id) returns None for all seeds and BFS never starts.
+    // Delegate to subgraph_via_db instead (mirrors path_via_db pattern).
+    let (graph, use_fallback) = {
         let state = typed_graph_state.read().unwrap_or_else(|e| e.into_inner());
-        state.typed_graph.clone()
+        (state.typed_graph.clone(), state.use_fallback)
     };
+
+    // When use_fallback=true the snapshot is empty (cold-start) or stale (cycle-detected).
+    // Fall back to live DB BFS so subgraph mode works immediately after context_edge add
+    // without waiting for the next background tick (GH #623).
+    if use_fallback {
+        return subgraph_via_db(
+            store,
+            &seed_ids,
+            max_depth,
+            max_nodes,
+            &petgraph_dirs,
+            &edge_types,
+            resolve_supersessions,
+        )
+        .await;
+    }
 
     // Step 3: BFS state.
     let mut visited: HashSet<u64> = HashSet::new();
@@ -331,6 +359,197 @@ pub(super) async fn handle_subgraph(
         edges,
         truncated,
         seed_ids,
+        depth_reached,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// DB-fallback BFS: subgraph_via_db (GH #623)
+// ---------------------------------------------------------------------------
+
+/// BFS over live SQL when `use_fallback = true` (cold-start or cycle-detected).
+///
+/// Mirrors `path_via_db` in `graph_read_path.rs` — same pattern, same caveats.
+/// Uses `query_direct_neighbors` with the resolved `NeighborDirection` and the
+/// caller's `edge_types` — both are forwarded as explicit parameters (hard requirement).
+///
+/// Edge dedup via `HashSet<(u64, u64, String)>` preserves the R-02 invariant so that
+/// `direction=both` does not return double edges on the same physical edge.
+/// Post-BFS dangling-edge filter (R-05) is also preserved.
+/// `MAX_EDGES_UPPER` guard applied before `fetch_edge_metadata` (hard requirement).
+///
+/// Per-node fan-out is capped at `MAX_DB_NEIGHBORS_PER_NODE` (same value as
+/// `path_via_db`) to prevent runaway BFS on extremely high-degree nodes.
+async fn subgraph_via_db(
+    store: &Store,
+    seed_ids: &[u64],
+    max_depth: u8,
+    max_nodes: u32,
+    petgraph_dirs: &[PetgraphDirection],
+    edge_types: &[RelationType],
+    resolve_supersessions: bool,
+) -> Result<SubgraphResponse, ErrorData> {
+    let type_strs: Vec<&str> = edge_types.iter().map(|t| t.as_str()).collect();
+    let max_nodes_usize = max_nodes as usize;
+
+    let mut visited: HashSet<u64> = HashSet::new();
+    // Queue: (current_entry_id, current_depth)
+    let mut frontier: VecDeque<(u64, u8)> = VecDeque::new();
+    // (source_id, target_id, relation_type_str, depth)
+    let mut collected_edges: Vec<(u64, u64, String, u8)> = Vec::new();
+    let mut collected_node_ids: Vec<u64> = Vec::new();
+    // Dedup by canonical triple (source_id, target_id, rel_type) (R-02).
+    let mut edge_set: HashSet<(u64, u64, String)> = HashSet::new();
+    let mut truncated = false;
+
+    // Seed phase — mirrors handle_subgraph seed phase.
+    for &seed_id in seed_ids {
+        let effective_id = if resolve_supersessions {
+            follow_to_current(store, seed_id).await.unwrap_or(seed_id)
+        } else {
+            seed_id
+        };
+
+        if visited.contains(&effective_id) {
+            continue;
+        }
+
+        if collected_node_ids.len() >= max_nodes_usize {
+            truncated = true;
+            break;
+        }
+
+        visited.insert(effective_id);
+        collected_node_ids.push(effective_id);
+        frontier.push_back((effective_id, 0));
+    }
+
+    // Post-seed cap check (mirrors handle_subgraph R-03 invariant).
+    if collected_node_ids.len() >= max_nodes_usize {
+        truncated = true;
+    }
+
+    // BFS phase.
+    if !truncated {
+        'bfs: while let Some((current_id, current_depth)) = frontier.pop_front() {
+            if current_depth >= max_depth {
+                continue;
+            }
+
+            for &petgraph_dir in petgraph_dirs {
+                // Map petgraph direction to NeighborDirection for query_direct_neighbors.
+                // `direction` is forwarded from the caller — never hard-coded (hard requirement).
+                let neighbor_dir = match petgraph_dir {
+                    PetgraphDirection::Outgoing => NeighborDirection::Outgoing,
+                    PetgraphDirection::Incoming => NeighborDirection::Incoming,
+                };
+
+                // Query live DB for direct neighbors in this direction.
+                let mut raw_neighbors = query_direct_neighbors(
+                    store.read_pool_server(),
+                    current_id,
+                    &type_strs,
+                    neighbor_dir,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::error!(current_id, error = %e, "subgraph_via_db: query_direct_neighbors failed");
+                    ErrorData::new(ERROR_INTERNAL, format!("graph query failed: {e}"), None)
+                })?;
+
+                // Fan-out cap: prevent runaway BFS on high-degree nodes.
+                raw_neighbors.truncate(MAX_DB_NEIGHBORS_PER_NODE);
+
+                for row in raw_neighbors {
+                    // Canonical edge direction from DB is always (source_id, target_id).
+                    let edge_src = row.source_id;
+                    let edge_tgt = row.target_id;
+                    let rel_type_str = row.relation_type.clone();
+                    let edge_key = (edge_src, edge_tgt, rel_type_str.clone());
+
+                    // Neighbor from traversal perspective.
+                    let neighbor_id = match petgraph_dir {
+                        PetgraphDirection::Outgoing => edge_tgt,
+                        PetgraphDirection::Incoming => edge_src,
+                    };
+
+                    // Supersession resolution on neighbor (R-01).
+                    let effective_neighbor = if resolve_supersessions {
+                        follow_to_current(store, neighbor_id)
+                            .await
+                            .unwrap_or(neighbor_id)
+                    } else {
+                        neighbor_id
+                    };
+
+                    // Dedup edge by canonical stored triple (R-02).
+                    if edge_set.insert(edge_key) {
+                        collected_edges.push((edge_src, edge_tgt, rel_type_str, current_depth + 1));
+                    }
+
+                    // Enqueue neighbor if not yet visited.
+                    if !visited.contains(&effective_neighbor) {
+                        if collected_node_ids.len() >= max_nodes_usize {
+                            truncated = true;
+                            break 'bfs;
+                        }
+                        visited.insert(effective_neighbor);
+                        collected_node_ids.push(effective_neighbor);
+                        frontier.push_back((effective_neighbor, current_depth + 1));
+                    }
+                }
+            }
+        }
+    }
+
+    // Dangling-edge filter (R-05): remove edges whose source or target is not in collected nodes.
+    let node_set: HashSet<u64> = collected_node_ids.iter().copied().collect();
+    collected_edges.retain(|(src, tgt, _, _)| node_set.contains(src) && node_set.contains(tgt));
+
+    // Batch node hydration.
+    let nodes: Vec<EntryRecord> = if collected_node_ids.is_empty() {
+        Vec::new()
+    } else {
+        fetch_nodes_batch(store, &collected_node_ids).await?
+    };
+
+    // Post-BFS metadata batch query.
+    // MAX_EDGES_UPPER guard before fetch_edge_metadata (hard requirement).
+    let metadata_map: HashMap<(u64, u64, String), Option<serde_json::Value>> =
+        if collected_edges.is_empty() {
+            HashMap::new()
+        } else {
+            // Truncate to MAX_EDGES_UPPER before building the OR-chain query.
+            // Excess edges lose metadata but are still present in the response shape.
+            if collected_edges.len() > MAX_EDGES_UPPER {
+                collected_edges.truncate(MAX_EDGES_UPPER);
+            }
+            fetch_edge_metadata(store, &collected_edges).await?
+        };
+
+    let depth_reached: u8 = collected_edges.iter().map(|e| e.3).max().unwrap_or(0);
+
+    let edges: Vec<EdgeRecord> = collected_edges
+        .iter()
+        .map(|(src, tgt, rel_type, depth)| {
+            let meta_key = (*src, *tgt, rel_type.clone());
+            let metadata = metadata_map.get(&meta_key).cloned().flatten();
+            EdgeRecord {
+                source_id: *src,
+                target_id: *tgt,
+                relation_type: rel_type.clone(),
+                direction: "outgoing".to_string(),
+                depth: *depth,
+                metadata,
+            }
+        })
+        .collect();
+
+    Ok(SubgraphResponse {
+        nodes,
+        edges,
+        truncated,
+        seed_ids: seed_ids.to_vec(),
         depth_reached,
     })
 }

--- a/crates/unimatrix-server/src/mcp/graph_read_subgraph.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_subgraph.rs
@@ -520,7 +520,9 @@ async fn subgraph_via_db(
             HashMap::new()
         } else {
             // Truncate to MAX_EDGES_UPPER before building the OR-chain query.
-            // Excess edges lose metadata but are still present in the response shape.
+            // Edges beyond the cap are dropped entirely from the response — they
+            // are absent from both `edges` and the depth_reached computation, so
+            // depth_reached may be understated when the cap fires mid-traversal.
             if collected_edges.len() > MAX_EDGES_UPPER {
                 collected_edges.truncate(MAX_EDGES_UPPER);
             }

--- a/crates/unimatrix-server/src/mcp/graph_read_subgraph_bfs_tests.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_subgraph_bfs_tests.rs
@@ -567,3 +567,206 @@ async fn test_bfs_star_topology_near_cap_edges_within_bound() {
         resp.edges.len()
     );
 }
+
+// ---------------------------------------------------------------------------
+// Section C: DB-fallback (GH #623) — use_fallback=true cold-start regression
+// ---------------------------------------------------------------------------
+
+/// GH #623 regression: subgraph returns depth_reached=0 when use_fallback=true.
+///
+/// Real SqlxStore, entries A and B with A→B Supports edge in GRAPH_EDGES.
+/// TypedGraphState::new() directly (use_fallback=true, no rebuild).
+/// handle_subgraph(seed_ids=[A], max_depth=1) must return edges.len()==1
+/// and depth_reached==1.
+#[tokio::test]
+async fn test_subgraph_use_fallback_true_with_real_entries_falls_back_to_db() {
+    use unimatrix_store::NewEntry;
+
+    let (store, _dir) = open_test_store().await;
+    let store = std::sync::Arc::new(store);
+
+    // Step 1: Insert entries A and B into the real store.
+    let id_a = store
+        .insert(NewEntry {
+            title: "Entry A".to_string(),
+            content: "content-a".to_string(),
+            topic: "test".to_string(),
+            category: "pattern".to_string(),
+            tags: vec![],
+            source: "test".to_string(),
+            status: unimatrix_store::Status::Active,
+            created_by: "test".to_string(),
+            feature_cycle: "bugfix-623".to_string(),
+            trust_source: "agent".to_string(),
+        })
+        .await
+        .expect("insert A");
+
+    let id_b = store
+        .insert(NewEntry {
+            title: "Entry B".to_string(),
+            content: "content-b".to_string(),
+            topic: "test".to_string(),
+            category: "pattern".to_string(),
+            tags: vec![],
+            source: "test".to_string(),
+            status: unimatrix_store::Status::Active,
+            created_by: "test".to_string(),
+            feature_cycle: "bugfix-623".to_string(),
+            trust_source: "agent".to_string(),
+        })
+        .await
+        .expect("insert B");
+
+    // Step 2: Insert A→B Supports edge directly into GRAPH_EDGES via raw SQL.
+    // (Same pattern as crt-035 and bugfix-612 tests.)
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    sqlx::query(
+        "INSERT OR IGNORE INTO graph_edges
+             (source_id, target_id, relation_type, weight, created_at,
+              created_by, source, bootstrap_only)
+         VALUES (?1, ?2, 'Supports', 1.0, ?3, 'test', '', 0)",
+    )
+    .bind(id_a as i64)
+    .bind(id_b as i64)
+    .bind(now as i64)
+    .execute(store.write_pool_server())
+    .await
+    .expect("insert Supports edge A→B");
+
+    // Step 3: Construct TypedGraphState::new() directly — use_fallback=true, no rebuild.
+    let handle = Arc::new(std::sync::RwLock::new(TypedGraphState::new()));
+    {
+        let guard = handle.read().unwrap_or_else(|e| e.into_inner());
+        assert!(
+            guard.use_fallback,
+            "TypedGraphState::new() must have use_fallback=true"
+        );
+    }
+
+    // Step 4: Call handle_subgraph with seed_ids=[A], max_depth=1.
+    let params = GraphParams {
+        mode: "subgraph".to_string(),
+        seed_ids: Some(vec![id_a]),
+        max_depth: Some(1),
+        edge_types: Some(vec!["Supports".to_string()]),
+        ..Default::default()
+    };
+    let result = handle_subgraph(&*store, &handle, &params).await;
+    assert!(
+        result.is_ok(),
+        "DB-fallback subgraph must return Ok, got: {result:?}"
+    );
+    let resp = result.unwrap();
+
+    // Step 5: Assert edges.len()==1 and depth_reached==1.
+    assert_eq!(
+        resp.edges.len(),
+        1,
+        "DB-fallback BFS must discover the A→B Supports edge (use_fallback=true); \
+         got {} edges. This is the GH #623 regression guard.",
+        resp.edges.len()
+    );
+    assert_eq!(
+        resp.depth_reached, 1,
+        "depth_reached must be 1 when A→B edge discovered; got {}. \
+         GH #623: depth_reached=0 was the bug symptom.",
+        resp.depth_reached
+    );
+    assert_eq!(resp.edges[0].source_id, id_a, "edge source must be A");
+    assert_eq!(resp.edges[0].target_id, id_b, "edge target must be B");
+    assert_eq!(resp.edges[0].relation_type, "Supports");
+    assert!(!resp.truncated, "two-node graph must not be truncated");
+}
+
+/// GH #623 regression: direction parameter is forwarded in DB-fallback mode.
+///
+/// Verifies that direction="incoming" works correctly in cold-start state —
+/// hard requirement from the architect's blocking note.
+#[tokio::test]
+async fn test_subgraph_use_fallback_true_direction_incoming_forwarded() {
+    use unimatrix_store::NewEntry;
+
+    let (store, _dir) = open_test_store().await;
+    let store = std::sync::Arc::new(store);
+
+    let id_a = store
+        .insert(NewEntry {
+            title: "Entry A".to_string(),
+            content: "content-a".to_string(),
+            topic: "test".to_string(),
+            category: "pattern".to_string(),
+            tags: vec![],
+            source: "test".to_string(),
+            status: unimatrix_store::Status::Active,
+            created_by: "test".to_string(),
+            feature_cycle: "bugfix-623".to_string(),
+            trust_source: "agent".to_string(),
+        })
+        .await
+        .expect("insert A");
+
+    let id_b = store
+        .insert(NewEntry {
+            title: "Entry B".to_string(),
+            content: "content-b".to_string(),
+            topic: "test".to_string(),
+            category: "pattern".to_string(),
+            tags: vec![],
+            source: "test".to_string(),
+            status: unimatrix_store::Status::Active,
+            created_by: "test".to_string(),
+            feature_cycle: "bugfix-623".to_string(),
+            trust_source: "agent".to_string(),
+        })
+        .await
+        .expect("insert B");
+
+    // Insert A→B Supports edge.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    sqlx::query(
+        "INSERT OR IGNORE INTO graph_edges
+             (source_id, target_id, relation_type, weight, created_at,
+              created_by, source, bootstrap_only)
+         VALUES (?1, ?2, 'Supports', 1.0, ?3, 'test', '', 0)",
+    )
+    .bind(id_a as i64)
+    .bind(id_b as i64)
+    .bind(now as i64)
+    .execute(store.write_pool_server())
+    .await
+    .expect("insert Supports edge A→B");
+
+    let handle = Arc::new(std::sync::RwLock::new(TypedGraphState::new()));
+
+    // Seed on B, direction=incoming — should find A→B via the incoming traversal from B.
+    let params = GraphParams {
+        mode: "subgraph".to_string(),
+        seed_ids: Some(vec![id_b]),
+        max_depth: Some(1),
+        edge_types: Some(vec!["Supports".to_string()]),
+        direction: Some("incoming".to_string()),
+        ..Default::default()
+    };
+    let result = handle_subgraph(&*store, &handle, &params).await;
+    assert!(
+        result.is_ok(),
+        "DB-fallback subgraph (incoming) must return Ok, got: {result:?}"
+    );
+    let resp = result.unwrap();
+    // B seeded with direction=incoming — should find A as a neighbor via A→B incoming edge.
+    assert_eq!(
+        resp.edges.len(),
+        1,
+        "incoming direction must find A→B edge from B's perspective; got {} edges",
+        resp.edges.len()
+    );
+    assert_eq!(resp.depth_reached, 1, "depth_reached must be 1");
+}


### PR DESCRIPTION
## Summary

- `handle_subgraph` and `neighbors_bfs` (depth>1) both read `state.typed_graph` from the `TypedGraphState` lock without checking `state.use_fallback`. When `use_fallback=true` (cold-start or supersession cycle detected), `typed_graph` is an empty `TypedRelationGraph` — BFS never starts, `depth_reached=0` for all seeds.
- Added `subgraph_via_db` and `neighbors_via_db` DB fallback functions mirroring the pattern from `graph_read_path.rs` (GH #612). Both forward `edge_types` and `direction` explicitly, preserve edge dedup, dangling-edge filter, and `MAX_EDGES_UPPER` guard.

## Test plan

- [x] `test_subgraph_use_fallback_true_with_real_entries_falls_back_to_db` — real store, `TypedGraphState::new()` directly (cold-start), assert `edges.len()==1`, `depth_reached==1`
- [x] `test_subgraph_use_fallback_true_direction_incoming_forwarded` — verifies `direction` param is forwarded, not hard-coded
- [x] `test_neighbors_bfs_use_fallback_true_depth_gt1_falls_back_to_db` — equivalent for neighbors
- [x] 3,197 unit tests pass, 0 failures
- [x] 23/23 integration smoke tests pass
- [x] 245 integration tests pass, 8 pre-existing xfailed (unchanged), 1 pre-existing xpass (unrelated, separate follow-up)
- [x] Bugfix gate: PASS (all 11 checks)

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)