### PR TITLE
fix: correct three stale test assertions (#695, #576, #575)

### DIFF
--- a/packages/unimatrix/test/init.test.js
+++ b/packages/unimatrix/test/init.test.js
@@ -96,7 +96,9 @@ describe("writeMcpJson", () => {
     const content = JSON.parse(fs.readFileSync(mcpPath, "utf8"));
     assert.strictEqual(content.mcpServers.unimatrix.command, BINARY);
     assert.deepStrictEqual(content.mcpServers.unimatrix.args, []);
-    assert.deepStrictEqual(content.mcpServers.unimatrix.env, {});
+    assert.deepStrictEqual(content.mcpServers.unimatrix.env, {
+      LD_LIBRARY_PATH: path.dirname(BINARY),
+    });
 
     assert.ok(
       actions.some((a) => a.includes("Created .mcp.json")),

--- a/product/test/infra-001/suites/test_edge_cases.py
+++ b/product/test/infra-001/suites/test_edge_cases.py
@@ -228,10 +228,9 @@ def test_interleaved_store_and_search(server):
         server.context_search(f"interleaved entry {i}", k=2)
 
 
-@pytest.mark.xfail(reason="Pre-existing: GH#576 — content size cap of 8000 bytes (fix #561) now rejects 50KB content; test predates the cap")
 def test_very_long_content(server):
     """E-15: Near-boundary-length content."""
-    content = load_large_content(50000)  # 50KB
+    content = load_large_content(8000)  # 8000 bytes — content size cap boundary (passes)
     resp = server.context_store(
         content, "testing", "convention", agent_id="human"
     )

--- a/product/test/infra-001/suites/test_tools.py
+++ b/product/test/infra-001/suites/test_tools.py
@@ -1171,7 +1171,6 @@ def test_retrospective_json_explicit(server):
     assert "feature_cycle" in parsed, f"Expected feature_cycle in JSON, got keys: {list(parsed.keys())}"
 
 
-@pytest.mark.xfail(reason="Pre-existing: GH#575 — error message is 'Invalid parameter format: must be summary, markdown, or json' not 'Unknown format'")
 def test_retrospective_format_invalid(server):
     """T-R09 (vnc-011): Invalid format returns error with descriptive message."""
     features = ["col-833"]
@@ -1179,7 +1178,7 @@ def test_retrospective_format_invalid(server):
     _seed_observation_sql(db_path, features)
 
     resp = server.context_cycle_review(features[0], agent_id="human", format="xml", timeout=30.0)
-    assert_tool_error(resp, "Unknown format")
+    assert_tool_error(resp, "must be summary, markdown, or json")
 
 
 # === context_status observation extension (col-002) =======================


### PR DESCRIPTION
## Summary

Combined bugfix for three **stale test assertions** — all test-only, no production code changed. Each assertion had drifted from an intentional production contract.

| Issue | File | Fix |
|-------|------|-----|
| #695 | `packages/unimatrix/test/init.test.js` | Expect `env: { LD_LIBRARY_PATH: path.dirname(BINARY) }` — `init.js` intentionally sets it (commit 07062006). Re-derives from test input, not a hardcoded literal. |
| #576 | `product/test/infra-001/suites/test_edge_cases.py` | Remove `@pytest.mark.xfail`; send 8000 bytes (the inclusive boundary of the 8000-byte content cap) instead of 50000. Acceptance intent preserved; boundary rejection already covered by `test_volume.py`. |
| #575 | `product/test/infra-001/suites/test_tools.py` | Remove `@pytest.mark.xfail`; expect centralized `parse_format` error substring `must be summary, markdown, or json` instead of the obsolete `Unknown format`. |

## Diagnosis

All three are **BAD TEST ASSERTION** — production (LD_LIBRARY_PATH env shape, 8000-byte cap, centralized `parse_format`) is correct; the assertions were never updated. #576/#575 were already `xfail`'d with these issue numbers; this fix removes the markers and re-enables real coverage.

## Validation

- Diff: 3 files, +5/-5, test-only (`git diff main --stat`)
- JS package suite: 773 passed / 1 skipped
- #576 & #575 target tests: **hard pass**, no xfail/xpass remaining
- Integration smoke: 23 passed
- Full edited suites: 211 passed / 3 unrelated pre-existing xfail (GH#111, #405, #305) / 0 failed
- Bugfix gate: **PASS**

Closes #695
Closes #576
Closes #575

🤖 Generated with [Claude Code](https://claude.com/claude-code)