### PR TITLE
fix(test): align TestLargeContent thresholds with 8KB server limit (#652)

### DIFF
--- a/product/test/infra-001/suites/test_volume.py
+++ b/product/test/infra-001/suites/test_volume.py
@@ -111,21 +111,21 @@ class TestVolume1K:
 class TestLargeContent:
     """Tests for large content payloads.
 
-    Server enforces a 50,000 character limit on content. Tests validate
-    behavior at and beyond this boundary.
+    Server enforces an 8,000 byte limit on content (StoreConfig.max_content_bytes).
+    Tests validate behavior at and beyond this boundary.
     """
 
     def test_large_content_at_limit(self, server):
-        """V-09: Content at server limit (49,999 chars) accepted."""
-        content = load_large_content(49999)
+        """V-09: Content at server limit (7,999 bytes) accepted."""
+        content = load_large_content(7999)
         resp = server.context_store(
             content, "testing", "convention", agent_id="human"
         )
         assert_tool_success(resp)
 
     def test_large_content_over_limit_rejected(self, server):
-        """V-10: Content over 50,000 chars rejected with clear error."""
-        content = load_large_content(51000)
+        """V-10: Content over 8,000 bytes rejected with clear error."""
+        content = load_large_content(8001)
         resp = server.context_store(
             content, "testing", "convention", agent_id="human"
         )


### PR DESCRIPTION
## Summary

Bugfix #561 lowered the server's content limit from 50,000 characters to 8,000 bytes (`StoreConfig.max_content_bytes`), but the `TestLargeContent` integration tests in `test_volume.py` were not updated to match.

- V-09 (`test_large_content_at_limit`): 49,999 → 7,999 bytes
- V-10 (`test_large_content_over_limit`): 51,000 → 8,001 bytes  
- V-11 (`test_very_large_content`): unchanged (1MB, already well above limit)
- Docstrings updated from "characters" → "bytes" to match `str::len()` enforcement

## Test Results

| Suite | Result |
|-------|--------|
| TestLargeContent | 3/3 pass |
| Cargo workspace | 4661/4661 pass |
| Integration smoke | 23/23 pass |
| Volume suite | 11/11 pass |

## Gate

Bug Fix Validation — **PASS** (7/7 checks)

Closes #652