### PR TITLE
fix(server): prevent integration tests from leaking dirs into ~/.unimatrix (#640)

### DIFF
--- a/crates/unimatrix-server/src/export.rs
+++ b/crates/unimatrix-server/src/export.rs
@@ -27,8 +27,29 @@ pub fn run_export(
     project_dir: Option<&Path>,
     output: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    run_export_inner(project_dir, output, None)
+}
+
+/// Run the export subcommand with an explicit `base_dir` for test isolation.
+///
+/// Identical to [`run_export`] but routes data storage to the given `base_dir`
+/// instead of `~/.unimatrix/`. Use this in tests to avoid leaking directories
+/// into the user's home directory.
+pub fn run_export_with_base(
+    project_dir: Option<&Path>,
+    output: Option<&Path>,
+    base_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    run_export_inner(project_dir, output, Some(base_dir))
+}
+
+fn run_export_inner(
+    project_dir: Option<&Path>,
+    output: Option<&Path>,
+    base_dir: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // 1. Resolve project paths
-    let paths = project::ensure_data_directory(project_dir, None)?;
+    let paths = project::ensure_data_directory(project_dir, base_dir)?;
 
     // 2. Bridge async to sync: use block_in_place when inside a tokio runtime
     //    (e.g. called from tests), otherwise create a temporary runtime.

--- a/crates/unimatrix-server/src/import/mod.rs
+++ b/crates/unimatrix-server/src/import/mod.rs
@@ -56,6 +56,37 @@ pub fn run_import(
     skip_hash_validation: bool,
     force: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    run_import_inner(project_dir, input, skip_hash_validation, force, None)
+}
+
+/// Run the import pipeline with an explicit `base_dir` for test isolation.
+///
+/// Identical to [`run_import`] but routes data storage to the given `base_dir`
+/// instead of `~/.unimatrix/`. Use this in tests to avoid leaking directories
+/// into the user's home directory.
+pub fn run_import_with_base(
+    project_dir: Option<&Path>,
+    input: &Path,
+    skip_hash_validation: bool,
+    force: bool,
+    base_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    run_import_inner(
+        project_dir,
+        input,
+        skip_hash_validation,
+        force,
+        Some(base_dir),
+    )
+}
+
+fn run_import_inner(
+    project_dir: Option<&Path>,
+    input: &Path,
+    skip_hash_validation: bool,
+    force: bool,
+    base_dir: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) => {
             // Already inside an async runtime — use block_in_place to avoid nesting.
@@ -65,6 +96,7 @@ pub fn run_import(
                     input,
                     skip_hash_validation,
                     force,
+                    base_dir,
                 ))
             })
         }
@@ -79,6 +111,7 @@ pub fn run_import(
                 input,
                 skip_hash_validation,
                 force,
+                base_dir,
             ))
         }
     }
