### PR TITLE
fix: harden cargo test convention to stop orphaned process trees (#122)

### DIFF
--- a/.claude/agents/ndp/ndp-validator.md
+++ b/.claude/agents/ndp/ndp-validator.md
@@ -77,7 +77,8 @@ Read `.claude/skills/validate/SKILL.md` for the full procedure. Summary:
 ```bash
 cargo build --workspace 2>&1 | grep -A5 "^error" | head -20
 cargo build --workspace 2>&1 | tail -3
-cargo test --workspace 2>&1 | tail -30
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
+setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 ```
 Plus anti-stub scan and deploy.sh integrity check (if deploy.sh was modified).
 
@@ -137,8 +138,9 @@ ALWAYS truncate cargo output:
 cargo build --workspace 2>&1 | grep -A5 "^error" | head -20
 cargo build --workspace 2>&1 | tail -3
 
-# Tests: summary only
-cargo test --workspace 2>&1 | tail -30
+# Tests: hardened workspace run — own process group + hard ceiling + file-not-pipe.
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
+setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30

--- a/.claude/agents/ndp/ndp-validator.md
+++ b/.claude/agents/ndp/ndp-validator.md
@@ -78,7 +78,7 @@ Read `.claude/skills/validate/SKILL.md` for the full procedure. Summary:
 cargo build --workspace 2>&1 | grep -A5 "^error" | head -20
 cargo build --workspace 2>&1 | tail -3
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 ```
 Plus anti-stub scan and deploy.sh integrity check (if deploy.sh was modified).
 
@@ -140,7 +140,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Tests: hardened workspace run — own process group + hard ceiling + file-not-pipe.
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30

--- a/.claude/agents/uni/uni-rust-dev.md
+++ b/.claude/agents/uni/uni-rust-dev.md
@@ -146,7 +146,7 @@ Include in your agent report:
 ## Self-Check (Run Before Returning Results)
 
 - [ ] `cargo build --workspace` passes (zero errors)
-- [ ] `cargo test --workspace` passes (no new failures)
+- [ ] `cargo test --workspace` passes (no new failures) — run via the hardened convention in `.claude/rules/rust-workspace.md` (`setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc`), never as a bare `cargo test ... | tail` pipe
 - [ ] No `todo!()`, `unimplemented!()`, `TODO`, `FIXME`, or `HACK` in non-test code
 - [ ] All modified files are within the scope defined in the brief
 - [ ] Error handling uses project error type with context, not `.unwrap()` in non-test code

--- a/.claude/agents/uni/uni-rust-dev.md
+++ b/.claude/agents/uni/uni-rust-dev.md
@@ -146,7 +146,7 @@ Include in your agent report:
 ## Self-Check (Run Before Returning Results)
 
 - [ ] `cargo build --workspace` passes (zero errors)
-- [ ] `cargo test --workspace` passes (no new failures) — run via the hardened convention in `.claude/rules/rust-workspace.md` (`setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc`), never as a bare `cargo test ... | tail` pipe
+- [ ] `cargo test --workspace` passes (no new failures) — run via the hardened convention in `.claude/rules/rust-workspace.md` (`setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc`), never as a bare `cargo test ... | tail` pipe
 - [ ] No `todo!()`, `unimplemented!()`, `TODO`, `FIXME`, or `HACK` in non-test code
 - [ ] All modified files are within the scope defined in the brief
 - [ ] Error handling uses project error type with context, not `.unwrap()` in non-test code

--- a/.claude/agents/uni/uni-scrum-master.md
+++ b/.claude/agents/uni/uni-scrum-master.md
@@ -153,7 +153,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30

--- a/.claude/agents/uni/uni-scrum-master.md
+++ b/.claude/agents/uni/uni-scrum-master.md
@@ -151,12 +151,17 @@ NEVER pipe full cargo output into context. Always truncate:
 cargo build --workspace 2>&1 | grep -A5 "^error" | head -20
 cargo build --workspace 2>&1 | tail -3
 
-# Test: summary only
-cargo test --workspace 2>&1 | tail -30
+# Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
+setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30
 ```
+
+Never rewrite the test line as a pipeline (`cargo test ... | tail`) or background it —
+`rc=$?` must capture `cargo test`, not `tail`. `timeout` rc=124 = killed-at-ceiling
+(investigate the hang), not an ordinary test failure.
 
 ---
 

--- a/.claude/agents/uni/uni-tester.md
+++ b/.claude/agents/uni/uni-tester.md
@@ -100,7 +100,7 @@ test-plan/
 
 ### What You Do
 
-1. Execute unit tests: `cargo test --workspace 2>&1 | tail -30`
+1. Execute unit tests via the hardened convention (see "Cargo Output Truncation" below): `setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc`
 2. Execute integration smoke tests (MANDATORY gate): `cd product/test/infra-001 && python -m pytest suites/ -v -m smoke --timeout=60`
 3. Execute relevant integration suites based on what the feature touches (see suite selection table below)
 4. Execute feature-level tests mapped to the Risk Strategy
@@ -254,11 +254,15 @@ When an integration test fails, determine causation:
 ## Cargo Output Truncation (CRITICAL)
 
 ```bash
-# Test: summary only
-cargo test --workspace 2>&1 | tail -30
+# Test: hardened workspace run — own process group + hard ceiling + file-not-pipe.
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
+setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 ```
 
-NEVER pipe full cargo output into context.
+NEVER pipe full cargo output into context. NEVER rewrite the line above as a pipeline
+(`cargo test ... | tail`) or background it — `rc=$?` must capture `cargo test`, not `tail`,
+or gates read false-green. `timeout` rc=124 = killed-at-ceiling (investigate the hang),
+not an ordinary test failure. See `.claude/rules/rust-workspace.md` for the full rationale.
 
 ## What You Return
 

--- a/.claude/agents/uni/uni-tester.md
+++ b/.claude/agents/uni/uni-tester.md
@@ -100,7 +100,7 @@ test-plan/
 
 ### What You Do
 
-1. Execute unit tests via the hardened convention (see "Cargo Output Truncation" below): `setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc`
+1. Execute unit tests via the hardened convention (see "Cargo Output Truncation" below): `setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc`
 2. Execute integration smoke tests (MANDATORY gate): `cd product/test/infra-001 && python -m pytest suites/ -v -m smoke --timeout=60`
 3. Execute relevant integration suites based on what the feature touches (see suite selection table below)
 4. Execute feature-level tests mapped to the Risk Strategy
@@ -256,7 +256,7 @@ When an integration test fails, determine causation:
 ```bash
 # Test: hardened workspace run — own process group + hard ceiling + file-not-pipe.
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 ```
 
 NEVER pipe full cargo output into context. NEVER rewrite the line above as a pipeline

--- a/.claude/agents/uni/uni-validator.md
+++ b/.claude/agents/uni/uni-validator.md
@@ -254,7 +254,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Tests: hardened workspace run — own process group + hard ceiling + file-not-pipe.
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 ```
 
 NEVER pipe full cargo output into context. NEVER rewrite the test line as a pipeline

--- a/.claude/agents/uni/uni-validator.md
+++ b/.claude/agents/uni/uni-validator.md
@@ -252,11 +252,15 @@ When checking compilation (Gate 3b):
 cargo build --workspace 2>&1 | grep -A5 "^error" | head -20
 cargo build --workspace 2>&1 | tail -3
 
-# Tests: summary only
-cargo test --workspace 2>&1 | tail -30
+# Tests: hardened workspace run — own process group + hard ceiling + file-not-pipe.
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
+setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 ```
 
-NEVER pipe full cargo output into context.
+NEVER pipe full cargo output into context. NEVER rewrite the test line as a pipeline
+(`cargo test ... | tail`) or background it — `rc=$?` must capture `cargo test`, not `tail`,
+or gates read false-green. `timeout` rc=124 = killed-at-ceiling (investigate the hang),
+not an ordinary test failure. See `.claude/rules/rust-workspace.md` for the full rationale.
 
 ---
 

--- a/.claude/protocols/implementation-protocol.md
+++ b/.claude/protocols/implementation-protocol.md
@@ -276,8 +276,9 @@ Always truncate cargo output to prevent context bloat:
 cargo build --workspace 2>&1 | grep -A5 "^error" | head -20
 cargo build --workspace 2>&1 | tail -3
 
-# Test: summary only
-cargo test --workspace 2>&1 | tail -30
+# Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
+setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30

--- a/.claude/protocols/implementation-protocol.md
+++ b/.claude/protocols/implementation-protocol.md
@@ -278,7 +278,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30

--- a/.claude/protocols/uni/uni-bugfix-protocol.md
+++ b/.claude/protocols/uni/uni-bugfix-protocol.md
@@ -516,7 +516,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30

--- a/.claude/protocols/uni/uni-bugfix-protocol.md
+++ b/.claude/protocols/uni/uni-bugfix-protocol.md
@@ -514,12 +514,17 @@ Always truncate cargo output:
 cargo build --workspace 2>&1 | grep -A5 "^error" | head -20
 cargo build --workspace 2>&1 | tail -3
 
-# Test: summary only
-cargo test --workspace 2>&1 | tail -30
+# Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
+setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30
 ```
+
+Never rewrite the test line as a pipeline (`cargo test ... | tail`) or background it —
+`rc=$?` must capture `cargo test`, not `tail`. `timeout` rc=124 = killed-at-ceiling
+(investigate the hang), not an ordinary test failure.
 
 NEVER pipe full cargo output into context.
 

--- a/.claude/protocols/uni/uni-delivery-protocol.md
+++ b/.claude/protocols/uni/uni-delivery-protocol.md
@@ -560,9 +560,11 @@ Always truncate cargo output:
 cargo build --workspace 2>&1 | grep -A5 "^error" | head -20
 cargo build --workspace 2>&1 | tail -3
 
-# Test: summary only (prefer JSON when available)
-cargo test --workspace 2>&1 | tail -30
-# Or: cargo test --workspace -- --format json 2>&1 | tail -30
+# Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
+setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+# Never rewrite as a pipeline (`cargo test ... | tail`) or background it: rc=$? must
+# capture cargo test, not tail. timeout rc=124 = killed-at-ceiling (investigate the hang).
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30

--- a/.claude/protocols/uni/uni-delivery-protocol.md
+++ b/.claude/protocols/uni/uni-delivery-protocol.md
@@ -562,7 +562,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 # Never rewrite as a pipeline (`cargo test ... | tail`) or background it: rc=$? must
 # capture cargo test, not tail. timeout rc=124 = killed-at-ceiling (investigate the hang).
 

--- a/.claude/rules/rust-workspace.md
+++ b/.claude/rules/rust-workspace.md
@@ -14,12 +14,54 @@ paths:
 cargo build --workspace 2>&1 | grep -A5 "^error" | head -20
 cargo build --workspace 2>&1 | tail -3
 
-# Test: summary only
-cargo test --workspace 2>&1 | tail -30
+# Test: hardened workspace run (see "Hardened cargo test convention" below)
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
+setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30
 ```
+
+## Hardened cargo test convention (canonical — copy byte-identical)
+
+`cargo test --workspace` MUST be invoked through this exact single-line form. It is
+the single source of truth; every agent/protocol copy must match it byte-for-byte so
+the regression lint (`product/test/infra-002/check-cargo-test-convention.sh`) passes.
+
+```bash
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
+setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+```
+
+Why each piece exists (do NOT rewrite it as a pipeline — `cargo test ... | tail`):
+
+- **`setsid`** runs `cargo` (and its `rustc`/test-binary descendants) in a NEW session
+  and process group. If the Bash tool call is interrupted/timed-out, the harness can
+  signal the whole group instead of orphaning the cargo subtree to PID 1 (root cause
+  of #122 — orphans hold `target/.cargo-lock` and test `.db` handles, hanging later runs).
+- **`timeout` + named constant** `CARGO_TEST_TIMEOUT_SECS` (default **600s**, NOT a bare
+  magic number) imposes a hard ceiling and kills the entire child tree on expiry. 600s
+  fits a cold full-workspace build+test; integration-heavy crates may approach it on a
+  cold cache. Tune in ONE place via the env var.
+- **`> /tmp/uni-test.$$.log 2>&1`** writes to a PID-namespaced file, NOT a live pipe.
+  A pipe makes `cargo` the upstream writer of a pipeline the harness cannot kill as a
+  unit; a file removes that orphan-writer problem while preserving output truncation.
+- **EXIT-CODE GUARD (load-bearing — gate integrity):** the capture+report is a SINGLE
+  NON-PIPELINED statement. `rc=$?` captures the status of `cargo test` (via `timeout`),
+  NOT `tail`. NEVER rewrite this as `... | tail` and NEVER background it (`&`) — either
+  makes `$rc` the wrong process's status and gates read FALSE-GREEN. `tail` runs AFTER
+  `rc` is captured, so it cannot clobber the result; `exit $rc` propagates the real status.
+- **`rm -f /tmp/uni-test.$$.log`** cleans the log on every success/failure path before
+  `exit`. An interrupted run may leave at most one PID-stamped file (acceptable); files
+  do not accumulate per successful run.
+
+### rc=124 means KILLED at the ceiling — not a test failure
+
+`timeout` returns exit code **124** when it kills the run at `CARGO_TEST_TIMEOUT_SECS`.
+Treat **124 as "the run was killed for hanging" (investigate the hang)** — it is FAIL,
+but it is NOT an ordinary parseable red suite and MUST NOT be auto-retried as if a test
+flaked. On 124: investigate the hang (likely an orphan/lock from a prior run), then
+re-run per-crate (`cargo test -p {crate} --lib`) rather than blindly retrying `--workspace`.
 
 ## Naming Conventions
 

--- a/.claude/rules/rust-workspace.md
+++ b/.claude/rules/rust-workspace.md
@@ -15,8 +15,10 @@ cargo build --workspace 2>&1 | grep -A5 "^error" | head -20
 cargo build --workspace 2>&1 | tail -3
 
 # Test: hardened workspace run (see "Hardened cargo test convention" below)
-# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children.
+# `setsid -w` is REQUIRED: without -w, setsid returns its own fork status (0) instead of
+# the inner command's exit code, producing false-green gates (GH#709). rc=124 = killed at ceiling.
+setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30
@@ -29,16 +31,22 @@ the single source of truth; every agent/protocol copy must match it byte-for-byt
 the regression lint (`product/test/infra-002/check-cargo-test-convention.sh`) passes.
 
 ```bash
-# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children.
+# `setsid -w` is REQUIRED: without -w, setsid returns its own fork status (0) instead of
+# the inner command's exit code, producing false-green gates (GH#709). rc=124 = killed at ceiling.
+setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 ```
 
 Why each piece exists (do NOT rewrite it as a pipeline — `cargo test ... | tail`):
 
-- **`setsid`** runs `cargo` (and its `rustc`/test-binary descendants) in a NEW session
+- **`setsid -w`** runs `cargo` (and its `rustc`/test-binary descendants) in a NEW session
   and process group. If the Bash tool call is interrupted/timed-out, the harness can
   signal the whole group instead of orphaning the cargo subtree to PID 1 (root cause
   of #122 — orphans hold `target/.cargo-lock` and test `.db` handles, hanging later runs).
+  The **`-w` flag is mandatory**: bare `setsid` forks and returns the *fork's* status
+  (always 0), so `rc=$?` would capture 0 even when `cargo test` FAILS or is killed at the
+  ceiling — a silent false-green that INVERTS the gate-integrity guarantee #122 exists to
+  protect (GH#709). `-w` makes `setsid` wait for the child and propagate its real exit code.
 - **`timeout` + named constant** `CARGO_TEST_TIMEOUT_SECS` (default **600s**, NOT a bare
   magic number) imposes a hard ceiling and kills the entire child tree on expiry. 600s
   fits a cold full-workspace build+test; integration-heavy crates may approach it on a

--- a/product/test/infra-002/README.md
+++ b/product/test/infra-002/README.md
@@ -1,0 +1,41 @@
+# infra-002 — cargo-test orphan-cleanup regression guard (#122)
+
+Bug #122: every uni agent ran the bare convention `cargo test --workspace 2>&1 | tail -30`.
+With no process group and no timeout, an interrupted Bash tool call signaled only the
+pipeline leader; `cargo`/`rustc`/test-binary children reparented to PID 1 and survived,
+holding `target/.cargo-lock` and test `.db` handles — hanging or false-failing later runs.
+
+Tier A fix (this guard's subject): the canonical convention in
+`.claude/rules/rust-workspace.md` was hardened to run in its own session/process group
+with a hard ceiling, writing to a file instead of a live pipe:
+
+```bash
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
+setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+```
+
+## What the guard does
+
+`check-cargo-test-convention.sh` scans `.claude/` and exits non-zero if any agent,
+protocol, or rule file invokes `cargo test` as the head of a bare pipe (`cargo test ... |`)
+without `setsid`. This prevents the convention from silently reverting.
+
+It is a standalone shell script — deliberately NOT a `cargo test --workspace` target — so
+it can never be defeated by the orphan/lock bug it guards against.
+
+## Run
+
+```bash
+# scan the live tree (CI / pre-PR gate)
+bash product/test/infra-002/check-cargo-test-convention.sh
+
+# prove the guard still works: flags the old bare form, passes the hardened form
+bash product/test/infra-002/check-cargo-test-convention.sh --self-test
+```
+
+Exit codes: `0` clean, `1` violation(s) found, `2` usage/self-test failure.
+
+## Scope
+
+Tier A only. Tier B (hook-based reaping in `unimatrix-observe`) and Tier C (per-crate
+routine testing default) are deferred to follow-up issues — see #122 discussion.

--- a/product/test/infra-002/README.md
+++ b/product/test/infra-002/README.md
@@ -10,15 +10,30 @@ Tier A fix (this guard's subject): the canonical convention in
 with a hard ceiling, writing to a file instead of a live pipe:
 
 ```bash
-# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+# CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children.
+# `setsid -w` is REQUIRED: without -w, setsid returns its own fork status (0) instead of
+# the inner command's exit code, producing false-green gates (GH#709). rc=124 = killed at ceiling.
+setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
 ```
+
+Follow-up defect (GH#709): the first hardened form shipped `setsid` **without** `-w`.
+Bare `setsid` forks and returns the *fork's* exit status (always 0), so `rc=$?`
+captured 0 even when `cargo test` failed or was killed at the ceiling — a silent
+false-green that inverted the very gate-integrity guarantee #122 exists to protect.
+The corrected form uses `setsid -w`, which waits for the child and propagates its
+real exit code.
 
 ## What the guard does
 
 `check-cargo-test-convention.sh` scans `.claude/` and exits non-zero if any agent,
-protocol, or rule file invokes `cargo test` as the head of a bare pipe (`cargo test ... |`)
-without `setsid`. This prevents the convention from silently reverting.
+protocol, or rule file:
+
+- invokes `cargo test` as the head of a bare pipe (`cargo test ... |`) without
+  `setsid` (CLASS 1, #122 — no process group), OR
+- invokes `cargo test` via `setsid` **without** the `-w` flag (CLASS 2, GH#709 —
+  false-green exit code).
+
+This prevents the convention from silently reverting to either defective form.
 
 It is a standalone shell script — deliberately NOT a `cargo test --workspace` target — so
 it can never be defeated by the orphan/lock bug it guards against.
@@ -29,7 +44,8 @@ it can never be defeated by the orphan/lock bug it guards against.
 # scan the live tree (CI / pre-PR gate)
 bash product/test/infra-002/check-cargo-test-convention.sh
 
-# prove the guard still works: flags the old bare form, passes the hardened form
+# prove the guard still works: flags the bare-pipe form AND the setsid-without-w
+# form, passes the hardened `setsid -w` form
 bash product/test/infra-002/check-cargo-test-convention.sh --self-test
 ```
 

--- a/product/test/infra-002/check-cargo-test-convention.sh
+++ b/product/test/infra-002/check-cargo-test-convention.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# infra-002 regression guard for bug #122 (cargo-test orphan cleanup).
+#
+# Bug recap: the canonical convention `cargo test --workspace 2>&1 | tail -30`
+# runs cargo as the head of a bare pipe with no process group and no timeout.
+# When the harness interrupts the Bash tool call, only the pipeline leader is
+# signaled; cargo/rustc/test-binary children reparent to PID 1 and survive,
+# holding target/.cargo-lock and test .db handles -> later runs hang/false-fail.
+#
+# The hardened form runs in its own session/process group with a hard ceiling and
+# writes to a file instead of a live pipe:
+#
+#   setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace \
+#     > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; \
+#     rm -f /tmp/uni-test.$$.log; exit $rc
+#
+# This guard FAILS (exit 1) if any agent / protocol / rule file under .claude/
+# invokes `cargo test` as the head of a bare pipe without BOTH `setsid` and
+# `timeout` on the same line. It is a standalone shell check (NOT a
+# `cargo test --workspace` target) so it cannot be defeated by the very bug it
+# guards against.
+#
+# Run:
+#   bash product/test/infra-002/check-cargo-test-convention.sh
+#   bash product/test/infra-002/check-cargo-test-convention.sh --self-test
+#
+# Exit codes: 0 = clean, 1 = violation(s) found, 2 = usage/self-test failure.
+
+set -uo pipefail
+
+# Resolve the repo root from this script's location (works from any cwd).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+SCAN_DIR="${REPO_ROOT}/.claude"
+
+# A line is a VIOLATION when ALL of these hold:
+#   1. it contains a `cargo test` invocation,
+#   2. that `cargo test` is the head of a pipe (`cargo test ... |`),
+#   3. the line does NOT contain `setsid` (no process group), and
+#   4. it is a real invocation, not the documentation placeholder
+#      `cargo test ...` (literal ellipsis) used in DON'T-DO-THIS warnings.
+#
+# Requiring `setsid` (rather than also `timeout`) on the matched line is
+# sufficient: the canonical hardened form always carries both, and `setsid` is
+# the piece that makes the run a killable process group — the load-bearing fix.
+
+# Match `cargo test` followed by anything, then a pipe, where the char before
+# the pipe that starts the pipe is not part of the literal `cargo test ...`
+# placeholder. We detect the placeholder separately and exclude it.
+scan() {
+  local target_dir="$1"
+  # Pattern: a `cargo test` whose first downstream `|` (a pipe, not `||`)
+  # appears on the same line.
+  grep -rnE 'cargo test([^|]|\|\|)*\|([^|]|$)' "${target_dir}" 2>/dev/null \
+    | grep -v 'setsid' \
+    | grep -v 'cargo test \.\.\.'
+}
+
+check() {
+  local violations
+  violations="$(scan "${SCAN_DIR}")"
+  if [ -n "${violations}" ]; then
+    echo "FAIL: bare 'cargo test' pipe(s) found without setsid (bug #122 regression):" >&2
+    echo "${violations}" >&2
+    echo "" >&2
+    echo "Use the hardened convention from .claude/rules/rust-workspace.md:" >&2
+    echo "  setsid timeout \"\${CARGO_TEST_TIMEOUT_SECS:-600}\" cargo test --workspace > /tmp/uni-test.\$\$.log 2>&1; rc=\$?; tail -30 /tmp/uni-test.\$\$.log; rm -f /tmp/uni-test.\$\$.log; exit \$rc" >&2
+    return 1
+  fi
+  echo "OK: no bare 'cargo test' pipes under ${SCAN_DIR} (#122 convention intact)."
+  return 0
+}
+
+# --self-test proves the guard catches the OLD bare form and passes the NEW one,
+# so the check itself cannot silently rot. It uses temp fixtures, not the repo.
+self_test() {
+  local tmp bad good rc_bad rc_good
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "${tmp}"' RETURN
+  bad="${tmp}/bad.md"
+  good="${tmp}/good.md"
+  printf 'cargo test --workspace 2>&1 | tail -30\n' > "${bad}"
+  printf 'setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc\n' > "${good}"
+
+  scan "${tmp}" | grep -q 'bad.md'; rc_bad=$?
+  if [ "${rc_bad}" -ne 0 ]; then
+    echo "SELF-TEST FAIL: guard did NOT flag the old bare-pipe form." >&2
+    return 2
+  fi
+  if scan "${tmp}" | grep -q 'good.md'; then
+    echo "SELF-TEST FAIL: guard wrongly flagged the hardened form." >&2
+    return 2
+  fi
+  echo "SELF-TEST OK: flags old bare form, passes hardened form."
+  return 0
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  "")          check ;;
+  *)           echo "usage: $0 [--self-test]" >&2; exit 2 ;;
+esac

--- a/product/test/infra-002/check-cargo-test-convention.sh
+++ b/product/test/infra-002/check-cargo-test-convention.sh
@@ -9,17 +9,22 @@
 # holding target/.cargo-lock and test .db handles -> later runs hang/false-fail.
 #
 # The hardened form runs in its own session/process group with a hard ceiling and
-# writes to a file instead of a live pipe:
+# writes to a file instead of a live pipe. `setsid -w` is mandatory:
 #
-#   setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace \
+#   setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace \
 #     > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; \
 #     rm -f /tmp/uni-test.$$.log; exit $rc
 #
-# This guard FAILS (exit 1) if any agent / protocol / rule file under .claude/
-# invokes `cargo test` as the head of a bare pipe without BOTH `setsid` and
-# `timeout` on the same line. It is a standalone shell check (NOT a
-# `cargo test --workspace` target) so it cannot be defeated by the very bug it
-# guards against.
+# Second defect (GH#709): bare `setsid` (no -w) forks and returns the *fork's*
+# status (always 0), so `rc=$?` reads 0 even when cargo test FAILS or is killed at
+# the ceiling -> silent false-green gate, inverting the #122 guarantee. `setsid -w`
+# waits for the child and propagates its real exit code.
+#
+# This guard FAILS (exit 1) if any agent / protocol / rule file under .claude/:
+#   (a) invokes `cargo test` as the head of a bare pipe without `setsid`, OR
+#   (b) invokes `cargo test` via `setsid` WITHOUT the `-w` flag.
+# It is a standalone shell check (NOT a `cargo test --workspace` target) so it
+# cannot be defeated by the very bug it guards against.
 #
 # Run:
 #   bash product/test/infra-002/check-cargo-test-convention.sh
@@ -34,65 +39,103 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 SCAN_DIR="${REPO_ROOT}/.claude"
 
-# A line is a VIOLATION when ALL of these hold:
-#   1. it contains a `cargo test` invocation,
-#   2. that `cargo test` is the head of a pipe (`cargo test ... |`),
-#   3. the line does NOT contain `setsid` (no process group), and
-#   4. it is a real invocation, not the documentation placeholder
-#      `cargo test ...` (literal ellipsis) used in DON'T-DO-THIS warnings.
+# Two violation classes are detected (a real `cargo test` invocation, never the
+# documentation placeholder `cargo test ...` with a literal ellipsis):
 #
-# Requiring `setsid` (rather than also `timeout`) on the matched line is
-# sufficient: the canonical hardened form always carries both, and `setsid` is
-# the piece that makes the run a killable process group — the load-bearing fix.
+#   CLASS 1 — bare pipe (#122): `cargo test` is the head of a pipe
+#     (`cargo test ... |`) and the line does NOT contain `setsid`. No process
+#     group -> orphaned cargo subtree.
+#
+#   CLASS 2 — setsid without -w (GH#709): the line uses `setsid` to launch
+#     `cargo test` but does NOT pass `-w`. Bare `setsid` returns its fork status
+#     (0), swallowing the real exit code -> false-green gate.
+#
+# `setsid -w` (with the flag) is the only accepted hardened form.
 
-# Match `cargo test` followed by anything, then a pipe, where the char before
-# the pipe that starts the pipe is not part of the literal `cargo test ...`
-# placeholder. We detect the placeholder separately and exclude it.
-scan() {
+# CLASS 1: cargo test as head of a pipe (`|`, not `||`) on the same line,
+# without setsid.
+scan_bare_pipe() {
   local target_dir="$1"
-  # Pattern: a `cargo test` whose first downstream `|` (a pipe, not `||`)
-  # appears on the same line.
   grep -rnE 'cargo test([^|]|\|\|)*\|([^|]|$)' "${target_dir}" 2>/dev/null \
     | grep -v 'setsid' \
     | grep -v 'cargo test \.\.\.'
 }
 
+# CLASS 2: a `setsid` that launches `cargo test` on the same line but lacks the
+# `-w` flag. Match `setsid` followed by a token that is neither `-w` nor the
+# start of another option leading into `cargo test`. The placeholder
+# `cargo test ...` is excluded as in CLASS 1.
+scan_setsid_no_w() {
+  local target_dir="$1"
+  grep -rnE 'setsid[[:space:]]+([^[:space:]-]|-[^w])[^|]*cargo test' "${target_dir}" 2>/dev/null \
+    | grep -v 'cargo test \.\.\.'
+}
+
+# Combined scan used by --self-test against fixtures: emits any violating line.
+scan() {
+  local target_dir="$1"
+  { scan_bare_pipe "${target_dir}"; scan_setsid_no_w "${target_dir}"; } | sort -u
+}
+
 check() {
-  local violations
-  violations="$(scan "${SCAN_DIR}")"
-  if [ -n "${violations}" ]; then
+  local bare_pipe setsid_no_w rc=0
+  bare_pipe="$(scan_bare_pipe "${SCAN_DIR}")"
+  setsid_no_w="$(scan_setsid_no_w "${SCAN_DIR}")"
+
+  if [ -n "${bare_pipe}" ]; then
     echo "FAIL: bare 'cargo test' pipe(s) found without setsid (bug #122 regression):" >&2
-    echo "${violations}" >&2
+    echo "${bare_pipe}" >&2
     echo "" >&2
+    rc=1
+  fi
+  if [ -n "${setsid_no_w}" ]; then
+    echo "FAIL: 'setsid' launching cargo test WITHOUT -w (GH#709 false-green regression):" >&2
+    echo "${setsid_no_w}" >&2
+    echo "" >&2
+    rc=1
+  fi
+  if [ "${rc}" -ne 0 ]; then
     echo "Use the hardened convention from .claude/rules/rust-workspace.md:" >&2
-    echo "  setsid timeout \"\${CARGO_TEST_TIMEOUT_SECS:-600}\" cargo test --workspace > /tmp/uni-test.\$\$.log 2>&1; rc=\$?; tail -30 /tmp/uni-test.\$\$.log; rm -f /tmp/uni-test.\$\$.log; exit \$rc" >&2
+    echo "  setsid -w timeout \"\${CARGO_TEST_TIMEOUT_SECS:-600}\" cargo test --workspace > /tmp/uni-test.\$\$.log 2>&1; rc=\$?; tail -30 /tmp/uni-test.\$\$.log; rm -f /tmp/uni-test.\$\$.log; exit \$rc" >&2
     return 1
   fi
-  echo "OK: no bare 'cargo test' pipes under ${SCAN_DIR} (#122 convention intact)."
+  echo "OK: no bare 'cargo test' pipes and no setsid-without-w under ${SCAN_DIR} (#122 + GH#709 convention intact)."
   return 0
 }
 
-# --self-test proves the guard catches the OLD bare form and passes the NEW one,
-# so the check itself cannot silently rot. It uses temp fixtures, not the repo.
+# --self-test proves the guard catches BOTH defective forms and passes the
+# hardened one, so the check itself cannot silently rot. It uses temp fixtures,
+# not the repo. Cases:
+#   (a) bare-pipe form (no setsid)            -> MUST be flagged (CLASS 1, #122)
+#   (b) setsid WITHOUT -w                     -> MUST be flagged (CLASS 2, GH#709)
+#   (c) setsid -w hardened form               -> MUST pass
 self_test() {
-  local tmp bad good rc_bad rc_good
+  local tmp bad nowait good
   tmp="$(mktemp -d)"
   trap 'rm -rf "${tmp}"' RETURN
   bad="${tmp}/bad.md"
+  nowait="${tmp}/nowait.md"
   good="${tmp}/good.md"
   printf 'cargo test --workspace 2>&1 | tail -30\n' > "${bad}"
-  printf 'setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc\n' > "${good}"
+  printf 'setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc\n' > "${nowait}"
+  printf 'setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc\n' > "${good}"
 
-  scan "${tmp}" | grep -q 'bad.md'; rc_bad=$?
-  if [ "${rc_bad}" -ne 0 ]; then
-    echo "SELF-TEST FAIL: guard did NOT flag the old bare-pipe form." >&2
+  # (a) bare-pipe form must be flagged.
+  if ! scan "${tmp}" | grep -q 'bad.md'; then
+    echo "SELF-TEST FAIL: guard did NOT flag the old bare-pipe form (CLASS 1)." >&2
     return 2
   fi
+  # (b) setsid WITHOUT -w must be flagged.
+  if ! scan "${tmp}" | grep -q 'nowait.md'; then
+    echo "SELF-TEST FAIL: guard did NOT flag the setsid-without-w form (CLASS 2, GH#709)." >&2
+    return 2
+  fi
+  # (c) setsid -w hardened form must pass.
   if scan "${tmp}" | grep -q 'good.md'; then
-    echo "SELF-TEST FAIL: guard wrongly flagged the hardened form." >&2
+    echo "SELF-TEST FAIL: guard wrongly flagged the hardened 'setsid -w' form." >&2
     return 2
   fi
-  echo "SELF-TEST OK: flags old bare form, passes hardened form."
+  echo "SELF-TEST OK: flags bare-pipe + setsid-without-w forms, passes 'setsid -w' hardened form."
   return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes #122 — zombie `cargo test --workspace` processes from subagents that reparent to PID 1, hold `target/.cargo-lock` and test `.db` handles, and hang or false-fail later workspace runs.

**Root cause:** the bare convention `cargo test --workspace 2>&1 | tail -30` runs cargo as the upstream writer of a non-killable pipeline. When the harness interrupts the Bash call, only the pipeline leader is signaled; cargo/rustc/test-binary children orphan to PID 1 and survive.

## Fix (Tier A — approved scope)

Hardened, byte-identical convention across every `.claude/` copy:

```bash
setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
```

- `setsid -w` — own process group (whole tree killable, no orphans) **and** propagates the child exit code.
- `timeout` (named `CARGO_TEST_TIMEOUT_SECS`, default 600) — hard ceiling; rc=124 = killed-not-failure (investigate the hang, do not blindly retry).
- file-not-pipe + `rm -f` — no live pipe to leak, PID-namespaced log cleaned on every path.
- **Single non-pipelined statement** so `rc=$?` captures cargo (via `timeout`), not `tail` (gate-integrity / false-green guard).

### Regression guard
`product/test/infra-002/check-cargo-test-convention.sh` — standalone shell scan of `.claude/` (not a cargo target, avoids circularity). Fails on **CLASS 1** (bare-pipe `cargo test` without `setsid`, the original #122) and **CLASS 2** (`setsid` without `-w`, GH#709). Ships `--self-test` proving all three cases.

## Mid-fix regression caught & fixed (GH#709, now closed)
The first commit used `setsid` **without** `-w`, which returns the fork status (always 0) — a silent false-green that inverted the gate-integrity guarantee. Caught at test verification, fixed in `03888c12`, guard strengthened to reject the form.

## Deferred (not in this PR)
- **Tier B** (SubagentStop hook reaping) — can't be built as proposed: hook is sub-50ms sync per ADR-002 and carries no pgid; deferred to a server-side follow-up.
- **Tier C** (per-crate routine testing) — the infra-002 strategic track.

## Verification
- Exit codes: `setsid -w timeout 1 sleep 5`→124, `... false`→1, `... true`→0
- Guard: 0 violations + `--self-test` PASS (deterministic, 2×)
- 12/12 setsid cargo lines use `-w`
- Integration smoke: 23 passed / 0 failed / 0 xfail
- 0 `.rs` files changed (convention + guard only); no-regression on workspace suite
- Gate: Bug Fix Validation — **PASS** (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
