### PR TITLE
fix(router): enforce body size limit on stream, not just Content-Length header (#663)

### DIFF
--- a/crates/unimatrix-server/src/http/router.rs
+++ b/crates/unimatrix-server/src/http/router.rs
@@ -18,7 +18,7 @@ use bytes::Bytes;
 use http::{Method, Request, Response, StatusCode};
 use http_body::Body;
 use http_body_util::combinators::BoxBody;
-use http_body_util::{BodyExt, Full};
+use http_body_util::{BodyExt, Full, Limited};
 use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
 use rmcp::transport::{StreamableHttpServerConfig, StreamableHttpService};
 use tower::Service;
@@ -45,7 +45,7 @@ pub struct PathRouter<ReqBody>
 where
     ReqBody: Body + Send + 'static,
     ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
+    ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     project_router: ProjectRouter<ReqBody>,
 }
@@ -54,7 +54,7 @@ impl<ReqBody> std::fmt::Debug for PathRouter<ReqBody>
 where
     ReqBody: Body + Send + 'static,
     ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
+    ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PathRouter")
@@ -67,7 +67,7 @@ impl<ReqBody> PathRouter<ReqBody>
 where
     ReqBody: Body + Send + 'static,
     ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
+    ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     /// Create a new PathRouter wrapping a ProjectRouter.
     pub fn new(project_router: ProjectRouter<ReqBody>) -> Self {
@@ -79,7 +79,7 @@ impl<ReqBody> Clone for PathRouter<ReqBody>
 where
     ReqBody: Body + Send + 'static,
     ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
+    ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     fn clone(&self) -> Self {
         PathRouter {
@@ -92,7 +92,7 @@ impl<ReqBody> Service<Request<ReqBody>> for PathRouter<ReqBody>
 where
     ReqBody: Body + Send + 'static,
     ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
+    ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     type Response = Response<BoxBody<Bytes, Infallible>>;
     type Error = Infallible;
@@ -165,16 +165,17 @@ pub struct ProjectRouter<ReqBody>
 where
     ReqBody: Body + Send + 'static,
     ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
+    ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
-    default_server: McpAdapter<ReqBody>,
+    default_server: McpAdapter,
+    _phantom: std::marker::PhantomData<fn(ReqBody)>,
 }
 
 impl<ReqBody> std::fmt::Debug for ProjectRouter<ReqBody>
 where
     ReqBody: Body + Send + 'static,
     ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
+    ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ProjectRouter")
@@ -187,13 +188,14 @@ impl<ReqBody> ProjectRouter<ReqBody>
 where
     ReqBody: Body + Send + 'static,
     ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
+    ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     /// Create a new ProjectRouter in single-project default mode.
     pub fn new(server: UnimatrixServer, max_body_bytes: usize) -> Self {
         let mcp_adapter = McpAdapter::new(server, max_body_bytes);
         ProjectRouter {
             default_server: mcp_adapter,
+            _phantom: std::marker::PhantomData,
         }
     }
 
@@ -214,11 +216,12 @@ impl<ReqBody> Clone for ProjectRouter<ReqBody>
 where
     ReqBody: Body + Send + 'static,
     ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
+    ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
 {
     fn clone(&self) -> Self {
         ProjectRouter {
             default_server: self.default_server.clone(),
+            _phantom: std::marker::PhantomData,
         }
     }
 }
@@ -232,29 +235,25 @@ where
 /// maps rmcp errors to consistent JSON responses, and provides a workaround
 /// seam for extension propagation issues.
 ///
+/// Body size enforcement uses a two-layer strategy:
+/// 1. **Fast-path**: Content-Length header check rejects oversized requests
+///    without reading any body bytes (zero-cost for well-behaved clients).
+/// 2. **Stream-level**: `http_body_util::Limited` wraps the body stream to
+///    enforce the limit regardless of transfer encoding (chunked TE fix,
+///    GH #663). The body is fully collected before passing to rmcp.
+///
 /// R-01 spike result: extensions DO propagate through rmcp (the `Parts`
 /// struct including `extensions` is injected into MCP message extensions).
 /// The copy step is therefore a debug assertion, not a runtime fallback.
-pub(crate) struct McpAdapter<ReqBody>
-where
-    ReqBody: Body + Send + 'static,
-    ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
-{
+#[derive(Clone)]
+pub(crate) struct McpAdapter {
     /// The rmcp StreamableHttpService. Isolated behind this adapter.
     streamable: StreamableHttpService<UnimatrixServer, LocalSessionManager>,
     /// Maximum request body size (bytes). Enforced before rmcp sees the body.
     max_body_bytes: usize,
-    /// Phantom for ReqBody generic.
-    _phantom: std::marker::PhantomData<fn(ReqBody)>,
 }
 
-impl<ReqBody> std::fmt::Debug for McpAdapter<ReqBody>
-where
-    ReqBody: Body + Send + 'static,
-    ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
-{
+impl std::fmt::Debug for McpAdapter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("McpAdapter")
             .field("max_body_bytes", &self.max_body_bytes)
@@ -262,12 +261,7 @@ where
     }
 }
 
-impl<ReqBody> McpAdapter<ReqBody>
-where
-    ReqBody: Body + Send + 'static,
-    ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
-{
+impl McpAdapter {
     /// Create a new McpAdapter wrapping a `StreamableHttpService`.
     fn new(server: UnimatrixServer, max_body_bytes: usize) -> Self {
         let session_manager = Arc::new(LocalSessionManager::default());
@@ -279,16 +273,25 @@ where
         McpAdapter {
             streamable,
             max_body_bytes,
-            _phantom: std::marker::PhantomData,
         }
     }
 
     /// Handle an MCP request with body size enforcement and error mapping.
-    async fn handle(
+    ///
+    /// Generic over the incoming body type so callers can pass any
+    /// `Body` (e.g., `hyper::body::Incoming`). The body is consumed here;
+    /// rmcp always receives `Request<Full<Bytes>>`.
+    async fn handle<ReqBody>(
         &mut self,
         request: Request<ReqBody>,
-    ) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
-        // Step 1: Enforce body size limit BEFORE rmcp (R-11, ADR-003).
+    ) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible>
+    where
+        ReqBody: Body + Send + 'static,
+        ReqBody::Data: Send + 'static,
+        ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        // Step 1: Fast-path Content-Length header check (zero-cost rejection).
+        // Rejects obviously oversized requests without reading any body bytes.
         let exceeds_limit = request
             .headers()
             .get(http::header::CONTENT_LENGTH)
@@ -300,28 +303,37 @@ where
             return Ok(payload_too_large_response());
         }
 
-        // Step 2: Delegate to StreamableHttpService.
+        // Step 2: Stream-level body collection with size limit (GH #663).
+        // Limited wraps the body stream and returns LengthLimitError if the
+        // accumulated data exceeds max_body_bytes. This catches chunked TE
+        // bodies that omit Content-Length.
+        let (parts, body) = request.into_parts();
+        let limited_body = Limited::new(body, self.max_body_bytes);
+
+        let collected = match limited_body.collect().await {
+            Ok(collected) => collected,
+            Err(err) => {
+                // Distinguish size-limit errors from other body read errors
+                // (e.g., client disconnect). Only return 413 for LengthLimitError.
+                if err
+                    .downcast_ref::<http_body_util::LengthLimitError>()
+                    .is_some()
+                {
+                    return Ok(payload_too_large_response());
+                }
+                // Other body read errors (disconnect, malformed chunks) → 500.
+                return Ok(internal_error_response());
+            }
+        };
+
+        // Step 3: Reconstruct request with fully-collected body for rmcp.
         // R-01 validated: extensions propagate through rmcp via Parts injection.
-        let response = self.streamable.call(request).await;
+        let full_request = Request::from_parts(parts, Full::new(collected.to_bytes()));
+        let response = self.streamable.call(full_request).await;
 
         match response {
             Ok(resp) => Ok(resp),
             Err(never) => match never {},
-        }
-    }
-}
-
-impl<ReqBody> Clone for McpAdapter<ReqBody>
-where
-    ReqBody: Body + Send + 'static,
-    ReqBody::Data: Send + 'static,
-    ReqBody::Error: std::fmt::Display,
-{
-    fn clone(&self) -> Self {
-        McpAdapter {
-            streamable: self.streamable.clone(),
-            max_body_bytes: self.max_body_bytes,
-            _phantom: std::marker::PhantomData,
         }
     }
 }
@@ -341,6 +353,21 @@ fn payload_too_large_response() -> Response<BoxBody<Bytes, Infallible>> {
             ))
             .map_err(|never| match never {})
             .boxed(),