@@ -90,9 +123,10 @@ async fn run_import_async(
     input: &Path,
     skip_hash_validation: bool,
     force: bool,
+    base_dir: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Phase 1: Setup
-    let paths = project::ensure_data_directory(project_dir, None)?;
+    let paths = project::ensure_data_directory(project_dir, base_dir)?;
     let store = Arc::new(
         SqlxStore::open(
             &paths.db_path,
@@ -465,15 +499,22 @@ mod tests {
     /// unimatrix-store/src/migration.rs. Update when the schema advances.
     const CURRENT_SCHEMA_VERSION: i64 = 12;
 
-    /// Create a project dir structure and return it.
+    /// Create a project dir structure with an isolated base_dir and return both.
     ///
     /// Does NOT open a SqlxStore — run_import will create and migrate the database
     /// on first use. This avoids holding a pool connection that would conflict with
     /// run_import's BEGIN IMMEDIATE when both try to write the same SQLite file.
-    fn make_project_dir() -> TempDir {
+    fn make_project_dir() -> (TempDir, TempDir) {
         let project_dir = TempDir::new().expect("create project temp dir");
-        project::ensure_data_directory(Some(project_dir.path()), None).unwrap();
-        project_dir
+        let base_dir = TempDir::new().expect("create base temp dir");
+        let paths = project::ensure_data_directory(Some(project_dir.path()), Some(base_dir.path()))
+            .unwrap();
+        // Meta-assertion: data_dir must live inside base_dir (GH#640 guard).
+        assert!(
+            paths.data_dir.starts_with(base_dir.path()),
+            "data_dir must be inside base_dir to prevent home directory leaks"
+        );
+        (project_dir, base_dir)
     }
 
     async fn open_test_store_at(db_path: &Path) -> SqlxStore {
@@ -562,13 +603,19 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_validate_header_bad_format_version() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
         let output_dir = TempDir::new().unwrap();
         let lines = vec![make_header(sv, 2, 0)];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("2"), "should mention version 2: {err}");
@@ -577,12 +624,18 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_validate_header_future_schema_version() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let output_dir = TempDir::new().unwrap();
         let lines = vec![make_header(999, 1, 0)];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -602,13 +655,19 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_validate_header_format_version_zero() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
         let output_dir = TempDir::new().unwrap();
         let lines = vec![make_header(sv, 0, 0)];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("0"), "should mention version 0: {err}");
@@ -618,7 +677,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_hash_validation_valid_chain() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
 
         let hash_a = compute_content_hash("Entry A", "Content A");
@@ -632,13 +691,19 @@ mod tests {
         ];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(result.is_ok(), "valid chain should pass: {result:?}");
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_hash_validation_broken_chain() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
 
         let output_dir = TempDir::new().unwrap();
@@ -650,7 +715,13 @@ mod tests {
         ];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("1"), "should mention entry ID: {err}");
@@ -662,7 +733,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_hash_validation_content_mismatch() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
 
         // Build entry with wrong content_hash
@@ -679,7 +750,13 @@ mod tests {
         ];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("1"), "should mention entry ID: {err}");
@@ -688,7 +765,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_hash_validation_empty_previous_hash() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
 
         let output_dir = TempDir::new().unwrap();
@@ -700,7 +777,13 @@ mod tests {
         ];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(
             result.is_ok(),
             "empty previous_hash should pass: {result:?}"
@@ -709,7 +792,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_hash_validation_empty_title_edge_case() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
 
         let output_dir = TempDir::new().unwrap();
@@ -721,13 +804,19 @@ mod tests {
         ];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(result.is_ok(), "empty title should pass: {result:?}");
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_hash_validation_empty_both() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
 
         let output_dir = TempDir::new().unwrap();
@@ -739,7 +828,13 @@ mod tests {
         ];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(
             result.is_ok(),
             "empty title+content should pass: {result:?}"
@@ -750,7 +845,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_malformed_jsonl_line_with_line_number() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
 
         let output_dir = TempDir::new().unwrap();
@@ -764,7 +859,13 @@ mod tests {
         ];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("line 5"), "should mention line 5: {err}");
@@ -782,7 +883,7 @@ mod tests {
     /// Handle::try_current() returns Err and the new runtime path is taken.
     #[test]
     fn test_run_import_no_ambient_runtime_does_not_panic() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
 
         let output_dir = TempDir::new().unwrap();
@@ -796,7 +897,13 @@ mod tests {
 
         // Must not panic. The import succeeds (embedding may fail if model is
         // unavailable, but that is an Err return — not a panic).
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         // The important invariant: no panic occurred. Accept Ok or Err.
         // If the ONNX model is present this will be Ok; in CI without the model
         // it returns Err from embed_reconstruct, which is acceptable.
@@ -821,12 +928,20 @@ mod tests {
     #[test]
     fn test_empty_file_errors() {
         let project_dir = TempDir::new().expect("create project temp dir");
-        let _ = project::ensure_data_directory(Some(project_dir.path()), None).unwrap();
+        let base_dir = TempDir::new().expect("create base temp dir");
+        let _ = project::ensure_data_directory(Some(project_dir.path()), Some(base_dir.path()))
+            .unwrap();
         let output_dir = TempDir::new().unwrap();
         let path = output_dir.path().join("empty.jsonl");
         File::create(&path).unwrap();
 
-        let result = run_import(Some(project_dir.path()), &path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -837,14 +952,20 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_header_only_file() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
 
         let output_dir = TempDir::new().unwrap();
         let lines = vec![make_header(sv, 1, 0)];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, false, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            false,
+            false,
+            base_dir.path(),
+        );
         assert!(
             result.is_ok(),
             "header-only should be valid empty import: {result:?}"
@@ -855,11 +976,12 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sql_injection_in_title() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
-        let db_path = project::ensure_data_directory(Some(project_dir.path()), None)
-            .unwrap()
-            .db_path;
+        let db_path =
+            project::ensure_data_directory(Some(project_dir.path()), Some(base_dir.path()))
+                .unwrap()
+                .db_path;
 
         let malicious_title = "'; DROP TABLE entries; --";
         let output_dir = TempDir::new().unwrap();
@@ -871,11 +993,12 @@ mod tests {
         ];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(
+        let result = run_import_with_base(
             Some(project_dir.path()),
             &input_path,
             true, // skip hash -- hash won't match the SQL injection string
             false,
+            base_dir.path(),
         );
         assert!(
             result.is_ok(),
@@ -902,11 +1025,12 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sql_injection_in_content() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
-        let db_path = project::ensure_data_directory(Some(project_dir.path()), None)
-            .unwrap()
-            .db_path;
+        let db_path =
+            project::ensure_data_directory(Some(project_dir.path()), Some(base_dir.path()))
+                .unwrap()
+                .db_path;
 
         let malicious = "Robert'); DROP TABLE entries;--";
         let output_dir = TempDir::new().unwrap();
@@ -918,7 +1042,13 @@ mod tests {
         ];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, true, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            true,
+            false,
+            base_dir.path(),
+        );
         assert!(
             result.is_ok(),
             "SQL injection in content should be safe: {result:?}"
@@ -937,7 +1067,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_duplicate_entry_ids() {
-        let project_dir = make_project_dir();
+        let (project_dir, base_dir) = make_project_dir();
         let sv = CURRENT_SCHEMA_VERSION;
 
         let output_dir = TempDir::new().unwrap();
@@ -950,7 +1080,13 @@ mod tests {
         ];
         let input_path = write_jsonl(&output_dir, &lines);
 
-        let result = run_import(Some(project_dir.path()), &input_path, true, false);
+        let result = run_import_with_base(
+            Some(project_dir.path()),
+            &input_path,
+            true,
+            false,
+            base_dir.path(),
+        );
         assert!(result.is_err(), "duplicate PK should fail");
     }
 }

--- a/crates/unimatrix-server/src/snapshot.rs
+++ b/crates/unimatrix-server/src/snapshot.rs
@@ -52,8 +52,29 @@ pub fn run_snapshot(
     project_dir: Option<&Path>,
     out: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    run_snapshot_inner(project_dir, out, None)
+}
+
+/// Produce a snapshot with an explicit `base_dir` for test isolation.
+///
+/// Identical to [`run_snapshot`] but routes data storage to the given `base_dir`
+/// instead of `~/.unimatrix/`. Use this in tests to avoid leaking directories
+/// into the user's home directory.
+pub fn run_snapshot_with_base(
+    project_dir: Option<&Path>,
+    out: &Path,
+    base_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    run_snapshot_inner(project_dir, out, Some(base_dir))
+}
+
+fn run_snapshot_inner(
+    project_dir: Option<&Path>,
+    out: &Path,
+    base_dir: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // 1. Resolve project paths.
-    let paths = project::ensure_data_directory(project_dir, None)?;
+    let paths = project::ensure_data_directory(project_dir, base_dir)?;
 
     // 2. Live-DB path guard (C-13, FR-04, NFR-06, ADR-001).
     let active_db = std::fs::canonicalize(&paths.db_path).map_err(|e| {
@@ -290,13 +311,18 @@ mod tests {
 
     // ---------------------------------------------------------------------------
     // Helper: resolve the db_path that ensure_data_directory will assign for a
-    // given project_dir without requiring the DB to exist. The data directory
-    // is created by ensure_data_directory; the DB file itself is NOT.
+    // given project_dir and base_dir without requiring the DB to exist. The data
+    // directory is created by ensure_data_directory; the DB file itself is NOT.
     // ---------------------------------------------------------------------------
-    fn resolve_db_path(project_dir: &Path) -> PathBuf {
-        project::ensure_data_directory(Some(project_dir), None)
-            .expect("ensure_data_directory should succeed")
-            .db_path
+    fn resolve_db_path(project_dir: &Path, base_dir: &Path) -> PathBuf {
+        let paths = project::ensure_data_directory(Some(project_dir), Some(base_dir))
+            .expect("ensure_data_directory should succeed");
+        // Meta-assertion: data_dir must live inside base_dir (GH#640 guard).
+        assert!(
+            paths.data_dir.starts_with(base_dir),
+            "data_dir must be inside base_dir to prevent home directory leaks"
+        );
+        paths.db_path
     }
 
     // ---------------------------------------------------------------------------
@@ -305,13 +331,14 @@ mod tests {
     #[test]
     fn test_snapshot_path_guard_same_path() {
         let dir = TempDir::new().unwrap();
-        // Resolve the db_path that run_snapshot will use for this project dir.
-        let db_path = resolve_db_path(dir.path());
+        let base = TempDir::new().unwrap();
+        // Resolve the db_path that run_snapshot_with_base will use for this project dir.
+        let db_path = resolve_db_path(dir.path(), base.path());
         // Create the DB file so canonicalize succeeds on the source side.
         create_stub_file(&db_path);
 
         // Pass the same path as `out` — guard must reject it.
-        let result = run_snapshot(Some(dir.path()), &db_path);
+        let result = run_snapshot_with_base(Some(dir.path()), &db_path, base.path());
         assert!(result.is_err(), "expected path guard to reject same path");
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -335,14 +362,15 @@ mod tests {
     #[cfg(unix)]
     fn test_snapshot_path_guard_symlink() {
         let dir = TempDir::new().unwrap();
-        let db_path = resolve_db_path(dir.path());
+        let base = TempDir::new().unwrap();
+        let db_path = resolve_db_path(dir.path(), base.path());
         create_stub_file(&db_path);
 
         // Create a symlink in the temp dir pointing at the active DB.
         let symlink_path = dir.path().join("link.db");
         std::os::unix::fs::symlink(&db_path, &symlink_path).unwrap();
 
-        let result = run_snapshot(Some(dir.path()), &symlink_path);
+        let result = run_snapshot_with_base(Some(dir.path()), &symlink_path, base.path());
         assert!(result.is_err(), "expected symlink guard to reject");
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -357,12 +385,13 @@ mod tests {
     #[test]
     fn test_snapshot_parent_dir_missing() {
         let dir = TempDir::new().unwrap();
-        let db_path = resolve_db_path(dir.path());
+        let base = TempDir::new().unwrap();
+        let db_path = resolve_db_path(dir.path(), base.path());
         create_stub_file(&db_path);
 
         // Output path whose parent does not exist.
         let missing_parent = dir.path().join("nonexistent_parent").join("snap.db");
-        let result = run_snapshot(Some(dir.path()), &missing_parent);
+        let result = run_snapshot_with_base(Some(dir.path()), &missing_parent, base.path());
         assert!(result.is_err(), "expected error for missing parent dir");
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -383,9 +412,10 @@ mod tests {
         // Use a fresh temp dir — ensure_data_directory will create the data directory
         // but NOT the unimatrix.db file, so canonicalize on paths.db_path will fail.
         let dir = TempDir::new().unwrap();
+        let base = TempDir::new().unwrap();
         let out = dir.path().join("snap.db");
 
-        let result = run_snapshot(Some(dir.path()), &out);
+        let result = run_snapshot_with_base(Some(dir.path()), &out, base.path());
         assert!(
             result.is_err(),
             "expected error when source DB does not exist"

--- a/crates/unimatrix-server/tests/export_integration.rs
+++ b/crates/unimatrix-server/tests/export_integration.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use serde_json::Value;
 use tempfile::TempDir;
-use unimatrix_server::export::run_export;
+use unimatrix_server::export::{run_export, run_export_with_base};
 use unimatrix_server::project;
 use unimatrix_store::SqlxStore;
 
@@ -17,15 +17,23 @@ use unimatrix_store::SqlxStore;
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Set up a project directory and return (project_dir, db_path).
+/// Set up a project directory with an isolated base_dir and return
+/// (project_dir, base_dir, db_path).
 ///
-/// Uses `base_dir=None` so the database is resolved to `~/.unimatrix/{hash}/`,
-/// matching what `run_export` does internally. Each temp dir has a unique path
-/// hash so tests do not collide.
-fn setup_project() -> (TempDir, std::path::PathBuf) {
+/// Uses an explicit `base_dir` TempDir so the database is resolved inside a
+/// temporary directory rather than `~/.unimatrix/`. This prevents test runs
+/// from leaking orphaned hash directories into the user's home directory.
+fn setup_project() -> (TempDir, TempDir, std::path::PathBuf) {
     let project_dir = TempDir::new().expect("create project temp dir");
-    let paths = project::ensure_data_directory(Some(project_dir.path()), None).unwrap();
-    (project_dir, paths.db_path)
+    let base_dir = TempDir::new().expect("create base temp dir");
+    let paths =
+        project::ensure_data_directory(Some(project_dir.path()), Some(base_dir.path())).unwrap();
+    // Meta-assertion: data_dir must live inside base_dir (GH#640 guard).
+    assert!(
+        paths.data_dir.starts_with(base_dir.path()),
+        "data_dir must be inside base_dir to prevent home directory leaks"
+    );
+    (project_dir, base_dir, paths.db_path)
 }
 
 /// Open a SqlxStore synchronously from a db_path (for use in sync test helpers).
@@ -42,9 +50,11 @@ fn open_store(db_path: &Path) -> SqlxStore {
 }
 
 /// Run export to a buffer by writing to a file then reading it back.
-/// Returns the raw output string.
-fn run_export_to_string(project_dir: &Path, output_file: &Path) -> String {
-    run_export(Some(project_dir), Some(output_file)).expect("run_export should succeed");
+/// Returns the raw output string. Uses `run_export_with_base` to keep
+/// all test data inside `base_dir`.
+fn run_export_to_string(project_dir: &Path, base_dir: &Path, output_file: &Path) -> String {
+    run_export_with_base(Some(project_dir), Some(output_file), base_dir)
+        .expect("run_export_with_base should succeed");
     std::fs::read_to_string(output_file).expect("read output file")
 }
 
@@ -167,7 +177,7 @@ async fn populate_representative_data(pool: &sqlx::SqlitePool) {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_full_export_representative_data() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -178,7 +188,7 @@ fn test_full_export_representative_data() {
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("export.jsonl");
-    let output = run_export_to_string(project_dir.path(), &output_path);
+    let output = run_export_to_string(project_dir.path(), base_dir.path(), &output_path);
     let lines = parse_lines(&output);
 
     // Header present
@@ -232,14 +242,14 @@ fn test_full_export_representative_data() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_empty_database_export() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     // Just opening the store creates the schema
     let _store = open_store(&db_path);
     drop(_store);
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("export.jsonl");
-    let output = run_export_to_string(project_dir.path(), &output_path);
+    let output = run_export_to_string(project_dir.path(), base_dir.path(), &output_path);
     let lines = parse_lines(&output);
 
     // Header present with entry_count: 0
@@ -265,7 +275,7 @@ fn test_empty_database_export() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_deterministic_output() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -280,7 +290,7 @@ fn test_deterministic_output() {
     let mut outputs: Vec<String> = Vec::new();
     for i in 0..3 {
         let output_path = output_dir.path().join(format!("export_{i}.jsonl"));
-        let output = run_export_to_string(project_dir.path(), &output_path);
+        let output = run_export_to_string(project_dir.path(), base_dir.path(), &output_path);
         outputs.push(output);
     }
 
@@ -318,7 +328,7 @@ fn test_deterministic_output() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_excluded_tables_not_present() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -342,7 +352,7 @@ fn test_excluded_tables_not_present() {
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("export.jsonl");
-    let output = run_export_to_string(project_dir.path(), &output_path);
+    let output = run_export_to_string(project_dir.path(), base_dir.path(), &output_path);
     let lines = parse_lines(&output);
 
     let allowed: HashSet<&str> = [
@@ -373,7 +383,7 @@ fn test_excluded_tables_not_present() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_table_emission_order() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -384,7 +394,7 @@ fn test_table_emission_order() {
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("export.jsonl");
-    let output = run_export_to_string(project_dir.path(), &output_path);
+    let output = run_export_to_string(project_dir.path(), base_dir.path(), &output_path);
     let lines = parse_lines(&output);
 
     // Collect unique _table values in order of first appearance
@@ -419,7 +429,7 @@ fn test_table_emission_order() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_row_ordering_within_tables() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -463,7 +473,7 @@ fn test_row_ordering_within_tables() {
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("export.jsonl");
-    let output = run_export_to_string(project_dir.path(), &output_path);
+    let output = run_export_to_string(project_dir.path(), base_dir.path(), &output_path);
     let lines = parse_lines(&output);
 
     // Entries ordered by id
@@ -522,7 +532,7 @@ fn test_row_ordering_within_tables() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_output_file_path() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -535,7 +545,12 @@ fn test_output_file_path() {
     let output_path = output_dir.path().join("export.jsonl");
     assert!(!output_path.exists(), "Output file should not exist yet");
 
-    run_export(Some(project_dir.path()), Some(&output_path)).expect("export should succeed");
+    run_export_with_base(
+        Some(project_dir.path()),
+        Some(&output_path),
+        base_dir.path(),
+    )
+    .expect("export should succeed");
 
     assert!(output_path.exists(), "Output file should have been created");
     let content = std::fs::read_to_string(&output_path).unwrap();
@@ -550,7 +565,7 @@ fn test_output_file_path() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_header_validation() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -565,7 +580,7 @@ fn test_header_validation() {
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("export.jsonl");
-    let output = run_export_to_string(project_dir.path(), &output_path);
+    let output = run_export_to_string(project_dir.path(), base_dir.path(), &output_path);
     let lines = parse_lines(&output);
     let header = &lines[0];
     let obj = header.as_object().unwrap();
@@ -592,7 +607,7 @@ fn test_header_validation() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_entries_all_26_columns() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -624,7 +639,7 @@ fn test_entries_all_26_columns() {
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("export.jsonl");
-    let output = run_export_to_string(project_dir.path(), &output_path);
+    let output = run_export_to_string(project_dir.path(), base_dir.path(), &output_path);
     let lines = parse_lines(&output);
 
     let entry_row = lines
@@ -671,7 +686,7 @@ fn test_entries_all_26_columns() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_null_handling_nullable_columns() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -703,7 +718,7 @@ fn test_null_handling_nullable_columns() {
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("export.jsonl");
-    let output = run_export_to_string(project_dir.path(), &output_path);
+    let output = run_export_to_string(project_dir.path(), base_dir.path(), &output_path);
     let lines = parse_lines(&output);
 
     // Check entry nullable fields
@@ -752,7 +767,7 @@ fn test_null_handling_nullable_columns() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_every_non_header_line_has_table() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -763,7 +778,7 @@ fn test_every_non_header_line_has_table() {
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("export.jsonl");
-    let output = run_export_to_string(project_dir.path(), &output_path);
+    let output = run_export_to_string(project_dir.path(), base_dir.path(), &output_path);
     let lines = parse_lines(&output);
 
     let allowed_tables: HashSet<&str> = [
@@ -799,7 +814,7 @@ fn test_every_non_header_line_has_table() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_all_8_tables_with_row_counts() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -810,7 +825,7 @@ fn test_all_8_tables_with_row_counts() {
 
     let output_dir = TempDir::new().unwrap();
     let output_path = output_dir.path().join("export.jsonl");
-    let output = run_export_to_string(project_dir.path(), &output_path);
+    let output = run_export_to_string(project_dir.path(), base_dir.path(), &output_path);
     let lines = parse_lines(&output);
 
     let mut counts: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
@@ -834,12 +849,12 @@ fn test_all_8_tables_with_row_counts() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_error_on_invalid_output_path() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let _store = open_store(&db_path);
     drop(_store);
 
     let bad_path = std::path::Path::new("/nonexistent_dir_12345/export.jsonl");
-    let result = run_export(Some(project_dir.path()), Some(bad_path));
+    let result = run_export_with_base(Some(project_dir.path()), Some(bad_path), base_dir.path());
     assert!(result.is_err(), "Export to non-writable path should fail");
 }
 
@@ -868,8 +883,8 @@ fn test_error_on_nonexistent_database() {
 #[test]
 fn test_project_dir_isolation() {
     // Create two separate project dirs with different data
-    let (project_a, db_a) = setup_project();
-    let (project_b, db_b) = setup_project();
+    let (project_a, base_dir_a, db_a) = setup_project();
+    let (project_b, base_dir_b, db_b) = setup_project();
 
     // Populate A with "alpha" entry
     let store_a = open_store(&db_a);
@@ -907,7 +922,7 @@ fn test_project_dir_isolation() {
 
     // Export A
     let output_a = output_dir.path().join("export_a.jsonl");
-    let content_a = run_export_to_string(project_a.path(), &output_a);
+    let content_a = run_export_to_string(project_a.path(), base_dir_a.path(), &output_a);
     let lines_a = parse_lines(&content_a);
     let entry_a = lines_a
         .iter()
@@ -917,7 +932,7 @@ fn test_project_dir_isolation() {
 
     // Export B
     let output_b = output_dir.path().join("export_b.jsonl");
-    let content_b = run_export_to_string(project_b.path(), &output_b);
+    let content_b = run_export_to_string(project_b.path(), base_dir_b.path(), &output_b);
     let lines_b = parse_lines(&content_b);
     let entry_b = lines_b
         .iter()
@@ -931,7 +946,7 @@ fn test_project_dir_isolation() {
 // ---------------------------------------------------------------------------
 #[test]
 fn test_performance_500_entries() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -982,7 +997,12 @@ fn test_performance_500_entries() {
     let output_path = output_dir.path().join("export.jsonl");
 
     let start = std::time::Instant::now();
-    run_export(Some(project_dir.path()), Some(&output_path)).expect("export should succeed");
+    run_export_with_base(
+        Some(project_dir.path()),
+        Some(&output_path),
+        base_dir.path(),
+    )
+    .expect("export should succeed");
     let elapsed = start.elapsed();
 
     assert!(

--- a/crates/unimatrix-server/tests/import_integration.rs
+++ b/crates/unimatrix-server/tests/import_integration.rs
@@ -10,8 +10,8 @@ use std::path::Path;
 use serde_json::Value;
 use sqlx::Row as _;
 use tempfile::TempDir;
-use unimatrix_server::export::run_export;
-use unimatrix_server::import::run_import;
+use unimatrix_server::export::run_export_with_base;
+use unimatrix_server::import::run_import_with_base;
 use unimatrix_server::project;
 use unimatrix_store::{SqlxStore, compute_content_hash};
 
@@ -19,11 +19,23 @@ use unimatrix_store::{SqlxStore, compute_content_hash};
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Set up a project directory and return (project_dir, db_path).
-fn setup_project() -> (TempDir, std::path::PathBuf) {
+/// Set up a project directory with an isolated base_dir and return
+/// (project_dir, base_dir, db_path).
+///
+/// Uses an explicit `base_dir` TempDir so the database is resolved inside a
+/// temporary directory rather than `~/.unimatrix/`. This prevents test runs
+/// from leaking orphaned hash directories into the user's home directory.
+fn setup_project() -> (TempDir, TempDir, std::path::PathBuf) {
     let project_dir = TempDir::new().expect("create project temp dir");
-    let paths = project::ensure_data_directory(Some(project_dir.path()), None).unwrap();
-    (project_dir, paths.db_path)
+    let base_dir = TempDir::new().expect("create base temp dir");
+    let paths =
+        project::ensure_data_directory(Some(project_dir.path()), Some(base_dir.path())).unwrap();
+    // Meta-assertion: data_dir must live inside base_dir (GH#640 guard).
+    assert!(
+        paths.data_dir.starts_with(base_dir.path()),
+        "data_dir must be inside base_dir to prevent home directory leaks"
+    );
+    (project_dir, base_dir, paths.db_path)
 }
 
 /// Open a SqlxStore synchronously from a db_path.
@@ -246,8 +258,10 @@ fn parse_lines(output: &str) -> Vec<Value> {
 }
 
 /// Run export to string by writing to a file then reading it back.
-fn run_export_to_string(project_dir: &Path, output_file: &Path) -> String {
-    run_export(Some(project_dir), Some(output_file)).expect("run_export should succeed");
+/// Uses `run_export_with_base` to keep all test data inside `base_dir`.
+fn run_export_to_string(project_dir: &Path, base_dir: &Path, output_file: &Path) -> String {
+    run_export_with_base(Some(project_dir), Some(output_file), base_dir)
+        .expect("run_export_with_base should succeed");
     std::fs::read_to_string(output_file).expect("read output file")
 }
 
@@ -258,28 +272,29 @@ fn run_export_to_string(project_dir: &Path, output_file: &Path) -> String {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_round_trip_export_import_reexport() {
     // Step 1: Create populated DB and export
-    let (project_a, db_a) = setup_project();
+    let (project_a, base_dir_a, db_a) = setup_project();
     let store_a = open_store(&db_a);
     populate_representative_data(store_a.write_pool_server()).await;
     store_a.close().await.unwrap();
 
     let tmp = TempDir::new().unwrap();
     let export1_path = tmp.path().join("export1.jsonl");
-    let export1 = run_export_to_string(project_a.path(), &export1_path);
+    let export1 = run_export_to_string(project_a.path(), base_dir_a.path(), &export1_path);
 
     // Step 2: Import into fresh DB
-    let (project_b, _db_b) = setup_project();
-    run_import(
+    let (project_b, base_dir_b, _db_b) = setup_project();
+    run_import_with_base(
         Some(project_b.path()),
         &export1_path,
         false, // validate hashes
         false, // not force (empty DB)
+        base_dir_b.path(),
     )
     .expect("import should succeed");
 
     // Step 3: Re-export
     let export2_path = tmp.path().join("export2.jsonl");
-    let export2 = run_export_to_string(project_b.path(), &export2_path);
+    let export2 = run_export_to_string(project_b.path(), base_dir_b.path(), &export2_path);
 
     // Step 4: Compare (normalize exported_at and ignore provenance audit entry)
     let normalize = |s: &str| -> Vec<String> {
@@ -339,7 +354,7 @@ async fn test_round_trip_export_import_reexport() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_force_import_replaces_data() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let sv = get_schema_version(&store).await;
 
@@ -371,8 +386,14 @@ async fn test_force_import_replaces_data() {
     let input_path = write_jsonl(&tmp, &lines);
 
     // Import with --force
-    run_import(Some(project_dir.path()), &input_path, true, true)
-        .expect("force import should succeed");
+    run_import_with_base(
+        Some(project_dir.path()),
+        &input_path,
+        true,
+        true,
+        base_dir.path(),
+    )
+    .expect("force import should succeed");
 
     // Verify only 5 entries remain
     let store = open_store(&db_path);
@@ -392,7 +413,7 @@ async fn test_force_import_replaces_data() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_import_rejected_without_force_on_nonempty() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let sv = get_schema_version(&store).await;
 
@@ -408,7 +429,13 @@ async fn test_import_rejected_without_force_on_nonempty() {
     ];
     let input_path = write_jsonl(&tmp, &lines);
 
-    let result = run_import(Some(project_dir.path()), &input_path, false, false);
+    let result = run_import_with_base(
+        Some(project_dir.path()),
+        &input_path,
+        false,
+        false,
+        base_dir.path(),
+    );
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(err.contains("--force"), "should suggest --force: {err}");
@@ -424,7 +451,7 @@ async fn test_import_rejected_without_force_on_nonempty() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_force_on_empty_database() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let sv = get_schema_version(&store).await;
     store.close().await.unwrap();
@@ -438,7 +465,13 @@ async fn test_force_on_empty_database() {
     ];
     let input_path = write_jsonl(&tmp, &lines);
 
-    let result = run_import(Some(project_dir.path()), &input_path, false, true);
+    let result = run_import_with_base(
+        Some(project_dir.path()),
+        &input_path,
+        false,
+        true,
+        base_dir.path(),
+    );
     assert!(result.is_ok(), "force on empty should succeed: {result:?}");
 
     let store = open_store(&db_path);
@@ -455,7 +488,7 @@ async fn test_force_on_empty_database() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_counter_restoration_prevents_id_collision() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let sv = get_schema_version(&store).await;
     store.close().await.unwrap();
@@ -476,7 +509,14 @@ async fn test_counter_restoration_prevents_id_collision() {
     }
     let input_path = write_jsonl(&tmp, &lines);
 
-    run_import(Some(project_dir.path()), &input_path, false, false).expect("import should succeed");
+    run_import_with_base(
+        Some(project_dir.path()),
+        &input_path,
+        false,
+        false,
+        base_dir.path(),
+    )
+    .expect("import should succeed");
 
     // Verify next_entry_id is 101
     let store = open_store(&db_path);
@@ -493,7 +533,7 @@ async fn test_counter_restoration_prevents_id_collision() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_counter_values_match_export() {
-    let (project_a, db_a) = setup_project();
+    let (project_a, base_dir_a, db_a) = setup_project();
     let store_a = open_store(&db_a);
     populate_representative_data(store_a.write_pool_server()).await;
     store_a.close().await.unwrap();
@@ -501,7 +541,12 @@ async fn test_counter_values_match_export() {
     // Export
     let tmp = TempDir::new().unwrap();
     let export_path = tmp.path().join("export.jsonl");
-    run_export(Some(project_a.path()), Some(&export_path)).unwrap();
+    run_export_with_base(
+        Some(project_a.path()),
+        Some(&export_path),
+        base_dir_a.path(),
+    )
+    .unwrap();
 
     // Read exported counters
     let export_content = std::fs::read_to_string(&export_path).unwrap();
@@ -517,8 +562,15 @@ async fn test_counter_values_match_export() {
         .collect();
 
     // Import into fresh DB
-    let (project_b, db_b) = setup_project();
-    run_import(Some(project_b.path()), &export_path, false, false).expect("import should succeed");
+    let (project_b, base_dir_b, db_b) = setup_project();
+    run_import_with_base(
+        Some(project_b.path()),
+        &export_path,
+        false,
+        false,
+        base_dir_b.path(),
+    )
+    .expect("import should succeed");
 
     // Compare counters
     let store_b = open_store(&db_b);
@@ -541,7 +593,7 @@ async fn test_counter_values_match_export() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_atomicity_rollback_on_parse_failure() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let sv = get_schema_version(&store).await;
     store.close().await.unwrap();
@@ -559,7 +611,13 @@ async fn test_atomicity_rollback_on_parse_failure() {
     ];
     let input_path = write_jsonl(&tmp, &lines);
 
-    let result = run_import(Some(project_dir.path()), &input_path, true, false);
+    let result = run_import_with_base(
+        Some(project_dir.path()),
+        &input_path,
+        true,
+        false,
+        base_dir.path(),
+    );
     assert!(result.is_err());
 
     // Database should have zero entries (rolled back)
@@ -573,7 +631,7 @@ async fn test_atomicity_rollback_on_parse_failure() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_atomicity_rollback_on_fk_violation() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let sv = get_schema_version(&store).await;
     store.close().await.unwrap();
@@ -592,7 +650,13 @@ async fn test_atomicity_rollback_on_fk_violation() {
     ];
     let input_path = write_jsonl(&tmp, &lines);
 
-    let result = run_import(Some(project_dir.path()), &input_path, true, false);
+    let result = run_import_with_base(
+        Some(project_dir.path()),
+        &input_path,
+        true,
+        false,
+        base_dir.path(),
+    );
     assert!(result.is_err(), "FK violation should fail");
 }
 
@@ -602,7 +666,7 @@ async fn test_atomicity_rollback_on_fk_violation() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_skip_hash_validation_bypass() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let sv = get_schema_version(&store).await;
     store.close().await.unwrap();
@@ -623,11 +687,12 @@ async fn test_skip_hash_validation_bypass() {
     let input_path = write_jsonl(&tmp, &lines);
 
     // With --skip-hash-validation: should succeed
-    let result = run_import(
+    let result = run_import_with_base(
         Some(project_dir.path()),
         &input_path,
         true, // skip
         false,
+        base_dir.path(),
     );
     assert!(
         result.is_ok(),
@@ -637,7 +702,7 @@ async fn test_skip_hash_validation_bypass() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_hash_validation_failure_prevents_commit() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let sv = get_schema_version(&store).await;
     store.close().await.unwrap();
@@ -655,7 +720,13 @@ async fn test_hash_validation_failure_prevents_commit() {
     ];
     let input_path = write_jsonl(&tmp, &lines);
 
-    let result = run_import(Some(project_dir.path()), &input_path, false, false);
+    let result = run_import_with_base(
+        Some(project_dir.path()),
+        &input_path,
+        false,
+        false,
+        base_dir.path(),
+    );
     assert!(result.is_err());
 
     // Database should be empty (rolled back)
@@ -673,7 +744,7 @@ async fn test_hash_validation_failure_prevents_commit() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_empty_export_imports_successfully() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let sv = get_schema_version(&store).await;
     store.close().await.unwrap();
@@ -686,8 +757,14 @@ async fn test_empty_export_imports_successfully() {
     ];
     let input_path = write_jsonl(&tmp, &lines);
 
-    run_import(Some(project_dir.path()), &input_path, false, false)
-        .expect("empty import should succeed");
+    run_import_with_base(
+        Some(project_dir.path()),
+        &input_path,
+        false,
+        false,
+        base_dir.path(),
+    )
+    .expect("empty import should succeed");
 
     let store = open_store(&db_path);
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM entries")
@@ -711,7 +788,7 @@ async fn test_empty_export_imports_successfully() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_audit_provenance_entry_written() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let sv = get_schema_version(&store).await;
     store.close().await.unwrap();
@@ -725,7 +802,14 @@ async fn test_audit_provenance_entry_written() {
     ];
     let input_path = write_jsonl(&tmp, &lines);
 
-    run_import(Some(project_dir.path()), &input_path, false, false).expect("import should succeed");
+    run_import_with_base(
+        Some(project_dir.path()),
+        &input_path,
+        false,
+        false,
+        base_dir.path(),
+    )
+    .expect("import should succeed");
 
     let store = open_store(&db_path);
     let provenance: String =
@@ -741,7 +825,7 @@ async fn test_audit_provenance_entry_written() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_audit_provenance_no_id_collision() {
-    let (project_a, db_a) = setup_project();
+    let (project_a, base_dir_a, db_a) = setup_project();
     let store_a = open_store(&db_a);
     populate_representative_data(store_a.write_pool_server()).await;
     store_a.close().await.unwrap();
@@ -749,11 +833,23 @@ async fn test_audit_provenance_no_id_collision() {
     // Export (includes audit_log entries with event_ids 1-3)
     let tmp = TempDir::new().unwrap();
     let export_path = tmp.path().join("export.jsonl");
-    run_export(Some(project_a.path()), Some(&export_path)).unwrap();
+    run_export_with_base(
+        Some(project_a.path()),
+        Some(&export_path),
+        base_dir_a.path(),
+    )
+    .unwrap();
 
     // Import into fresh DB
-    let (project_b, db_b) = setup_project();
-    run_import(Some(project_b.path()), &export_path, false, false).expect("import should succeed");
+    let (project_b, base_dir_b, db_b) = setup_project();
+    run_import_with_base(
+        Some(project_b.path()),
+        &export_path,
+        false,
+        false,
+        base_dir_b.path(),
+    )
+    .expect("import should succeed");
 
     // Provenance entry should have event_id > 3
     let store_b = open_store(&db_b);
@@ -774,7 +870,7 @@ async fn test_audit_provenance_no_id_collision() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_all_eight_tables_restored() {
-    let (project_a, db_a) = setup_project();
+    let (project_a, base_dir_a, db_a) = setup_project();
     let store_a = open_store(&db_a);
     populate_representative_data(store_a.write_pool_server()).await;
     store_a.close().await.unwrap();
@@ -782,11 +878,23 @@ async fn test_all_eight_tables_restored() {
     // Export
     let tmp = TempDir::new().unwrap();
     let export_path = tmp.path().join("export.jsonl");
-    run_export(Some(project_a.path()), Some(&export_path)).unwrap();
+    run_export_with_base(
+        Some(project_a.path()),
+        Some(&export_path),
+        base_dir_a.path(),
+    )
+    .unwrap();
 
     // Import into fresh DB
-    let (project_b, db_b) = setup_project();
-    run_import(Some(project_b.path()), &export_path, false, false).expect("import should succeed");
+    let (project_b, base_dir_b, db_b) = setup_project();
+    run_import_with_base(
+        Some(project_b.path()),
+        &export_path,
+        false,
+        false,
+        base_dir_b.path(),
+    )
+    .expect("import should succeed");
 
     // Verify row counts
     let store_b = open_store(&db_b);
@@ -841,7 +949,7 @@ async fn test_all_eight_tables_restored() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_entry_columns_preserved_exactly() {
-    let (project_a, db_a) = setup_project();
+    let (project_a, base_dir_a, db_a) = setup_project();
     let store_a = open_store(&db_a);
 
     // Insert entry with edge values
@@ -880,13 +988,25 @@ async fn test_entry_columns_preserved_exactly() {
     // Export
     let tmp = TempDir::new().unwrap();
     let export_path = tmp.path().join("export.jsonl");
-    run_export(Some(project_a.path()), Some(&export_path)).unwrap();
+    run_export_with_base(
+        Some(project_a.path()),
+        Some(&export_path),
+        base_dir_a.path(),
+    )
+    .unwrap();
 
     // Import into fresh DB
-    let (project_b, db_b) = setup_project();
+    let (project_b, base_dir_b, db_b) = setup_project();
     // Use skip_hash_validation because previous_hash="prev-hash" is intentionally
     // a non-matching value to test that it gets preserved exactly.
-    run_import(Some(project_b.path()), &export_path, true, false).expect("import should succeed");
+    run_import_with_base(
+        Some(project_b.path()),
+        &export_path,
+        true,
+        false,
+        base_dir_b.path(),
+    )
+    .expect("import should succeed");
 
     // Verify every column
     let store_b = open_store(&db_b);
@@ -947,7 +1067,7 @@ async fn test_entry_columns_preserved_exactly() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_force_import_counter_restoration() {
-    let (project_dir, db_path) = setup_project();
+    let (project_dir, base_dir, db_path) = setup_project();
     let store = open_store(&db_path);
     let sv = get_schema_version(&store).await;
 
@@ -978,8 +1098,14 @@ async fn test_force_import_counter_restoration() {
     }
     let input_path = write_jsonl(&tmp, &lines);
 
-    run_import(Some(project_dir.path()), &input_path, true, true)
-        .expect("force import should succeed");
+    run_import_with_base(
+        Some(project_dir.path()),
+        &input_path,
+        true,
+        true,
+        base_dir.path(),
+    )
+    .expect("force import should succeed");
 
     let store = open_store(&db_path);
     let next_id: i64 =


### PR DESCRIPTION
## Summary

- Integration tests called `ensure_data_directory(..., None)` which resolved to `~/.unimatrix/{hash}/`, creating orphaned directories (2,865 orphans, 1.1 GB) never cleaned up
- Added `run_export_with_base`, `run_import_with_base`, `run_snapshot_with_base` variants (following existing `health.rs` `run_with_base` pattern) that accept explicit `base_dir`
- Updated all integration test helpers to pass test-scoped `TempDir` as `base_dir`
- Added meta-assertions (`data_dir.starts_with(base_dir.path())`) in test helpers to prevent silent regressions

## Test plan

- [x] All 5192 workspace tests pass
- [x] Clippy clean on modified files
- [x] Integration smoke tests 23/23 pass
- [x] Meta-assertions fire on every test invocation (50+ tests)
- [x] No unrelated changes included

Closes #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)