### PR TITLE
fix(store): reject databases with schema version newer than binary supports (#650)

### DIFF
--- a/crates/unimatrix-store/src/error.rs
+++ b/crates/unimatrix-store/src/error.rs
@@ -54,6 +54,12 @@ pub enum StoreError {
 
     /// Invalid input for an operation (e.g., correcting a deprecated entry).
     InvalidInput { field: String, reason: String },
+
+    /// Database schema version is newer than this binary supports.
+    SchemaTooNew {
+        database_version: u64,
+        binary_version: u64,
+    },
 }
 
 impl fmt::Display for StoreError {
@@ -79,6 +85,15 @@ impl fmt::Display for StoreError {
             StoreError::InvalidStatus(byte) => write!(f, "invalid status byte: {byte}"),
             StoreError::InvalidInput { field, reason } => {
                 write!(f, "invalid input for '{field}': {reason}")
+            }
+            StoreError::SchemaTooNew {
+                database_version,
+                binary_version,
+            } => {
+                write!(
+                    f,
+                    "database schema version ({database_version}) is newer than this binary supports ({binary_version}); upgrade unimatrix or restore a backup"
+                )
             }
         }
     }
@@ -222,5 +237,29 @@ mod tests {
         let err = StoreError::DrainTaskPanic;
         let msg = err.to_string();
         assert!(msg.contains("drain task panicked"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_error_display_schema_too_new() {
+        let err = StoreError::SchemaTooNew {
+            database_version: 99,
+            binary_version: 27,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("99"), "expected db version in: {msg}");
+        assert!(msg.contains("27"), "expected binary version in: {msg}");
+        assert!(
+            msg.contains("newer than this binary supports"),
+            "expected descriptive text in: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_error_source_returns_none_for_schema_too_new() {
+        let err = StoreError::SchemaTooNew {
+            database_version: 99,
+            binary_version: 27,
+        };
+        assert!(err.source().is_none());
     }
 }

--- a/crates/unimatrix-store/src/migration.rs
+++ b/crates/unimatrix-store/src/migration.rs
@@ -7,6 +7,7 @@
 //! by `create_tables_if_needed()` in `db.rs`. Migration is needed only when
 //! opening an existing database created at an older schema version.
 
+use std::cmp::Ordering;
 use std::path::Path;
 
 use sqlx::Connection;
@@ -63,8 +64,15 @@ pub(crate) async fn migrate_if_needed(
             .map(|v| v as u64)
             .unwrap_or(0);
 
-    if current_version >= CURRENT_SCHEMA_VERSION {
-        return Ok(()); // Already up to date; idempotent.
+    match current_version.cmp(&CURRENT_SCHEMA_VERSION) {
+        Ordering::Greater => {
+            return Err(StoreError::SchemaTooNew {
+                database_version: current_version,
+                binary_version: CURRENT_SCHEMA_VERSION,
+            });
+        }
+        Ordering::Equal => return Ok(()),
+        Ordering::Less => { /* fall through to migration logic */ }
     }
 
     // Step 3: Entry-rewriting migrations for very old schemas (v0, v1, v2).

--- a/crates/unimatrix-store/tests/migration_schema_too_new.rs
+++ b/crates/unimatrix-store/tests/migration_schema_too_new.rs
@@ -1,0 +1,176 @@
+//! Integration tests for SchemaTooNew rejection (GH #650).
+//!
+//! Covers:
+//!   SCHEMA-TOO-NEW-01 — open() rejects a database with schema_version > CURRENT_SCHEMA_VERSION
+//!   SCHEMA-TOO-NEW-02 — error contains correct database_version and binary_version
+//!   SCHEMA-TOO-NEW-03 — open() succeeds when schema_version == CURRENT_SCHEMA_VERSION (no regression)
+
+#![cfg(feature = "test-support")]
+
+use std::path::Path;
+
+use sqlx::ConnectOptions as _;
+use sqlx::sqlite::SqliteConnectOptions;
+use tempfile::TempDir;
+use unimatrix_store::SqlxStore;
+use unimatrix_store::migration::CURRENT_SCHEMA_VERSION;
+use unimatrix_store::pool_config::PoolConfig;
+
+// ---------------------------------------------------------------------------
+// Helper: create a minimal database at a specific schema_version
+// ---------------------------------------------------------------------------
+
+/// Create a minimal database with the `entries` and `counters` tables and the
+/// given `schema_version`. This is enough to trigger the version check in
+/// `migrate_if_needed()` without requiring the full DDL of all tables.
+async fn create_database_at_version(path: &Path, schema_version: u64) {
+    let opts = SqliteConnectOptions::new()
+        .filename(path)
+        .create_if_missing(true);
+
+    let mut conn = opts.connect().await.expect("open setup conn");
+
+    sqlx::query("PRAGMA journal_mode = WAL")
+        .execute(&mut conn)
+        .await
+        .expect("wal");
+    sqlx::query("PRAGMA foreign_keys = ON")
+        .execute(&mut conn)
+        .await
+        .expect("fk");
+
+    // Minimal tables: counters + entries (entries must exist for migration to
+    // read schema_version rather than returning Ok(()) for fresh databases).
+    sqlx::query(
+        "CREATE TABLE counters (
+            name TEXT PRIMARY KEY,
+            value INTEGER NOT NULL
+        )",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create counters");
+
+    sqlx::query(
+        "CREATE TABLE entries (
+            id              INTEGER PRIMARY KEY,
+            title           TEXT    NOT NULL,
+            content         TEXT    NOT NULL,
+            topic           TEXT    NOT NULL,
+            category        TEXT    NOT NULL,
+            source          TEXT    NOT NULL,
+            status          INTEGER NOT NULL DEFAULT 0,
+            confidence      REAL    NOT NULL DEFAULT 0.0,
+            created_at      INTEGER NOT NULL,
+            updated_at      INTEGER NOT NULL,
+            last_accessed_at INTEGER NOT NULL DEFAULT 0,
+            access_count    INTEGER NOT NULL DEFAULT 0,
+            supersedes      INTEGER,
+            superseded_by   INTEGER,
+            correction_count INTEGER NOT NULL DEFAULT 0,
+            embedding_dim   INTEGER NOT NULL DEFAULT 0,
+            created_by      TEXT    NOT NULL DEFAULT '',
+            modified_by     TEXT    NOT NULL DEFAULT '',
+            content_hash    TEXT    NOT NULL DEFAULT '',
+            previous_hash   TEXT    NOT NULL DEFAULT '',
+            version         INTEGER NOT NULL DEFAULT 0,
+            feature_cycle   TEXT    NOT NULL DEFAULT '',
+            trust_source    TEXT    NOT NULL DEFAULT '',
+            helpful_count   INTEGER NOT NULL DEFAULT 0,
+            unhelpful_count INTEGER NOT NULL DEFAULT 0,
+            pre_quarantine_status INTEGER
+        )",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("create entries");
+
+    sqlx::query("INSERT INTO counters (name, value) VALUES ('schema_version', ?1)")
+        .bind(schema_version as i64)
+        .execute(&mut conn)
+        .await
+        .expect("seed schema_version");
+}
+
+// ---------------------------------------------------------------------------
+// SCHEMA-TOO-NEW-01: open() rejects future schema version
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_open_rejects_schema_too_new() {
+    let dir = TempDir::new().expect("temp dir");
+    let db_path = dir.path().join("test.db");
+
+    let future_version = CURRENT_SCHEMA_VERSION + 1;
+    create_database_at_version(&db_path, future_version).await;
+
+    let result = SqlxStore::open(&db_path, PoolConfig::test_default()).await;
+
+    assert!(
+        result.is_err(),
+        "open() must reject a database with schema_version > CURRENT_SCHEMA_VERSION"
+    );
+
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("newer than this binary supports"),
+        "error message must describe the problem: {err_msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SCHEMA-TOO-NEW-02: error contains correct version numbers
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_schema_too_new_error_contains_versions() {
+    let dir = TempDir::new().expect("temp dir");
+    let db_path = dir.path().join("test.db");
+
+    let future_version = CURRENT_SCHEMA_VERSION + 5;
+    create_database_at_version(&db_path, future_version).await;
+
+    let result = SqlxStore::open(&db_path, PoolConfig::test_default()).await;
+
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+
+    let db_v_str = future_version.to_string();
+    let bin_v_str = CURRENT_SCHEMA_VERSION.to_string();
+    assert!(
+        err_msg.contains(&db_v_str),
+        "error must contain database version {db_v_str}: {err_msg}"
+    );
+    assert!(
+        err_msg.contains(&bin_v_str),
+        "error must contain binary version {bin_v_str}: {err_msg}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SCHEMA-TOO-NEW-03: open() succeeds when schema_version == CURRENT (no regression)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_open_succeeds_at_current_schema_version() {
+    let dir = TempDir::new().expect("temp dir");
+    let db_path = dir.path().join("test.db");
+
+    // A fresh database opens at CURRENT_SCHEMA_VERSION.
+    let store = SqlxStore::open(&db_path, PoolConfig::test_default())
+        .await
+        .expect("open fresh store must succeed");
+
+    let version: i64 =
+        sqlx::query_scalar("SELECT value FROM counters WHERE name = 'schema_version'")
+            .fetch_one(store.read_pool_test())
+            .await
+            .expect("read schema_version");
+
+    assert_eq!(
+        version, CURRENT_SCHEMA_VERSION as i64,
+        "fresh database must be at CURRENT_SCHEMA_VERSION"
+    );
+
+    store.close().await.unwrap();
+}


### PR DESCRIPTION
## Summary

- Adds `SchemaTooNew` error variant to `StoreError` with clear error message including both database and binary schema versions
- Replaces `>=` check in `migrate_if_needed()` with three-way `cmp` match: Greater → error, Equal → ok, Less → migrate
- Aligns `migration.rs` with existing forward-compatibility guards in import module and unimatrix-adapt

## Root Cause

`migrate_if_needed()` used `current_version >= CURRENT_SCHEMA_VERSION` to short-circuit, treating both "up to date" (==) and "too new" (>) as the same case. A downgraded binary (e.g., v0.8.0 schema 30 → v0.7.2 schema 27) would silently proceed against a schema it does not understand, risking data corruption.

## Test Plan

- [x] Unit test: `SchemaTooNew` Display output contains both version numbers
- [x] Unit test: `SchemaTooNew` source() returns None
- [x] Integration test: `open()` rejects database with `schema_version > CURRENT_SCHEMA_VERSION`
- [x] Integration test: error message contains correct version numbers
- [x] Integration test: `open()` succeeds at current schema version (no regression)
- [x] Full workspace: 5,059 passed, 0 failed
- [x] Clippy: clean for unimatrix-store
- [x] Integration smoke: 23 passed
- [x] Lifecycle suite: 60 passed, 0 failed
- [x] Volume suite: 10 passed, 0 failed (1 pre-existing xfail, GH#652)
- [x] Edge cases: 22 passed, 0 failed

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)