### PR TITLE
fix(infra): config categories not authoritative — compiled defaults diverged from config (#632)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -39,7 +39,7 @@ preset = "collaborative"
 # To add custom categories, extend this list — do not remove the built-in values
 # unless you have migrated all existing entries.
 # Default: the 5 built-in categories
-categories = ["lesson-learned", "decision", "convention", "pattern", "procedure"]
+categories = ["lesson-learned", "decision", "convention", "pattern", "procedure", "goal", "feature"]
 
 # Categories that receive an additional ranking boost in search results.
 #

--- a/config.toml
+++ b/config.toml
@@ -38,8 +38,8 @@ preset = "collaborative"
 # Entries using categories not in this list are rejected at write time.
 # To add custom categories, extend this list — do not remove the built-in values
 # unless you have migrated all existing entries.
-# Default: the 5 built-in categories
-categories = ["lesson-learned", "decision", "convention", "pattern", "procedure", "goal", "feature"]
+# Default: the 7 built-in categories
+categories = ["convention", "decision", "feature", "goal", "lesson-learned", "pattern", "procedure"]
 
 # Categories that receive an additional ranking boost in search results.
 #

--- a/crates/unimatrix-observe/src/domain/mod.rs
+++ b/crates/unimatrix-observe/src/domain/mod.rs
@@ -51,12 +51,13 @@ fn builtin_claude_code_pack() -> DomainPack {
             "SubagentStart".to_string(),
             "SubagentStop".to_string(),
         ],
-        // All 5 active INITIAL_CATEGORIES from CategoryAllowlist (C-10).
+        // All 7 active INITIAL_CATEGORIES from CategoryAllowlist (C-10).
         categories: vec![
-            "outcome".to_string(),
-            "lesson-learned".to_string(),
-            "decision".to_string(),
             "convention".to_string(),
+            "decision".to_string(),
+            "feature".to_string(),
+            "goal".to_string(),
+            "lesson-learned".to_string(),
             "pattern".to_string(),
             "procedure".to_string(),
         ],

--- a/crates/unimatrix-observe/tests/domain_pack_tests.rs
+++ b/crates/unimatrix-observe/tests/domain_pack_tests.rs
@@ -282,7 +282,7 @@ fn test_domain_pack_registry_no_runtime_write_path() {
     // If the above compile, the API surface is read-only as required.
 }
 
-/// T-DPR-12: CategoryAllowlist integration — built-in categories include all 5 active ones
+/// T-DPR-12: CategoryAllowlist integration — built-in categories include all 7 active ones
 #[test]
 fn test_builtin_pack_has_all_initial_categories() {
     let registry = DomainPackRegistry::with_builtin_claude_code();
@@ -290,10 +290,11 @@ fn test_builtin_pack_has_all_initial_categories() {
         .lookup("claude-code")
         .expect("claude-code must exist");
     let expected = [
-        "outcome",
-        "lesson-learned",
-        "decision",
         "convention",
+        "decision",
+        "feature",
+        "goal",
+        "lesson-learned",
         "pattern",
         "procedure",
     ];
@@ -303,7 +304,11 @@ fn test_builtin_pack_has_all_initial_categories() {
             "claude-code pack must include category '{cat}'"
         );
     }
-    // Removed in bugfix-436: duties and reference were stale categories.
+    // Retired categories must NOT be present.
+    assert!(
+        !pack.categories.contains(&"outcome".to_string()),
+        "claude-code pack must not include retired category 'outcome'"
+    );
     assert!(
         !pack.categories.contains(&"duties".to_string()),
         "claude-code pack must not include retired category 'duties'"

--- a/crates/unimatrix-server/src/infra/categories/mod.rs
+++ b/crates/unimatrix-server/src/infra/categories/mod.rs
@@ -12,10 +12,12 @@ use std::sync::RwLock;
 
 use crate::error::ServerError;
 
-pub(crate) const INITIAL_CATEGORIES: [&str; 5] = [
-    "lesson-learned",
-    "decision",
+pub(crate) const INITIAL_CATEGORIES: [&str; 7] = [
     "convention",
+    "decision",
+    "feature",
+    "goal",
+    "lesson-learned",
     "pattern",
     "procedure",
 ];

--- a/crates/unimatrix-server/src/infra/categories/tests.rs
+++ b/crates/unimatrix-server/src/infra/categories/tests.rs
@@ -42,6 +42,18 @@ fn test_validate_procedure() {
 }
 
 #[test]
+fn test_validate_goal() {
+    let al = CategoryAllowlist::new();
+    assert!(al.validate("goal").is_ok());
+}
+
+#[test]
+fn test_validate_feature() {
+    let al = CategoryAllowlist::new();
+    assert!(al.validate("feature").is_ok());
+}
+
+#[test]
 fn test_validate_duties() {
     let al = CategoryAllowlist::new();
     assert!(al.validate("duties").is_err());
@@ -63,7 +75,7 @@ fn test_validate_unknown_rejected() {
             valid_categories,
         } => {
             assert_eq!(category, "unknown");
-            assert_eq!(valid_categories.len(), 5);
+            assert_eq!(valid_categories.len(), 7);
         }
         _ => panic!("expected InvalidCategory"),
     }
@@ -93,7 +105,7 @@ fn test_add_category_then_validate() {
 fn test_list_categories_sorted() {
     let al = CategoryAllowlist::new();
     let list = al.list_categories();
-    assert_eq!(list.len(), 5);
+    assert_eq!(list.len(), 7);
     // Verify sorted
     for i in 1..list.len() {
         assert!(list[i] >= list[i - 1]);
@@ -110,11 +122,13 @@ fn test_error_lists_all_valid_categories() {
         } => {
             assert!(valid_categories.contains(&"convention".to_string()));
             assert!(valid_categories.contains(&"decision".to_string()));
+            assert!(valid_categories.contains(&"feature".to_string()));
+            assert!(valid_categories.contains(&"goal".to_string()));
             assert!(valid_categories.contains(&"lesson-learned".to_string()));
-            // ADR-005: "outcome" retired — must not appear in the valid-categories list.
-            assert!(!valid_categories.contains(&"outcome".to_string()));
             assert!(valid_categories.contains(&"pattern".to_string()));
             assert!(valid_categories.contains(&"procedure".to_string()));
+            // ADR-005: "outcome" retired — must not appear in the valid-categories list.
+            assert!(!valid_categories.contains(&"outcome".to_string()));
             // Removed in bugfix-436: duties and reference were stale categories.
             assert!(!valid_categories.contains(&"duties".to_string()));
             assert!(!valid_categories.contains(&"reference".to_string()));
@@ -173,11 +187,11 @@ fn test_poison_recovery_list_categories() {
     poison_allowlist(&al);
     // list_categories() should recover and return valid data.
     let list = al.list_categories();
-    // Should have initial 5 + "pre-panic-insert" from the poisoning thread.
+    // Should have initial 7 + "pre-panic-insert" from the poisoning thread.
     // ADR-005: "outcome" is no longer a default category.
     assert!(!list.contains(&"outcome".to_string()));
     assert!(list.contains(&"convention".to_string()));
-    assert!(list.len() >= 5);
+    assert!(list.len() >= 7);
 }
 
 #[test]
@@ -304,14 +318,14 @@ fn test_from_categories_empty_list_accepts_nothing() {
 
 // --- crt-025 ADR-005: outcome category retirement tests ---
 
-/// AC-15, FR-08.2: CategoryAllowlist::new() must have exactly 5 categories.
+/// AC-15, FR-08.2: CategoryAllowlist::new() must have exactly 7 categories.
 #[test]
-fn test_category_allowlist_has_five_categories() {
+fn test_category_allowlist_has_seven_categories() {
     let al = CategoryAllowlist::new();
     assert_eq!(
         al.list_categories().len(),
-        5,
-        "INITIAL_CATEGORIES must contain exactly 5 entries after duties and reference removal"
+        7,
+        "INITIAL_CATEGORIES must contain exactly 7 entries (goal and feature added)"
     );
 }
 
@@ -336,27 +350,21 @@ fn test_outcome_category_validate_err() {
             valid_categories,
         } => {
             assert_eq!(category, "outcome");
-            assert_eq!(valid_categories.len(), 5);
+            assert_eq!(valid_categories.len(), 7);
             assert!(!valid_categories.contains(&"outcome".to_string()));
         }
         _ => panic!("expected InvalidCategory error for retired category"),
     }
 }
 
-/// R-03: All 5 remaining categories validate successfully (regression guard).
+/// R-03: All 7 categories validate successfully (regression guard).
 #[test]
-fn test_all_remaining_five_categories_valid() {
+fn test_all_remaining_categories_valid() {
     let al = CategoryAllowlist::new();
-    for cat in &[
-        "lesson-learned",
-        "decision",
-        "convention",
-        "pattern",
-        "procedure",
-    ] {
+    for cat in &INITIAL_CATEGORIES {
         assert!(
             al.validate(cat).is_ok(),
-            "category '{}' must still be valid after duties and reference removal",
+            "category '{}' must be valid (present in INITIAL_CATEGORIES)",
             cat
         );
     }

--- a/crates/unimatrix-server/src/infra/config.rs
+++ b/crates/unimatrix-server/src/infra/config.rs
@@ -151,7 +151,7 @@ pub fn default_boosted_categories_set() -> HashSet<String> {
 #[derive(Debug, Clone, PartialEq, serde::Deserialize)]
 #[serde(default)]
 pub struct KnowledgeConfig {
-    /// Allowed entry categories. Default: the 5 INITIAL_CATEGORIES.
+    /// Allowed entry categories. Default: the 7 INITIAL_CATEGORIES.
     pub categories: Vec<String>,
     /// Categories that receive a provenance boost in search re-ranking.
     /// Default (serde): `["lesson-learned"]`. Default (Rust `Default` impl): `[]`.
@@ -3085,10 +3085,10 @@ pub static DEFAULT_CONFIG_TOML: &str = r#"# Unimatrix configuration file.
 # [knowledge] — categories and freshness configuration
 # ---------------------------------------------------------------------------
 [knowledge]
-# Allowed entry categories. Defaults are the 5 built-in INITIAL_CATEGORIES.
+# Allowed entry categories. Defaults are the 7 built-in INITIAL_CATEGORIES.
 # Each entry: lowercase letters (a-z), digits (0-9), hyphens (-), underscores (_).
 # Maximum 64 entries; each at most 64 characters.
-# categories = ["decision", "convention", "pattern", "lesson-learned", "procedure"]
+# categories = ["convention", "decision", "feature", "goal", "lesson-learned", "pattern", "procedure"]
 
 # Categories that receive a provenance boost in search re-ranking.
 # Must be a subset of categories above.

--- a/crates/unimatrix-server/src/main.rs
+++ b/crates/unimatrix-server/src/main.rs
@@ -481,7 +481,11 @@ async fn tokio_main_daemon(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 cfg
             }
             Err(e) => {
-                tracing::warn!(error = %e, "config load failed; using compiled defaults");
+                tracing::error!(
+                    error = %e,
+                    "CONFIG LOAD FAILED: {e} — falling back to compiled defaults. \
+                     Review the config file for syntax errors."
+                );
                 UnimatrixConfig::default()
             }
         },
@@ -880,7 +884,11 @@ async fn tokio_main_stdio(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 cfg
             }
             Err(e) => {
-                tracing::warn!(error = %e, "config load failed; using compiled defaults");
+                tracing::error!(
+                    error = %e,
+                    "CONFIG LOAD FAILED: {e} — falling back to compiled defaults. \
+                     Review the config file for syntax errors."
+                );
                 UnimatrixConfig::default()
             }
         },

--- a/product/test/infra-001/harness/generators.py
+++ b/product/test/infra-001/harness/generators.py
@@ -11,10 +11,11 @@ from typing import Any
 
 
 CATEGORIES = [
-    "outcome",
-    "lesson-learned",
-    "decision",
     "convention",
+    "decision",
+    "feature",
+    "goal",
+    "lesson-learned",
     "pattern",
     "procedure",
 ]


### PR DESCRIPTION
## Summary

Fixes #632 — daemon rejected `goal` and `feature` categories despite `config.toml` listing them as valid.

**Root cause**: Compound bug — (1) stray character in per-project config caused TOML parse failure, (2) parse failure silently swallowed at `warn!` level falling back to compiled defaults, (3) `INITIAL_CATEGORIES` lacked `goal`/`feature`, (4) `builtin_claude_code_pack()` still listed retired `outcome` category.

**Fix**:
- Expanded `INITIAL_CATEGORIES` from 5 to 7 (added `goal`, `feature`)
- Removed retired `outcome` from `builtin_claude_code_pack()`, added `goal`/`feature`
- Upgraded config parse error logging from `warn!` to `error!` with full path/detail
- Updated all 5 lockstep locations per lesson #4583 (categories/mod.rs, config.rs, domain/mod.rs, config.toml, generators.py)
- New tests: `test_validate_goal`, `test_validate_feature`

## Test plan

- [x] 4,943 unit tests pass (0 failures)
- [x] 277 integration tests pass (0 failures)
- [x] Clippy clean (only pre-existing warnings in untouched files)
- [x] Smoke suite 23/23
- [x] New bug-specific tests verify goal/feature categories accepted
- [x] Gate validation: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)