### PR TITLE
fix: rmcp-1.7 schema test expectations + stale binary-name refs (#684, #685)

### DIFF
--- a/.claude/skills/uni-git/SKILL.md
+++ b/.claude/skills/uni-git/SKILL.md
@@ -102,12 +102,12 @@ Each worktree contains a full `target/` build directory (~1-2GB). Failing to cle
 
 | Binary | Location | Used by |
 |--------|----------|---------|
-| Installed | `~/.local/bin/unimatrix-server` | Hooks, MCP server |
-| Build artifact | `target/release/unimatrix-server` | Integration tests |
+| Installed | `~/.local/bin/unimatrix` | Hooks, MCP server |
+| Build artifact | `target/release/unimatrix` | Integration tests |
 
 - `cargo build --release` in a worktree does NOT affect `~/.local/bin/` or other worktrees (each worktree has its own `target/`)
 - To update the installed binary: `cargo install --path crates/unimatrix-server`
-- Integration tests in worktrees: set `UNIMATRIX_BINARY` to the worktree's own `target/release/unimatrix-server`
+- Integration tests in worktrees: set `UNIMATRIX_BINARY` to the worktree's own `target/release/unimatrix`
 
 ## Rules
 

--- a/crates/unimatrix-server/src/server.rs
+++ b/crates/unimatrix-server/src/server.rs
@@ -3246,6 +3246,17 @@ mod tests {
     }
 
     // -- vnc-012 AC-10: schema snapshot — #[schemars(with = "T")] preserves type: integer --
+    //
+    // GH#684: rmcp >= 1.7 removed schemars' AddNullable transform (an OpenAPI 3.0
+    // extension, not JSON Schema 2020-12) from its schema generator. Option-backed
+    // fields now emit the spec-correct nullable union `"type": ["integer", "null"]`
+    // instead of bare `"integer"` + `nullable: true`. Required fields (with = "i64")
+    // still emit bare `"integer"`. The union is truthful — the server accepts JSON
+    // null for these params (serde_util.rs) — and is the contract going forward.
+    // Type-array unions are standard JSON Schema 2020-12 and verified compatible
+    // with Claude Code tool-schema parsing. AC-10's intent (guarding against the
+    // empty-schema `{}` fallback from an unpaired #[serde(deserialize_with)]) is
+    // preserved: a typo'd `with` attribute still emits `{}` and fails these asserts.
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_schema_integer_type_preserved_for_all_nine_fields() {
@@ -3263,12 +3274,17 @@ mod tests {
             })
             .collect();
 
-        // The 9 fields to verify as (tool_name, field_name) pairs
-        let checks: &[(&str, &str)] = &[
+        // 4 required fields (#[schemars(with = "i64")]) — bare "integer"
+        let required_checks: &[(&str, &str)] = &[
             ("context_get", "id"),
             ("context_deprecate", "id"),
             ("context_quarantine", "id"),
             ("context_correct", "original_id"),
+        ];
+
+        // 5 optional fields (#[schemars(with = "Option<...>")]) — rmcp >= 1.7 emits
+        // the JSON Schema 2020-12 nullable union ["integer", "null"]
+        let optional_checks: &[(&str, &str)] = &[
             ("context_lookup", "id"),
             ("context_lookup", "limit"),
             ("context_search", "k"),
@@ -3277,7 +3293,7 @@ mod tests {
             ("context_cycle_review", "evidence_limit"),
         ];
 
-        for (tool_name, field_name) in checks {
+        for (tool_name, field_name) in required_checks {
             let schema = schema_by_name
                 .get(*tool_name)
                 .unwrap_or_else(|| panic!("AC-10: tool {tool_name} not found in schema_by_name"));
@@ -3285,7 +3301,22 @@ mod tests {
             let field_type = &schema["properties"][field_name]["type"];
             assert_eq!(
                 field_type, "integer",
-                "AC-10: field {field_name} on {tool_name} must have type: integer in JSON schema; \
+                "AC-10: required field {field_name} on {tool_name} must have type: integer in \
+                 JSON schema; got: {field_type}. Check #[schemars(with = ...)] attribute."
+            );
+        }
+
+        for (tool_name, field_name) in optional_checks {
+            let schema = schema_by_name
+                .get(*tool_name)
+                .unwrap_or_else(|| panic!("AC-10: tool {tool_name} not found in schema_by_name"));
+
+            let field_type = &schema["properties"][field_name]["type"];
+            assert_eq!(
+                field_type,
+                &serde_json::json!(["integer", "null"]),
+                "AC-10: optional field {field_name} on {tool_name} must have type: \
+                 [integer, null] in JSON schema (rmcp >= 1.7 nullable union, GH#684); \
                  got: {field_type}. Check #[schemars(with = ...)] attribute."
             );
         }

--- a/product/features/684-685/agents/684-685-design-reviewer-report.md
+++ b/product/features/684-685/agents/684-685-design-reviewer-report.md
@@ -1,0 +1,44 @@
+# Design Review: 684-685-design-reviewer
+
+Combined bugfix design review for GH#684 (schema nullable union) and GH#685 (harness ServerDied).
+
+## Design Assessment
+
+- **Bug 1 (#684): APPROVED** — test-only fix is correct; the union schema is spec-correct, truthful, and preserves AC-10's guard intent.
+- **Bug 2 (#685): APPROVED WITH NOTES** — doc/Docker rename is correct; preflight check should be IN scope; one rename trap flagged.
+
+## Verification Performed
+
+- Read both investigator reports (GH comments) and the failing test (`crates/unimatrix-server/src/server.rs:3250-3304`), the 5 optional fields in `mcp/tools.rs`, and `mcp/serde_util.rs` (null acceptance confirmed at the visitor level).
+- Confirmed stale artifact: `target/release/unimatrix-server` mtime Mar 12 (20.7 MB) vs current `target/release/unimatrix` (Jun 5). Cargo.toml: package = `unimatrix-server`, bin = `unimatrix`.
+- Confirmed all stale references: `USAGE-PROTOCOL.md:11,36,92`, `Dockerfile:37,41`, `docker-compose.yml:14`. `conftest.py` auto-detection already resolves the correct name.
+- Counted smoke marks: exactly 23 across `suites/` — the investigator's 23/23 green run was the full smoke set.
+
+## Findings
+
+### Bug 1 (#684)
+
+1. **Non-blocking (but post a correcting comment on #684)** — The "Integration manifestation (same root cause)" comment claiming `test_get_with_string_id` / `test_deprecate_with_string_id` fail with -32602 under rmcp 1.7 is **refuted**. Both tests are `@pytest.mark.smoke` (`test_tools.py:1867,1900`) and therefore passed in the verified 23/23 run against the correct binary. Corroborating evidence: the reported error text `expected i64` matches a plain serde i64 deserializer — the current visitor's expecting string is "an integer or a string containing a base-10 integer". The -32602 run hit the stale 0.1.0 binary (built Mar 12, **before** vnc-012 added the coercion deserializers on Mar 29). String coercion lives in `serde_util.rs`, not rmcp; there is no rmcp-1.7 runtime coercion regression. The fix plan must NOT add any production change for this comment, and the comment should be corrected on the issue to prevent future misdiagnosis.
+2. **Non-blocking** — When updating the test, keep per-field assertion messages and note the rmcp-version coupling in the comment block (planned). Exact-equality against `json!(["integer","null"])` is fine; schemars emission order is deterministic.
+3. **(a) Test-update vs schemars-attribute: test-update is correct.** Forcing `#[schemars(with = "i64")]` on the 5 Option fields would advertise that `null` is invalid while `deserialize_opt_*` accepts it, would diverge from rmcp's MCP-spec alignment, and would not even restore the 0.16 wire shape (0.16 also emitted `nullable: true`). AC-10's intent (vnc-012 ADR-002) survives: a typo'd `with` attribute still emits `{}` and still fails the per-field assertion.
+4. **ADR maintenance done** — ADR-002 (#3788) stated the snapshot test asserts bare `"integer"` for all nine fields; that is stale since vnc-023 merged. Corrected to entry **#4732** documenting the rmcp-version-dependent shape and the do-not-force-bare-type rule.
+
+### Bug 2 (#685)
+
+1. **Non-blocking (trap — flag to implementer)** — `Dockerfile:15` `cargo build --release --package unimatrix-server` must **NOT** be renamed: the *package* is still `unimatrix-server` (`crates/unimatrix-server/Cargo.toml:2`); only the `[[bin]]` target is `unimatrix`. Only lines 37/41 (COPY/ENV) change. An over-zealous global rename breaks the docker build.
+2. **(b) Preflight check: IN scope.** The bug is environmental; without it the PR is doc-only with no regression guard — the preflight IS this bug's missing test, and test infra is cumulative per project rules. Keep minimal: in the session-scoped binary fixture, run the binary once and assert the reported version matches the workspace version (or at minimum that `serve` appears in `--help`). Implementer must verify the actual version invocation (`version` subcommand vs `--version`) rather than assume.
+3. **(c) Artifact deletion: not a PR change.** `target/release/unimatrix-server` is untracked build output — it cannot appear in a diff. Delete locally, note in the PR description. The preflight check is the durable guard for other machines and CI caches holding the fossil.
+4. **Non-blocking** — `ServerDied` hardening: the class already captures stderr (`client.py:50-54`, `self.stderr_output`); only the message changes. Bound the included stderr (e.g., last 3 lines) to avoid unbounded exception messages. Recommended — its absence directly caused the original misdiagnosis.
+5. **Non-blocking, optional** — `client.py:58` docstring still says "unimatrix-server subprocess"; cosmetic consistency.
+6. **Concur with investigator**: do NOT change the launch command — bare invocation is bridge mode (`main.rs:172-190`), not the stdio server. The issue's original suggestion would have introduced the real regression.
+
+### Cross-cutting
+
+- **Hot-path risks**: none. All changes are tests, docs, packaging; the client.py change is exception-path only.
+- **Blast radius**: #684 worst case = miscategorized field → loud test failure, zero production effect. #685 worst case = Dockerfile typo → build fails at COPY (immediate); compose env mismatch → caught by the preflight.
+- **Security**: no new trust boundaries. stderr in exception messages surfaces server logs in pytest output — local harness only, acceptable.
+- **Out of scope, concur**: PR CI lacks `cargo test --workspace` (how vnc-023 merged red). File as a separate nan-phase item; do not bundle here.
+
+## Knowledge Stewardship
+- Queried: mcp__unimatrix__context_briefing -- surfaced ADR-002 #3788 (AC-10 origin, decisive for assessing test-update vs attribute), lessons #4730/#4731 (already stored by investigators), patterns #3813/#3814 (deserialize_with pairing + string-id integration test mandate), #4699 (rmcp migration surface).
+- Stored: entry #4732 "ADR-002: Preserve integer JSON Schema via #[schemars(with = \"T\")]" via context_correct of #3788 -- amended the stale snapshot-test contract to document rmcp>=1.7 nullable-union shape and the do-not-force-bare-type rule. No new ADR needed: both fixes follow existing decisions; investigator lessons #4730/#4731 cover the failure modes.

--- a/product/features/684-685/agents/684-685-security-reviewer-report.md
+++ b/product/features/684-685/agents/684-685-security-reviewer-report.md
@@ -1,0 +1,57 @@
+# Security Review: 684-685-security-reviewer
+
+## Risk Level: low
+
+## Summary
+Test-expectation update (#684) plus binary-rename doc/Docker fixes and a session-scoped preflight guard (#685). No production runtime code changes. No new trust boundaries, no injection surface, no new dependencies, no secrets. No blocking findings.
+
+## Findings
+
+### 1. Schema union does not loosen input validation (#684)
+- **Severity**: none (verified non-issue)
+- **Location**: crates/unimatrix-server/src/server.rs:3246-3320 (test-only)
+- **Description**: The `["integer","null"]` union on 5 optional fields is truthful — `deserialize_opt_i64_or_string`/`deserialize_opt_usize_or_string` (`mcp/serde_util.rs`) have accepted JSON `null` since vnc-012 (`visit_none`/`visit_unit` → `None`). The 4 required fields' `I64OrStringVisitor` has no `visit_none`, so null is still rejected (-32602). Advertised schema now matches actual acceptance. AC-10's empty-schema `{}` guard survives (fails both assertion branches).
+- **Blocking**: no
+
+### 2. Preflight subprocess execution
+- **Severity**: low (informational)
+- **Location**: product/test/infra-001/harness/conftest.py:74-127
+- **Description**: `subprocess.run([binary, "version"], ...)` — list args, no shell, no injection. `UNIMATRIX_BINARY` is operator-controlled test config the harness already executes via `Popen` in client.py; no new trust boundary. Verified `handle_version` (main.rs:1461) is side-effect-free without `--project-dir` (DB-creation branch not reached). 30s timeout bounds hangs.
+- **Blocking**: no
+
+### 3. stderr tail in ServerDied exception messages
+- **Severity**: low (informational)
+- **Location**: product/test/infra-001/harness/client.py:51-62
+- **Description**: Server `RUST_LOG=info` output now appears in pytest error lines / CI logs. Bounded to 3 lines; full stderr was already retained on `self.stderr_output`. Acceptable for a local harness with synthetic data; revisit if the harness ever runs against real data in shared CI.
+- **Blocking**: no
+
+### 4. tomllib usage
+- **Severity**: none
+- **Location**: product/test/infra-001/harness/conftest.py:54-70
+- **Description**: Python 3.11+ stdlib (harness requires 3.12+) — no new dependency, no CVE surface. Parse failures (`OSError`/`TOMLDecodeError`/`KeyError`) degrade to skipping the version-match check; malformed Cargo.toml cannot crash collection.
+- **Blocking**: no
+
+### 5. Preflight false-positive friction
+- **Severity**: low
+- **Location**: product/test/infra-001/harness/conftest.py:117-126
+- **Description**: Strict version equality aborts sessions when an older binary is intentionally tested via `UNIMATRIX_BINARY`. Fail-closed and self-explanatory — correct trade-off. An env-var escape hatch can be added later if needed.
+- **Blocking**: no
+
+## Blast Radius Assessment
+- #684 worst case: miscategorized field → loud test failure; zero production effect.
+- #685 worst case: preflight bug → test-session abort (test-infra DoS only, never production). False-negative: same-version stale rebuild passes — still strictly better than pre-fix.
+- Dockerfile: COPY rename fails the build immediately if wrong (fail-closed). `--package unimatrix-server` correctly left unchanged (package vs bin-target distinction — design-review trap avoided).
+- Docker runtime image lacks workspace Cargo.toml → version-match skipped, execute/exit-code/format checks still run. Graceful degradation confirmed.
+
+## Regression Risk
+- Autouse session fixture runs in every harness invocation including Docker; verified safe degradation there.
+- `_WORKSPACE_ROOT` (5 `.parent` hops from harness/conftest.py) resolves correctly to repo root.
+- Exact-equality assertion on `["integer","null"]` couples the test to rmcp ≥1.7 emission order; investigator confirmed schemars emission deterministic. Test-only exposure.
+- suites/conftest.py re-export ensures fixture discovery — preserved.
+
+## PR Comments
+- Posted 1 review comment on PR #687 (gh pr review --comment)
+- Blocking findings: no
+
+## Knowledge Stewardship
+- Stored: nothing novel to store — lessons #4730/#4731 (rmcp nullable-union, stale bin-rename artifact) already stored by investigators; no recurring security anti-pattern observed across PRs.

--- a/product/test/infra-001/Dockerfile
+++ b/product/test/infra-001/Dockerfile
@@ -33,12 +33,13 @@ RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/o
     && ldconfig \
     && rm -rf onnxruntime-linux-x64-1.20.1*
 
-# Copy binary from builder
-COPY --from=builder /app/target/release/unimatrix-server /usr/local/bin/unimatrix-server
+# Copy binary from builder (bin target renamed unimatrix-server -> unimatrix in nan-004;
+# the cargo package above is still named unimatrix-server)
+COPY --from=builder /app/target/release/unimatrix /usr/local/bin/unimatrix
 
 # Environment for ONNX Runtime and binary location
 ENV LD_LIBRARY_PATH=/usr/local/lib
-ENV UNIMATRIX_BINARY=/usr/local/bin/unimatrix-server
+ENV UNIMATRIX_BINARY=/usr/local/bin/unimatrix
 ENV ORT_DYLIB_PATH=/usr/local/lib/libonnxruntime.so
 
 # Install Python test dependencies

--- a/product/test/infra-001/USAGE-PROTOCOL.md
+++ b/product/test/infra-001/USAGE-PROTOCOL.md
@@ -8,7 +8,7 @@ This document defines how the infra-001 integration test harness is used during 
 
 ## What the Harness Does
 
-The harness exercises the compiled `unimatrix-server` binary through the MCP JSON-RPC protocol over stdio — the exact interface agents use. It validates system-level behavior that unit tests cannot: protocol compliance, multi-step lifecycle flows, security defenses, confidence math, contradiction detection, scale behavior, and edge cases.
+The harness exercises the compiled `unimatrix` binary (built by the `unimatrix-server` package) through the MCP JSON-RPC protocol over stdio — the exact interface agents use. It validates system-level behavior that unit tests cannot: protocol compliance, multi-step lifecycle flows, security defenses, confidence math, contradiction detection, scale behavior, and edge cases.
 
 **205 tests across 9 suites:**
 
@@ -33,7 +33,7 @@ The harness exercises the compiled `unimatrix-server` binary through the MCP JSO
 **Local (no Docker):**
 - Python 3.12+
 - `pip install pytest pytest-timeout pytest-json-report`
-- Built binary at `target/release/unimatrix-server` (or set `UNIMATRIX_BINARY`)
+- Built binary at `target/release/unimatrix` (or set `UNIMATRIX_BINARY`)
 - ONNX Runtime shared library available (`ORT_DYLIB_PATH` or in `LD_LIBRARY_PATH`)
 
 **Docker:**
@@ -89,7 +89,7 @@ python -m pytest suites/test_tools.py::test_store_roundtrip -v
 | `TEST_SUITE` | `all` | Suite selection: `all`, `protocol`, `tools`, `lifecycle`, `volume`, `security`, `confidence`, `contradiction`, `edge_cases`, or comma-separated |
 | `TEST_WORKERS` | `1` | Parallel workers (use 1 — tests are not designed for parallel execution) |
 | `PYTEST_ARGS` | _(empty)_ | Extra pytest arguments (e.g., `-m smoke`, `-k test_store`, `--tb=short`) |
-| `UNIMATRIX_BINARY` | _(auto-detected)_ | Path to `unimatrix-server` binary |
+| `UNIMATRIX_BINARY` | _(auto-detected)_ | Path to `unimatrix` binary |
 | `RUST_LOG` | `info` | Server log level (visible in captured stderr) |
 | `RESULTS_DIR` | `/results` | Output directory for reports (Docker only) |
 

--- a/product/test/infra-001/docker-compose.yml
+++ b/product/test/infra-001/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - TEST_WORKERS=${TEST_WORKERS:-1}
       - PYTEST_ARGS=${PYTEST_ARGS:-}
       - RUST_LOG=${RUST_LOG:-info}
-      - UNIMATRIX_BINARY=/usr/local/bin/unimatrix-server
+      - UNIMATRIX_BINARY=/usr/local/bin/unimatrix
     volumes:
       - test-results:/results
     tmpfs:

--- a/product/test/infra-001/harness/client.py
+++ b/product/test/infra-001/harness/client.py
@@ -1,4 +1,4 @@
-"""MCP client library for unimatrix-server integration testing.
+"""MCP client library for unimatrix integration testing.
 
 Manages a server subprocess, handles MCP JSON-RPC protocol,
 and provides typed wrappers for all 10 context_* tools.
@@ -51,11 +51,18 @@ class ServerDied(ClientError):
     def __init__(self, returncode: int, stderr: str):
         self.returncode = returncode
         self.stderr_output = stderr
-        super().__init__(f"Server exited with code {returncode}")
+        # GH#685: include a bounded stderr tail so launch failures (e.g. clap
+        # rejecting a subcommand on a stale binary) are visible in the pytest
+        # error line instead of an opaque exit code.
+        tail = "\n".join(stderr.splitlines()[-3:]) if stderr else ""
+        message = f"Server exited with code {returncode}"
+        if tail:
+            message += f"; stderr tail:\n{tail}"
+        super().__init__(message)
 
 
 class UnimatrixClient:
-    """MCP client that manages a unimatrix-server subprocess.
+    """MCP client that manages a unimatrix server subprocess.
 
     Spawns the server binary, completes the MCP initialize handshake,
     provides typed methods for all 9 context_* tools, and handles

--- a/product/test/infra-001/harness/conftest.py
+++ b/product/test/infra-001/harness/conftest.py
@@ -2,11 +2,14 @@
 
 Provides function-scoped (fresh per test), module-scoped (shared),
 and populated server fixtures. Binary resolution from env var or
-workspace fallback.
+workspace fallback, plus a session-scoped binary version preflight.
 """
 
 import logging
 import os
+import re
+import subprocess
+import tomllib
 
 import pytest
 from pathlib import Path
@@ -18,6 +21,8 @@ logger = logging.getLogger("unimatrix.fixtures")
 
 BINARY_PATH: str | None = None
 
+_WORKSPACE_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+
 
 def _resolve_binary() -> str:
     """Find the unimatrix binary."""
@@ -25,10 +30,9 @@ def _resolve_binary() -> str:
     if env_path and os.path.isfile(env_path):
         return env_path
 
-    workspace_root = Path(__file__).resolve().parent.parent.parent.parent.parent
     candidates = [
-        workspace_root / "target" / "release" / "unimatrix",
-        workspace_root / "target" / "debug" / "unimatrix",
+        _WORKSPACE_ROOT / "target" / "release" / "unimatrix",
+        _WORKSPACE_ROOT / "target" / "debug" / "unimatrix",
     ]
     for candidate in candidates:
         if candidate.is_file():
@@ -45,6 +49,81 @@ def get_binary_path() -> str:
     if BINARY_PATH is None:
         BINARY_PATH = _resolve_binary()
     return BINARY_PATH
+
+
+def _workspace_version() -> str | None:
+    """Read the workspace version from the root Cargo.toml.
+
+    Returns None when the workspace Cargo.toml is not available (e.g. inside
+    the Docker test-runtime image, which only ships the harness).
+    """
+    cargo_toml = _WORKSPACE_ROOT / "Cargo.toml"
+    if not cargo_toml.is_file():
+        return None
+    try:
+        with open(cargo_toml, "rb") as f:
+            data = tomllib.load(f)
+        return data["workspace"]["package"]["version"]
+    except (OSError, tomllib.TOMLDecodeError, KeyError):
+        return None
+
+
+@pytest.fixture(scope="session", autouse=True)
+def binary_version_preflight():
+    """GH#685 regression guard: fail fast on a stale or mismatched binary.
+
+    The nan-004 bin rename (unimatrix-server -> unimatrix) left a stale
+    artifact that, when picked up via UNIMATRIX_BINARY, made all 23 smoke
+    tests error with an opaque 'ServerDied code 2'. This preflight runs the
+    binary's `version` subcommand once per session and asserts the reported
+    version matches the workspace Cargo.toml version, converting that failure
+    mode into one self-explanatory session abort.
+    """
+    binary = get_binary_path()
+
+    try:
+        proc = subprocess.run(
+            [binary, "version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        pytest.exit(
+            f"Binary preflight failed: could not run '{binary} version': {e}. "
+            "Check UNIMATRIX_BINARY points at a current unimatrix build.",
+            returncode=1,
+        )
+
+    if proc.returncode != 0:
+        stderr_tail = "\n".join(proc.stderr.splitlines()[-3:])
+        pytest.exit(
+            f"Binary preflight failed: '{binary} version' exited with code "
+            f"{proc.returncode} — the binary is likely a stale pre-rename "
+            f"artifact (GH#685). stderr tail:\n{stderr_tail}",
+            returncode=1,
+        )
+
+    match = re.search(r"unimatrix (\S+)", proc.stdout)
+    if not match:
+        pytest.exit(
+            f"Binary preflight failed: '{binary} version' printed unexpected "
+            f"output {proc.stdout.strip()!r} (expected 'unimatrix <version>').",
+            returncode=1,
+        )
+    binary_version = match.group(1)
+
+    expected = _workspace_version()
+    if expected is not None and binary_version != expected:
+        pytest.exit(
+            f"Binary preflight failed: binary at {binary} reports version "
+            f"{binary_version} but the workspace Cargo.toml version is "
+            f"{expected}. Rebuild with 'cargo build --release' or point "
+            "UNIMATRIX_BINARY at a current binary (GH#685).",
+            returncode=1,
+        )
+
+    logger.info("Binary preflight OK: %s (version %s)", binary, binary_version)
 
 
 @pytest.fixture(scope="function")

--- a/product/test/infra-001/suites/conftest.py
+++ b/product/test/infra-001/suites/conftest.py
@@ -14,4 +14,4 @@ if harness_parent not in sys.path:
 
 # Re-export fixtures so pytest discovers them for suites/
 from harness.conftest import server, shared_server, populated_server, admin_server, fast_tick_server  # noqa: F401
-from harness.conftest import get_binary_path  # noqa: F401
+from harness.conftest import get_binary_path, binary_version_preflight  # noqa: F401


### PR DESCRIPTION
## Summary

Combined bugfix for two rmcp 0.16→1.7 migration fallouts (vnc-023 #674):

### #684 — `context_lookup` id schema emits `["integer","null"]`
- **Root cause**: rmcp 1.7 removed schemars' `AddNullable` transform (JSON Schema 2020-12 compliance). The 5 `Option`-backed id fields now emit the nullable union; the 4 required `with = "i64"` fields still emit bare `"integer"`.
- **Fix**: test-only — `test_schema_integer_type_preserved_for_all_nine_fields` split into 4 required (`"integer"`) and 5 optional (`["integer","null"]`) expectations. No schemars attributes forced: the union is truthful (serde layer accepts null) and AC-10's empty-schema guard survives (a `{}` schema still fails both branches).
- **Client compatibility verified**: the union round-trips through Claude Code's tool-schema parsing — confirmed live against the running 0.7.2 server in an active Claude Code session. Codex/Gemini untested (multi-LLM criterion #4710/ass-049); if a stricter client rejects type-arrays, revisit with bare-type force.

### #685 — infra-001 harness ServerDied code 2
- **Root cause**: the GH issue's analysis was **refuted** — the harness launch command (`serve --stdio`) is correct. The failing run executed a stale v0.1.0 `target/release/unimatrix-server` artifact; nan-004 renamed the bin to `unimatrix` and docs still referenced the old name.
- **Fix**: binary-name refs corrected in `USAGE-PROTOCOL.md`, `Dockerfile` (COPY/env only — `--package unimatrix-server` is the package name, unchanged), `docker-compose.yml`, and `uni-git` skill; new session-scoped `binary_version_preflight` conftest fixture (regression guard — converts 23 opaque code-2 errors into one self-explanatory abort); `ServerDied` now surfaces a 3-line stderr tail (its absence caused the original misdiagnosis). Stale artifact deleted locally (untracked, no diff).

## Test results
- Unit: 5505 passed, 0 failed (workspace); target test passes
- Clippy: `unimatrix-server` clean; pre-existing Rust 1.95 lints in untouched `unimatrix-observe`/`unimatrix-engine` deferred to a separate nan item
- Integration smoke: 23 passed (pre-fix: 3 failed / 20 errors)
- Full integration suite: 352 passed, 12 xfailed, 2 xpassed (pre-existing ONNX-env markers), 0 failures
- Preflight guard verified to fire on both failure modes

Gate: Bug Fix Validation — **PASS** (8/8)

Closes #684
Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)