### PR TITLE
fix: embedding model SHA-256 hash verification (#651)

### DIFF
--- a/crates/unimatrix-server/src/embed_reconstruct.rs
+++ b/crates/unimatrix-server/src/embed_reconstruct.rs
@@ -39,6 +39,14 @@ pub fn reconstruct_embeddings(
     vector_dir: &Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Step 1: Initialize ONNX provider
+    // NOTE (bugfix-651): The import path does not have access to InferenceConfig,
+    // so embedding_model_sha256 hash verification is not available here. The import
+    // path operates on the CLI sync path (no server config loaded). Log a warning
+    // so operators know hash verification was skipped.
+    eprintln!(
+        "WARNING: embedding model hash verification is not available on the import path. \
+         Verify model integrity manually if importing into a production instance."
+    );
     eprintln!("Initializing embedding model...");
     let embed_config = EmbedConfig::default();
     let provider = OnnxProvider::new(embed_config).map_err(|e| {

--- a/crates/unimatrix-server/src/eval/profile/layer.rs
+++ b/crates/unimatrix-server/src/eval/profile/layer.rs
@@ -250,7 +250,14 @@ impl EvalServiceLayer {
         // ----------------------------------------------------------------
         let embed_handle = EmbedServiceHandle::new();
         let embed_config = EmbedConfig::default();
-        embed_handle.start_loading(embed_config);
+        embed_handle.start_loading(
+            embed_config,
+            profile
+                .config_overrides
+                .inference
+                .embedding_model_sha256
+                .clone(),
+        );
 
         // ----------------------------------------------------------------
         // Step 6b: Build NLI handle for NLI-enabled profiles (crt-023, FR-26, ADR-006).

--- a/crates/unimatrix-server/src/infra/config.rs
+++ b/crates/unimatrix-server/src/infra/config.rs
@@ -261,6 +261,20 @@ pub struct InferenceConfig {
     pub rayon_pool_size: usize,
 
     // -----------------------------------------------------------------------
+    // Embedding model hash verification (bugfix-651)
+    // -----------------------------------------------------------------------
+    /// SHA-256 hash of the embedding model ONNX file as a 64-char lowercase hex string.
+    ///
+    /// When set, the hash is verified before the ONNX session is loaded into memory.
+    /// When `None`, hash verification is skipped with a `warn`-level log.
+    /// Must be exactly 64 hex characters if set.
+    ///
+    /// Security-critical: global-wins semantics in merge. A per-project config
+    /// MUST NOT override a global hash pin.
+    #[serde(default)]
+    pub embedding_model_sha256: Option<String>,
+
+    // -----------------------------------------------------------------------
     // NLI cross-encoder fields (crt-023)
     // -----------------------------------------------------------------------
     /// Enable the NLI cross-encoder (default `false`, opt-in).
@@ -702,6 +716,7 @@ impl Default for InferenceConfig {
         // On 20-core:    num_cpus = 20; 20/2 = 10; max(10, 4) = 10; min(10, 8) = 8.
         InferenceConfig {
             rayon_pool_size: (num_cpus::get() / 2).max(4).min(8),
+            embedding_model_sha256: None,
             nli_enabled: default_nli_enabled(),
             nli_model_name: None,
             nli_model_path: None,
@@ -1021,6 +1036,18 @@ impl InferenceConfig {
                 path: path.to_path_buf(),
                 value: self.rayon_pool_size,
             });
+        }
+
+        // -- embedding_model_sha256: exactly 64 hex chars when Some (bugfix-651) --
+        if let Some(ref sha) = self.embedding_model_sha256 {
+            if sha.len() != 64 || !sha.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Err(ConfigError::NliFieldOutOfRange {
+                    path: path.to_path_buf(),
+                    field: "embedding_model_sha256",
+                    value: format!("{sha} ({} chars)", sha.len()),
+                    reason: "must be a 64-character lowercase hex string",
+                });
+            }
         }
 
         // -- NLI usize range checks [1, 100] --
@@ -2718,6 +2745,24 @@ fn merge_configs(global: UnimatrixConfig, project: UnimatrixConfig) -> Unimatrix
             } else {
                 global.inference.rayon_pool_size
             },
+            // bugfix-651: global-wins semantics for embedding_model_sha256.
+            // A per-project config MUST NOT override a global hash pin (security-critical).
+            embedding_model_sha256: if global.inference.embedding_model_sha256.is_some() {
+                if project.inference.embedding_model_sha256.is_some()
+                    && project.inference.embedding_model_sha256
+                        != global.inference.embedding_model_sha256
+                {
+                    tracing::warn!(
+                        "per-project embedding_model_sha256 ignored — global hash pin takes precedence (security)"
+                    );
+                }
+                global.inference.embedding_model_sha256
+            } else {
+                project
+                    .inference
+                    .embedding_model_sha256
+                    .or(global.inference.embedding_model_sha256)
+            },
             nli_enabled: if project.inference.nli_enabled != default.inference.nli_enabled {
                 project.inference.nli_enabled
             } else {
@@ -3216,6 +3261,11 @@ pub static DEFAULT_CONFIG_TOML: &str = r#"# Unimatrix configuration file.
 # Default: (num_cpus / 2).max(4).min(8). Valid range: [1, 64].
 # When nli_enabled = true, a pool floor of 6 is applied at startup.
 # rayon_pool_size = 4
+
+# SHA-256 hash of the embedding model ONNX file (64-char lowercase hex).
+# When set, hash is verified before loading. Run `unimatrix model-download` to get the hash.
+# Security-critical: global config hash pin cannot be overridden by per-project config.
+# embedding_model_sha256 = ""
 
 # Enable the NLI cross-encoder for re-ranking (opt-in, default false).
 # When false, all search uses cosine similarity fallback.
@@ -5430,6 +5480,56 @@ mod tests {
         // None means no verification — must pass.
         let c = InferenceConfig {
             nli_model_sha256: None,
+            ..InferenceConfig::default()
+        };
+        assert!(c.validate(Path::new("/fake")).is_ok());
+    }
+
+    // bugfix-651: embedding_model_sha256 format validation.
+
+    #[test]
+    fn test_validate_embedding_model_sha256_wrong_length_fails() {
+        let c = InferenceConfig {
+            embedding_model_sha256: Some("short_hash".to_string()),
+            ..InferenceConfig::default()
+        };
+        assert_validate_fails_with_field(c, "embedding_model_sha256");
+    }
+
+    #[test]
+    fn test_validate_embedding_model_sha256_63_chars_fails() {
+        let c = InferenceConfig {
+            embedding_model_sha256: Some("a".repeat(63)),
+            ..InferenceConfig::default()
+        };
+        assert_validate_fails_with_field(c, "embedding_model_sha256");
+    }
+
+    #[test]
+    fn test_validate_embedding_model_sha256_non_hex_fails() {
+        let c = InferenceConfig {
+            embedding_model_sha256: Some("z".repeat(64)),
+            ..InferenceConfig::default()
+        };
+        assert_validate_fails_with_field(c, "embedding_model_sha256");
+    }
+
+    #[test]
+    fn test_validate_embedding_model_sha256_valid_64_hex_passes() {
+        let c = InferenceConfig {
+            embedding_model_sha256: Some("a".repeat(64)),
+            ..InferenceConfig::default()
+        };
+        assert!(
+            c.validate(Path::new("/fake")).is_ok(),
+            "64-char lowercase hex sha256 must pass validation"
+        );
+    }
+
+    #[test]
+    fn test_validate_embedding_model_sha256_none_passes() {
+        let c = InferenceConfig {
+            embedding_model_sha256: None,
             ..InferenceConfig::default()
         };
         assert!(c.validate(Path::new("/fake")).is_ok());
@@ -9383,6 +9483,70 @@ nli_informs_ppr_weight = 0.4
         assert_eq!(
             from_section.knowledge.categories, from_default.knowledge.categories,
             "serde field default for categories must match impl Default"
+        );
+    }
+
+    // bugfix-651: embedding_model_sha256 global-wins merge tests
+
+    #[test]
+    fn test_merge_embedding_sha256_global_wins_over_project() {
+        // Global sets embedding_model_sha256 — per-project MUST NOT override (security).
+        let mut global = UnimatrixConfig::default();
+        global.inference.embedding_model_sha256 = Some("a".repeat(64));
+
+        let mut project = UnimatrixConfig::default();
+        project.inference.embedding_model_sha256 = Some("b".repeat(64));
+
+        let merged = merge_configs(global, project);
+        assert_eq!(
+            merged.inference.embedding_model_sha256,
+            Some("a".repeat(64)),
+            "global embedding_model_sha256 must win over per-project (security)"
+        );
+    }
+
+    #[test]
+    fn test_merge_embedding_sha256_project_used_when_global_none() {
+        // Global does not set hash — per-project hash is used.
+        let global = UnimatrixConfig::default();
+        assert!(global.inference.embedding_model_sha256.is_none());
+
+        let mut project = UnimatrixConfig::default();
+        project.inference.embedding_model_sha256 = Some("c".repeat(64));
+
+        let merged = merge_configs(global, project);
+        assert_eq!(
+            merged.inference.embedding_model_sha256,
+            Some("c".repeat(64)),
+            "per-project embedding_model_sha256 must be used when global is None"
+        );
+    }
+
+    #[test]
+    fn test_merge_embedding_sha256_both_none() {
+        let global = UnimatrixConfig::default();
+        let project = UnimatrixConfig::default();
+        let merged = merge_configs(global, project);
+        assert_eq!(
+            merged.inference.embedding_model_sha256, None,
+            "merged embedding_model_sha256 must be None when both are None"
+        );
+    }
+
+    #[test]
+    fn test_merge_embedding_sha256_global_same_as_project() {
+        // Both global and project set the same hash — no warning, global value used.
+        let mut global = UnimatrixConfig::default();
+        global.inference.embedding_model_sha256 = Some("d".repeat(64));
+
+        let mut project = UnimatrixConfig::default();
+        project.inference.embedding_model_sha256 = Some("d".repeat(64));
+
+        let merged = merge_configs(global, project);
+        assert_eq!(
+            merged.inference.embedding_model_sha256,
+            Some("d".repeat(64)),
+            "matching hashes must produce the global value"
         );
     }
 }

--- a/crates/unimatrix-server/src/infra/embed_handle.rs
+++ b/crates/unimatrix-server/src/infra/embed_handle.rs
@@ -8,8 +8,9 @@ use std::sync::Arc;
 
 use tokio::sync::RwLock;
 use unimatrix_core::EmbedAdapter;
-use unimatrix_embed::{EmbedConfig, EmbeddingProvider, OnnxProvider};
+use unimatrix_embed::{EmbedConfig, EmbeddingProvider, OnnxProvider, ensure_model};
 
+use super::hash::verify_sha256;
 use crate::error::ServerError;
 
 /// Maximum number of automatic retry attempts before giving up permanently.
@@ -36,6 +37,9 @@ enum EmbedState {
 pub struct EmbedServiceHandle {
     state: RwLock<EmbedState>,
     config: RwLock<Option<EmbedConfig>>,
+    /// Expected SHA-256 hash of the embedding model ONNX file (64-char hex).
+    /// `None` → skip verification with a `warn`-level log.
+    expected_sha256: RwLock<Option<String>>,
 }
 
 impl EmbedServiceHandle {
@@ -44,6 +48,7 @@ impl EmbedServiceHandle {
         Arc::new(EmbedServiceHandle {
             state: RwLock::new(EmbedState::Loading),
             config: RwLock::new(None),
+            expected_sha256: RwLock::new(None),
         })
     }
 
@@ -52,7 +57,10 @@ impl EmbedServiceHandle {
     /// The task downloads the model if not cached, then transitions
     /// the handle to Ready or Failed. If loading fails, a retry monitor
     /// automatically re-attempts up to `MAX_RETRIES` times (#52).
-    pub fn start_loading(self: &Arc<Self>, config: EmbedConfig) {
+    ///
+    /// `expected_sha256`: optional SHA-256 hash of the ONNX file. When `Some`,
+    /// the hash is verified BEFORE the ONNX session is loaded into memory (bugfix-651).
+    pub fn start_loading(self: &Arc<Self>, config: EmbedConfig, expected_sha256: Option<String>) {
         // Store config for potential retries.
         {
             let mut cfg = match self.config.try_write() {
@@ -64,16 +72,66 @@ impl EmbedServiceHandle {
             };
             *cfg = Some(config.clone());
         }
-        self.spawn_load_task(config, 1);
+        // Store expected hash for retries.
+        {
+            let mut sha = match self.expected_sha256.try_write() {
+                Ok(guard) => guard,
+                Err(_) => {
+                    tracing::error!("embed sha256 lock contended at startup");
+                    return;
+                }
+            };
+            *sha = expected_sha256.clone();
+        }
+        self.spawn_load_task(config, 1, expected_sha256);
         self.spawn_retry_monitor();
     }
 
     /// Spawn the background model loading task.
-    fn spawn_load_task(self: &Arc<Self>, config: EmbedConfig, attempt: u32) {
+    ///
+    /// Ordering is security-critical (bugfix-651):
+    ///   1. `ensure_model()` — download/cache the ONNX file
+    ///   2. `verify_sha256()` — verify integrity BEFORE loading into memory
+    ///   3. `OnnxProvider::new()` — build the ONNX session (calls `ensure_model()` again, cache-hit no-op)
+    fn spawn_load_task(
+        self: &Arc<Self>,
+        config: EmbedConfig,
+        attempt: u32,
+        expected_sha256: Option<String>,
+    ) {
         let handle = Arc::clone(self);
 
         tokio::spawn(async move {
-            let result = tokio::task::spawn_blocking(move || OnnxProvider::new(config)).await;
+            let config_for_provider = config.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                // Step 1: ensure model files are downloaded/cached.
+                let cache_dir = config.resolve_cache_dir();
+                let model_dir = ensure_model(config.model, &cache_dir)?;
+
+                // Step 2: verify hash BEFORE loading the ONNX session into memory.
+                if let Some(ref expected_hash) = expected_sha256 {
+                    verify_sha256(&model_dir, config.model.onnx_filename(), expected_hash)
+                        .map_err(|e| {
+                            // Log must contain "security" and "hash mismatch" (matching NLI pattern).
+                            tracing::error!(
+                                expected = %expected_hash,
+                                "embedding model security: hash mismatch — model file integrity check failed: {e}"
+                            );
+                            unimatrix_embed::EmbedError::InferenceFailed(format!(
+                                "security: hash mismatch for embedding model at {}: {e}",
+                                model_dir.display()
+                            ))
+                        })?;
+                } else {
+                    tracing::warn!(
+                        "embedding_model_sha256 not set; embedding model integrity verification is disabled"
+                    );
+                }
+
+                // Step 3: build ONNX session (ensure_model is called again inside, harmless cache-hit).
+                OnnxProvider::new(config_for_provider)
+            })
+            .await;
 
             let mut state = handle.state.write().await;
             match result {
@@ -175,6 +233,7 @@ impl EmbedServiceHandle {
                                 "retrying embedding model load"
                             );
                             let cfg_clone = cfg.clone();
+                            let sha_clone = handle.expected_sha256.read().await.clone();
                             *state = EmbedState::Retrying {
                                 attempt: next_attempt,
                             };
@@ -183,7 +242,7 @@ impl EmbedServiceHandle {
 
                             // Backoff before spawning retry.
                             tokio::time::sleep(delay).await;
-                            handle.spawn_load_task(cfg_clone, next_attempt);
+                            handle.spawn_load_task(cfg_clone, next_attempt, sha_clone);
                         } else {
                             // No config available, cannot retry.
                             return;

--- a/crates/unimatrix-server/src/infra/hash.rs
+++ b/crates/unimatrix-server/src/infra/hash.rs
@@ -1,0 +1,100 @@
+//! Shared SHA-256 hash verification for ONNX model files.
+//!
+//! Extracted from `nli_handle.rs` so both the NLI and embedding model loading
+//! paths can verify file integrity before constructing ONNX sessions (bugfix-651).
+
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+/// Verify the SHA-256 hash of an ONNX model file.
+///
+/// `model_dir` is the directory containing the model file.
+/// `onnx_filename` is the filename within that directory (e.g., `"model.onnx"`).
+/// `expected_hex` is the expected SHA-256 hash as a 64-char lowercase hex string.
+///
+/// Returns `Ok(())` on match, `Err(String)` with a mismatch description on failure.
+pub(crate) fn verify_sha256(
+    model_dir: &Path,
+    onnx_filename: &str,
+    expected_hex: &str,
+) -> Result<(), String> {
+    let onnx_file = model_dir.join(onnx_filename);
+    let bytes = std::fs::read(&onnx_file)
+        .map_err(|e| format!("failed to read model file for hash check: {e}"))?;
+
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let actual_hex = format!("{:x}", hasher.finalize());
+
+    if actual_hex.eq_ignore_ascii_case(expected_hex) {
+        Ok(())
+    } else {
+        Err(format!("expected {expected_hex}, got {actual_hex}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_verify_sha256_correct_hash() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let model_file = tmp_dir.path().join("model.onnx");
+        let content = b"test model content";
+        std::fs::write(&model_file, content).unwrap();
+
+        let mut hasher = Sha256::new();
+        hasher.update(content);
+        let expected = format!("{:x}", hasher.finalize());
+
+        let result = verify_sha256(tmp_dir.path(), "model.onnx", &expected);
+        assert!(
+            result.is_ok(),
+            "Correct hash must pass verification: {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_verify_sha256_wrong_hash_returns_err() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let model_file = tmp_dir.path().join("model.onnx");
+        std::fs::write(&model_file, b"some bytes").unwrap();
+
+        let wrong_hash = "b".repeat(64);
+        let result = verify_sha256(tmp_dir.path(), "model.onnx", &wrong_hash);
+        assert!(result.is_err(), "Wrong hash must fail verification");
+        let msg = result.unwrap_err();
+        assert!(
+            msg.contains("expected") && msg.contains(&wrong_hash),
+            "Error message must contain expected hash: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_verify_sha256_missing_file_returns_err() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let result = verify_sha256(tmp_dir.path(), "model.onnx", &"a".repeat(64));
+        assert!(result.is_err(), "Missing file must fail hash verification");
+        assert!(
+            result.unwrap_err().contains("failed to read"),
+            "Error must describe read failure"
+        );
+    }
+
+    #[test]
+    fn test_verify_sha256_case_insensitive() {
+        let tmp_dir = tempfile::TempDir::new().unwrap();
+        let model_file = tmp_dir.path().join("model.onnx");
+        let content = b"case test";
+        std::fs::write(&model_file, content).unwrap();
+
+        let mut hasher = Sha256::new();
+        hasher.update(content);
+        let expected_lower = format!("{:x}", hasher.finalize());
+        let expected_upper = expected_lower.to_uppercase();
+
+        assert!(verify_sha256(tmp_dir.path(), "model.onnx", &expected_upper).is_ok());
+    }
+}

--- a/crates/unimatrix-server/src/infra/mod.rs
+++ b/crates/unimatrix-server/src/infra/mod.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod contradiction;
 pub mod daemon;
 pub mod embed_handle;
+pub mod hash;
 pub mod nli_handle;
 pub mod outcome_tags;
 pub mod pidfile;

--- a/crates/unimatrix-server/src/infra/nli_handle.rs
+++ b/crates/unimatrix-server/src/infra/nli_handle.rs
@@ -8,13 +8,14 @@
 //! - `nli_enabled = false` guard: provider never loads; `get_provider()` returns
 //!   `Err(NliNotReady)` immediately.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
 use unimatrix_embed::{EmbedError, NliModel, NliProvider, ensure_nli_model};
+
+use super::hash::verify_sha256;
 
 use crate::error::ServerError;
 
@@ -545,25 +546,7 @@ fn resolve_model_dir(model: &NliModel, config: &NliConfig) -> Result<PathBuf, Em
     }
 }
 
-/// Verify the SHA-256 hash of `model_dir/model.onnx`.
-///
-/// `model_dir` is the directory returned by `resolve_model_dir`.
-/// Returns `Ok(())` on match, `Err(String)` with a mismatch description on failure.
-fn verify_sha256(model_dir: &Path, onnx_filename: &str, expected_hex: &str) -> Result<(), String> {
-    let onnx_file = model_dir.join(onnx_filename);
-    let bytes = std::fs::read(&onnx_file)
-        .map_err(|e| format!("failed to read model file for hash check: {e}"))?;
-
-    let mut hasher = Sha256::new();
-    hasher.update(&bytes);
-    let actual_hex = format!("{:x}", hasher.finalize());
-
-    if actual_hex.eq_ignore_ascii_case(expected_hex) {
-        Ok(())
-    } else {
-        Err(format!("expected {expected_hex}, got {actual_hex}"))
-    }
-}
+// verify_sha256 is now in infra::hash (shared between embed_handle and nli_handle).
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -572,6 +555,8 @@ fn verify_sha256(model_dir: &Path, onnx_filename: &str, expected_hex: &str) -> R
 #[cfg(test)]
 mod tests {
     use std::io::Write;
+
+    use sha2::{Digest, Sha256};
 
     use super::*;
 

--- a/crates/unimatrix-server/src/main.rs
+++ b/crates/unimatrix-server/src/main.rs
@@ -609,7 +609,10 @@ async fn tokio_main_daemon(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize embedding service (lazy — background task).
     let embed_handle = EmbedServiceHandle::new();
-    embed_handle.start_loading(EmbedConfig::default());
+    embed_handle.start_loading(
+        EmbedConfig::default(),
+        config.inference.embedding_model_sha256.clone(),
+    );
 
     // Initialize agent registry and bootstrap defaults.
     let registry = Arc::new(AgentRegistry::new(
@@ -965,7 +968,10 @@ async fn tokio_main_stdio(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     // Initialize embedding service (lazy — background task).
     let embed_handle = EmbedServiceHandle::new();
-    embed_handle.start_loading(EmbedConfig::default());
+    embed_handle.start_loading(
+        EmbedConfig::default(),
+        config.inference.embedding_model_sha256.clone(),
+    );
 
     // Initialize agent registry and bootstrap defaults.
     let registry = Arc::new(AgentRegistry::new(
@@ -1435,13 +1441,25 @@ fn handle_model_download(
         cache_dir.display()
     );
 
-    match unimatrix_embed::ensure_model(embed_config.model, &cache_dir) {
-        Ok(model_dir) => eprintln!("Embedding model ready: {}", model_dir.display()),
+    let embed_model_dir = match unimatrix_embed::ensure_model(embed_config.model, &cache_dir) {
+        Ok(model_dir) => {
+            eprintln!("Embedding model ready: {}", model_dir.display());
+            model_dir
+        }
         Err(e) => {
             eprintln!("Embedding model download failed: {e}");
             return Err(Box::new(e));
         }
-    }
+    };
+
+    // Compute and output SHA-256 hash of the embedding model ONNX file (bugfix-651).
+    let embed_onnx_path = embed_model_dir.join(embed_config.model.onnx_filename());
+    eprintln!("Computing SHA-256 hash of {}...", embed_onnx_path.display());
+    let embed_hash_hex = compute_file_sha256(&embed_onnx_path)?;
+    println!("embedding: {}", embed_hash_hex);
+    eprintln!();
+    eprintln!("Add the following to your config.toml under [inference]:");
+    eprintln!("  embedding_model_sha256 = \"{}\"", embed_hash_hex);
 
     // Step 2: If --nli flag not given, return here (existing behavior preserved).
     if !nli {
@@ -1484,8 +1502,8 @@ fn handle_model_download(
     let hash_hex = compute_file_sha256(&onnx_path)?;
 
     // Step 6: Print hash to stdout (operator copies to config.toml).
-    // Format: one line, lowercase hex, 64 chars. Ready to paste.
-    println!("{}", hash_hex);
+    // Format: prefixed with "nli:" for disambiguation from embedding hash.
+    println!("nli: {}", hash_hex);
 
     // Step 7: Print guidance to stderr.
     eprintln!();

--- a/crates/unimatrix-server/src/test_support.rs
+++ b/crates/unimatrix-server/src/test_support.rs
@@ -81,7 +81,7 @@ impl TestHarness {
 
         let embed_handle = EmbedServiceHandle::new();
         let config = EmbedConfig::default();
-        embed_handle.start_loading(config);
+        embed_handle.start_loading(config, None);
 
         // Wait for model to load
         let mut attempts = 0;

--- a/crates/unimatrix-server/tests/export_integration.rs
+++ b/crates/unimatrix-server/tests/export_integration.rs
@@ -1195,7 +1195,10 @@ fn test_all_11_tables_with_new_tables_populated() {
         .find(|l| l.get("_table").and_then(|t| t.as_str()) == Some("graph_edges"))
         .unwrap();
     let ge_obj = ge_row.as_object().unwrap();
-    assert!(!ge_obj.contains_key("id"), "AC-01: graph_edges must not export id");
+    assert!(
+        !ge_obj.contains_key("id"),
+        "AC-01: graph_edges must not export id"
+    );
     assert!(ge_obj.contains_key("source_id"));
     assert!(ge_obj.contains_key("target_id"));
     assert!(ge_obj.contains_key("relation_type"));
@@ -1211,7 +1214,10 @@ fn test_all_11_tables_with_new_tables_populated() {
         .find(|l| l.get("_table").and_then(|t| t.as_str()) == Some("observations"))
         .unwrap();
     let obs_obj = obs_row.as_object().unwrap();
-    assert!(obs_obj.contains_key("id"), "AC-02: observations must export id");
+    assert!(
+        obs_obj.contains_key("id"),
+        "AC-02: observations must export id"
+    );
 
     // AC-03: cycle_events must NOT have goal_embedding
     let ce_row = lines
@@ -1327,8 +1333,8 @@ fn test_skip_quarantined_does_not_filter_observations_or_cycle_events() {
         Some(project_dir.path()),
         Some(&output_path),
         base_dir.path(),
-        true,  // skip_quarantined
-        true,  // confirm
+        true, // skip_quarantined
+        true, // confirm
     )
     .expect("export with skip_quarantined should succeed");
 
@@ -1344,8 +1350,14 @@ fn test_skip_quarantined_does_not_filter_observations_or_cycle_events() {
         .filter(|l| l.get("_table").and_then(|t| t.as_str()) == Some("cycle_events"))
         .count();
 
-    assert_eq!(obs_count, 3, "R-21: all 3 observations exported regardless of quarantined entries");
-    assert_eq!(ce_count, 2, "R-21: all 2 cycle_events exported regardless of quarantined entries");
+    assert_eq!(
+        obs_count, 3,
+        "R-21: all 3 observations exported regardless of quarantined entries"
+    );
+    assert_eq!(
+        ce_count, 2,
+        "R-21: all 2 cycle_events exported regardless of quarantined entries"
+    );
 
     // Also verify the quarantined entry itself is excluded
     let entry_count = lines
@@ -1401,8 +1413,8 @@ fn test_skip_quarantined_stderr_reports_skip_counts() {
         Some(project_dir.path()),
         Some(&output_path),
         base_dir.path(),
-        true,  // skip_quarantined (triggers eprintln skip counts)
-        true,  // confirm
+        true, // skip_quarantined (triggers eprintln skip counts)
+        true, // confirm
     )
     .expect("export should succeed and skip counts reported to stderr");
 
@@ -1419,7 +1431,10 @@ fn test_skip_quarantined_stderr_reports_skip_counts() {
         .filter(|l| l.get("_table").and_then(|t| t.as_str()) == Some("entry_tags"))
         .count();
     assert_eq!(entry_count, 1, "1 active entry exported");
-    assert_eq!(tag_count, 0, "0 tags (only tag belonged to quarantined entry)");
+    assert_eq!(
+        tag_count, 0,
+        "0 tags (only tag belonged to quarantined entry)"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1492,8 +1507,8 @@ fn test_skip_quarantined_export_import_hash_valid() {
         Some(project_dir.path()),
         Some(&output_path),
         base_dir.path(),
-        true,  // skip_quarantined
-        true,  // confirm
+        true, // skip_quarantined
+        true, // confirm
     )
     .expect("filtered export should succeed");
 
@@ -1514,10 +1529,12 @@ fn test_skip_quarantined_export_import_hash_valid() {
         .enable_all()
         .build()
         .expect("runtime");
-    let count: i64 = rt2.block_on(
-        sqlx::query_scalar("SELECT COUNT(*) FROM entries").fetch_one(store_b.write_pool_server()),
-    )
-    .unwrap();
+    let count: i64 = rt2
+        .block_on(
+            sqlx::query_scalar("SELECT COUNT(*) FROM entries")
+                .fetch_one(store_b.write_pool_server()),
+        )
+        .unwrap();
     assert_eq!(count, 2, "AC-31: only 2 active entries in imported DB");
     drop((store_b, db_b)); // keep db_b alive until here
 }

--- a/crates/unimatrix-server/tests/import_integration.rs
+++ b/crates/unimatrix-server/tests/import_integration.rs
@@ -1305,12 +1305,14 @@ async fn test_force_import_clears_observation_metric_tables() {
     assert_eq!(ce_count, 0, "R-02: cycle_events cleared after --force");
 
     // observation_phase_metrics should also be cleared
-    let opm_count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM observation_phase_metrics")
-            .fetch_one(pool)
-            .await
-            .unwrap_or(0);
-    assert_eq!(opm_count, 0, "R-02: observation_phase_metrics cleared after --force");
+    let opm_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM observation_phase_metrics")
+        .fetch_one(pool)
+        .await
+        .unwrap_or(0);
+    assert_eq!(
+        opm_count, 0,
+        "R-02: observation_phase_metrics cleared after --force"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1373,9 +1375,15 @@ async fn test_observations_id_collision_via_plain_insert() {
         false, // no force
         base_dir.path(),
     );
-    assert!(result.is_err(), "R-05: non-empty DB without --force must fail");
+    assert!(
+        result.is_err(),
+        "R-05: non-empty DB without --force must fail"
+    );
     let err_msg = result.unwrap_err().to_string();
-    assert!(err_msg.contains("--force"), "R-05: error should mention --force: {err_msg}");
+    assert!(
+        err_msg.contains("--force"),
+        "R-05: error should mention --force: {err_msg}"
+    );
 
     // With --force: clears table first, import succeeds (no ID collision)
     let tmp2 = TempDir::new().unwrap();
@@ -1394,16 +1402,21 @@ async fn test_observations_id_collision_via_plain_insert() {
         true, // force
         base_dir.path(),
     );
-    assert!(result2.is_ok(), "R-05: --force clears table before insert, must succeed: {result2:?}");
+    assert!(
+        result2.is_ok(),
+        "R-05: --force clears table before insert, must succeed: {result2:?}"
+    );
 
     // Verify the new observation (from import) is present
     let store = open_store(&db_path);
-    let hook: String =
-        sqlx::query_scalar("SELECT hook FROM observations WHERE id = 1")
-            .fetch_one(store.write_pool_server())
-            .await
-            .unwrap();
-    assert_eq!(hook, "on_result", "R-05: imported observation present after force import");
+    let hook: String = sqlx::query_scalar("SELECT hook FROM observations WHERE id = 1")
+        .fetch_one(store.write_pool_server())
+        .await
+        .unwrap();
+    assert_eq!(
+        hook, "on_result",
+        "R-05: imported observation present after force import"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1452,19 +1465,17 @@ async fn test_round_trip_all_11_tables() {
     // AC-16: verify observations.id preserved
     let store_b = open_store(&db_b);
     let pool_b = store_b.write_pool_server();
-    let obs_ids: Vec<i64> =
-        sqlx::query_scalar("SELECT id FROM observations ORDER BY id")
-            .fetch_all(pool_b)
-            .await
-            .unwrap();
+    let obs_ids: Vec<i64> = sqlx::query_scalar("SELECT id FROM observations ORDER BY id")
+        .fetch_all(pool_b)
+        .await
+        .unwrap();
     assert_eq!(obs_ids, vec![1i64, 2], "AC-16: observations.id preserved");
 
     // AC-17: verify cycle_events.id preserved
-    let ce_ids: Vec<i64> =
-        sqlx::query_scalar("SELECT id FROM cycle_events ORDER BY id")
-            .fetch_all(pool_b)
-            .await
-            .unwrap();
+    let ce_ids: Vec<i64> = sqlx::query_scalar("SELECT id FROM cycle_events ORDER BY id")
+        .fetch_all(pool_b)
+        .await
+        .unwrap();
     assert_eq!(ce_ids, vec![1i64, 2], "AC-17: cycle_events.id preserved");
 
     // Verify graph_edges present
@@ -1529,6 +1540,9 @@ async fn test_round_trip_all_11_tables() {
         lines2.len()
     );
     for (i, (a, b)) in lines1.iter().zip(lines2.iter()).enumerate() {
-        assert_eq!(a, b, "AC-15: line {i} differs:\n  export1: {a}\n  export2: {b}");
+        assert_eq!(
+            a, b,
+            "AC-15: line {i} differs:\n  export1: {a}\n  export2: {b}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds `embedding_model_sha256` config field to `InferenceConfig`, mirroring the existing `nli_model_sha256` pattern
- Extracts `verify_sha256()` from `nli_handle.rs` into shared `infra/hash.rs` module, used by both NLI and embedding handles
- Enforces verify-before-load ordering: `ensure_model()` → `verify_sha256()` → `OnnxProvider::new()` — hash is checked before the ONNX session loads into memory
- Global-wins merge semantics: per-project config cannot override a global hash pin (security-critical field)
- Adds SHA-256 output for embedding model in `unimatrix model-download` CLI
- Adds import path warning in `embed_reconstruct.rs` when hash verification is unavailable

## Root Cause

crt-023 added SHA-256 hash verification for the NLI model but never back-ported it to the embedding model loading path. A replaced or corrupted embedding ONNX model file would be loaded without detection.

## Test Plan

- [x] 4 hash verification unit tests (correct, wrong, missing file, case-insensitive)
- [x] 5 config validation tests (wrong length, 63 chars, non-hex, valid 64 hex, None)
- [x] 4 global-wins merge tests (global wins, project fallback, both None, same value)
- [x] Full workspace: 5293 tests passed, 0 failed
- [x] Integration: 301 tests passed, 0 failed
- [x] Clippy: no new warnings

Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)