### PR TITLE
fix(deps): bump openssl 0.10.80 and rustls-webpki 0.103.13 (#665)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,15 +2013,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2045,9 +2044,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -2660,9 +2659,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Bumps `openssl` 0.10.75 → 0.10.80, `openssl-sys` 0.9.111 → 0.9.116, `rustls-webpki` 0.103.9 → 0.103.13
- Resolves 4 high-severity CVEs in openssl (CVE-2026-41681, CVE-2026-41898, CVE-2026-41678, CVE-2026-41676) and 1 high-severity DoS in rustls-webpki
- Cargo.lock-only change — no source code or Cargo.toml modifications

## Test plan
- [x] `cargo build --workspace` — compiles clean
- [x] `cargo test --workspace` — 5,416 passed, 0 failed
- [x] `cargo clippy --workspace` — no new warnings (52 pre-existing in unimatrix-observe)
- [x] Integration smoke tests — 23/23 passed
- [x] Dry-run confirmed only 3 packages changed

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)