+        )
+        .expect("static response builder cannot fail")
+}
+
+/// 500 Internal Server Error response for body read failures (e.g., client
+/// disconnect, malformed chunks). Distinct from 413 to avoid masking
+/// non-size-related errors (GH #663).
+fn internal_error_response() -> Response<BoxBody<Bytes, Infallible>> {
+    Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .header("content-type", "application/json")
+        .body(
+            Full::new(Bytes::from(r#"{"error":"failed to read request body"}"#))
+                .map_err(|never| match never {})
+                .boxed(),
         )
         .expect("static response builder cannot fail")
 }

--- a/crates/unimatrix-server/src/http/router/tests.rs
+++ b/crates/unimatrix-server/src/http/router/tests.rs
@@ -27,7 +27,8 @@ async fn collect_body(resp: Response<BoxBody<Bytes, Infallible>>) -> (StatusCode
 }
 
 /// Mock MCP adapter that returns 200 with a marker body when called.
-/// Enforces body size limits (mirrors real McpAdapter behavior).
+/// Enforces body size limits using the same two-layer strategy as the real
+/// McpAdapter: Content-Length fast-path + Limited stream-level check (GH #663).
 #[derive(Debug, Clone)]
 struct MockMcpAdapter {
     max_body_bytes: usize,
@@ -44,11 +45,16 @@ impl MockMcpAdapter {
         MockMcpAdapter { max_body_bytes }
     }
 
-    async fn handle(
+    async fn handle<ReqBody>(
         &self,
-        request: Request<TestBody>,
-    ) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
-        // Enforce body size limit (mirrors real adapter).
+        request: Request<ReqBody>,
+    ) -> Result<Response<BoxBody<Bytes, Infallible>>, Infallible>
+    where
+        ReqBody: Body + Send + 'static,
+        ReqBody::Data: Send + 'static,
+        ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        // Layer 1: Content-Length fast-path (mirrors real adapter).
         let exceeds_limit = request
             .headers()
             .get(http::header::CONTENT_LENGTH)
@@ -58,6 +64,23 @@ impl MockMcpAdapter {
 
         if exceeds_limit {
             return Ok(payload_too_large_response());
+        }
+
+        // Layer 2: Stream-level Limited body check (GH #663).
+        let (_parts, body) = request.into_parts();
+        let limited_body = Limited::new(body, self.max_body_bytes);
+
+        match limited_body.collect().await {
+            Ok(_collected) => {}
+            Err(err) => {
+                if err
+                    .downcast_ref::<http_body_util::LengthLimitError>()
+                    .is_some()
+                {
+                    return Ok(payload_too_large_response());
+                }
+                return Ok(internal_error_response());
+            }
         }
 
         Ok(Response::builder()
@@ -74,10 +97,15 @@ impl MockMcpAdapter {
 
 /// Simulate PathRouter dispatch logic with a mock backend.
 /// Tests the routing decisions without requiring a full UnimatrixServer.
-async fn dispatch_request(
+async fn dispatch_request<ReqBody>(
     mock: &MockMcpAdapter,
-    request: Request<TestBody>,
-) -> Response<BoxBody<Bytes, Infallible>> {
+    request: Request<ReqBody>,
+) -> Response<BoxBody<Bytes, Infallible>>
+where
+    ReqBody: Body + Send + 'static,
+    ReqBody::Data: Send + 'static,
+    ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
     let path = request.uri().path().to_owned();
     let method = request.method().clone();
 
@@ -169,7 +197,7 @@ async fn test_post_observe_returns_501_stub() {
     );
 }
 
-// ---- T-PR-06: Body size limit rejects oversized ----
+// ---- T-PR-06: Body size limit rejects oversized (Content-Length fast-path) ----
 
 #[tokio::test]
 async fn test_body_size_limit_rejects_oversized() {
@@ -369,4 +397,176 @@ fn test_payload_too_large_response_format() {
 #[test]
 fn test_default_max_body_bytes() {
     assert_eq!(DEFAULT_MAX_BODY_BYTES, 1_048_576);
+}
+
+// ---------------------------------------------------------------------------
+// GH #663 — Chunked TE body size enforcement tests
+// ---------------------------------------------------------------------------
+
+/// Custom multi-frame body for testing chunked-style delivery without needing
+/// the `futures` crate. Yields frames from a `VecDeque`, then signals end.
+struct ChunkedTestBody {
+    frames: std::collections::VecDeque<
+        Result<http_body::Frame<Bytes>, Box<dyn std::error::Error + Send + Sync>>,
+    >,
+}
+
+impl ChunkedTestBody {
+    /// Create from multiple byte chunks (simulates chunked TE with no Content-Length).
+    fn from_chunks(chunks: Vec<Vec<u8>>) -> Self {
+        let frames = chunks
+            .into_iter()
+            .map(|c| Ok(http_body::Frame::data(Bytes::from(c))))
+            .collect();
+        ChunkedTestBody { frames }
+    }
+
+    /// Create a body that yields one good chunk then an error (simulates disconnect).
+    fn with_disconnect(good_chunk: Vec<u8>) -> Self {
+        let mut frames = std::collections::VecDeque::new();
+        frames.push_back(Ok(http_body::Frame::data(Bytes::from(good_chunk))));
+        frames.push_back(Err(
+            Box::new(DisconnectError) as Box<dyn std::error::Error + Send + Sync>
+        ));
+        ChunkedTestBody { frames }
+    }
+}
+
+impl Body for ChunkedTestBody {
+    type Data = Bytes;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    fn poll_frame(
+        mut self: std::pin::Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        Poll::Ready(self.frames.pop_front())
+    }
+}
+
+/// Test error simulating a client disconnect mid-stream.
+#[derive(Debug)]
+struct DisconnectError;
+
+impl std::fmt::Display for DisconnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("client disconnected")
+    }
+}
+
+impl std::error::Error for DisconnectError {}
+
+// ---- GH #663 T1: Chunked body under limit → 200 ----
+
+#[tokio::test]
+async fn test_chunked_body_under_limit_returns_200() {
+    let mock = MockMcpAdapter::with_max_body_bytes(1024);
+
+    // 3 chunks of 100 bytes each = 300 bytes, well under 1024 limit.
+    // No Content-Length header — simulates chunked TE.
+    let body = ChunkedTestBody::from_chunks(vec![vec![0u8; 100], vec![0u8; 100], vec![0u8; 100]]);
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/mcp")
+        .body(body)
+        .unwrap();
+
+    let resp = dispatch_request(&mock, req).await;
+    let (status, body) = collect_body(resp).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.contains(r#""routed":"mcp""#), "body: {body}");
+}
+
+// ---- GH #663 T2: Chunked body over limit → 413 (Limited catches it) ----
+
+#[tokio::test]
+async fn test_chunked_body_over_limit_returns_413() {
+    let mock = MockMcpAdapter::with_max_body_bytes(256);
+
+    // 4 chunks of 100 bytes = 400 bytes, over 256 limit.
+    // No Content-Length header — the old header-only check would miss this.
+    let body = ChunkedTestBody::from_chunks(vec![
+        vec![0u8; 100],
+        vec![0u8; 100],
+        vec![0u8; 100],
+        vec![0u8; 100],
+    ]);
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/mcp")
+        .body(body)
+        .unwrap();
+
+    let resp = dispatch_request(&mock, req).await;
+    let (status, body) = collect_body(resp).await;
+
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+    assert!(
+        body.contains("request body exceeds maximum size"),
+        "body: {body}"
+    );
+}
+
+// ---- GH #663 T3: Content-Length over limit → 413 (fast-path, no body read) ----
+
+#[tokio::test]
+async fn test_content_length_over_limit_fast_path_413() {
+    let mock = MockMcpAdapter::with_max_body_bytes(512);
+
+    // Content-Length header declares 1024 bytes, over 512 limit.
+    // Body content is irrelevant — header check should reject immediately.
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/mcp")
+        .header("content-length", "1024")
+        .body(empty_body())
+        .unwrap();
+
+    let resp = dispatch_request(&mock, req).await;
+    let (status, body) = collect_body(resp).await;
+
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+    assert!(
+        body.contains("request body exceeds maximum size"),
+        "body: {body}"
+    );
+}
+
+// ---- GH #663 T4: Mid-stream disconnect → 500, NOT 413 ----
+
+#[tokio::test]
+async fn test_midstream_body_error_returns_500_not_413() {
+    let mock = MockMcpAdapter::with_max_body_bytes(1024);
+
+    // Body sends 100 good bytes then errors (simulates client disconnect).
+    // Limit is 1024 so this is NOT a size violation.
+    let body = ChunkedTestBody::with_disconnect(vec![0u8; 100]);
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/mcp")
+        .body(body)
+        .unwrap();
+
+    let resp = dispatch_request(&mock, req).await;
+    let (status, body) = collect_body(resp).await;
+
+    // Must be 500, NOT 413 — this is a disconnect, not a size violation.
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert!(body.contains("failed to read request body"), "body: {body}");
+}
+
+// ---- GH #663: internal_error_response format ----
+
+#[test]
+fn test_internal_error_response_format() {
+    let resp = internal_error_response();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        resp.headers().get("content-type").unwrap(),
+        "application/json"
+    );
 }


### PR DESCRIPTION
## Summary

- Chunked transfer encoding bypassed the 1MB body size limit because `McpAdapter::handle` only checked the `Content-Length` header — which chunked TE omits entirely
- Added stream-level `http_body_util::Limited` enforcement that pre-consumes the body with a size cap before passing to rmcp, returning **413 Payload Too Large** on limit exceeded
- Kept the Content-Length header check as a zero-cost fast-path (rejects without reading body bytes)
- Removed the `ReqBody` generic from `McpAdapter` — it now always passes `Full<Bytes>` to rmcp, simplifying type signatures
- Proper error discrimination: `LengthLimitError` → 413, other body errors (client disconnect) → 500

Closes #663

## Test plan

- [x] `test_chunked_body_under_limit_returns_200` — chunked body under limit passes through
- [x] `test_chunked_body_over_limit_returns_413` — Limited catches oversized chunked body
- [x] `test_content_length_over_limit_fast_path_413` — header fast-path still works
- [x] `test_midstream_body_error_returns_500_not_413` — error downcasting is correct
- [x] `test_internal_error_response_format` — response format verification
- [x] Full workspace: 5,421 unit tests passed
- [x] Integration smoke: 23/23 passed
- [x] Integration security suite: 20/20 passed
- [x] Clippy clean (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)