### PR TITLE
fix: deadline-poll test sync for fire-and-forget write races (#691, #452, #305)

### DIFF
--- a/crates/unimatrix-server/src/uds/listener.rs
+++ b/crates/unimatrix-server/src/uds/listener.rs
@@ -5305,6 +5305,46 @@ mod tests {
             .collect()
     }
 
+    /// Deadline-poll for a fire-and-forget `spawn_blocking` observation write to land,
+    /// then return the session's rows. Modeled on the canonical loop in
+    /// `tests/transcript.rs` (5s deadline + 100ms settle): polls `query_observations`
+    /// every ~10ms until it reaches `expected` rows, then settles 100ms so callers can
+    /// still assert the EXACT final count. Uses `tokio::time::sleep().await` (never
+    /// `std::thread::sleep`) to keep the current-thread `#[tokio::test]` reactor alive so
+    /// the in-flight `Handle::current().block_on` INSERT completes before teardown (the
+    /// "A Tokio 1.x context ... is being shutdown" race). Positive-assertion only —
+    /// never poll for an absence.
+    #[allow(clippy::type_complexity)]
+    async fn await_observations(
+        store: &Store,
+        session_id: &str,
+        expected: usize,
+    ) -> Vec<(
+        String,
+        i64,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    )> {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let rows = query_observations(store, session_id).await;
+            if rows.len() >= expected {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for {expected} observation row(s) for {session_id} (got {})",
+                rows.len()
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        // Settle so a trailing row would still fail an exact-count assertion.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        query_observations(store, session_id).await
+    }
+
     #[tokio::test]
     async fn col018_context_search_creates_observation() {
         // T-01, AC-01: ContextSearch with valid session_id produces observation row
@@ -5338,11 +5378,7 @@ mod tests {
         )
         .await;
 
-        // Allow spawn_blocking to complete
-        tokio::task::yield_now().await;
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
-        let rows = query_observations(&store, "sess-obs-1").await;
+        let rows = await_observations(&store, "sess-obs-1", 1).await;
         assert_eq!(rows.len(), 1, "expected exactly 1 observation row");
         let (sid, ts, hook, tool, input, topic) = &rows[0];
         assert_eq!(sid, "sess-obs-1");
@@ -5386,10 +5422,7 @@ mod tests {
         )
         .await;
 
-        tokio::task::yield_now().await;
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
-        let rows = query_observations(&store, "sess-topic-1").await;
+        let rows = await_observations(&store, "sess-topic-1", 1).await;
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].5.as_deref(), Some("col-018"));
     }
@@ -5427,10 +5460,7 @@ mod tests {
         )
         .await;
 
-        tokio::task::yield_now().await;
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
-        let rows = query_observations(&store, "sess-generic-1").await;
+        let rows = await_observations(&store, "sess-generic-1", 1).await;
         assert_eq!(rows.len(), 1);
         assert!(
             rows[0].5.is_none(),
@@ -5471,10 +5501,7 @@ mod tests {
         )
         .await;
 
-        tokio::task::yield_now().await;
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
-        let rows = query_observations(&store, "sess-path-1").await;
+        let rows = await_observations(&store, "sess-path-1", 1).await;
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].5.as_deref(), Some("col-018"));
     }
@@ -5513,10 +5540,7 @@ mod tests {
         )
         .await;
 
-        tokio::task::yield_now().await;
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
-        let rows = query_observations(&store, "sess-trunc-1").await;
+        let rows = await_observations(&store, "sess-trunc-1", 1).await;
         assert_eq!(rows.len(), 1);
         let input = rows[0].4.as_ref().expect("input should be present");
         assert_eq!(input.len(), 4096, "input should be truncated to 4096 chars");
@@ -5556,10 +5580,7 @@ mod tests {
         )
         .await;
 
-        tokio::task::yield_now().await;
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
-        let rows = query_observations(&store, "sess-exact-1").await;
+        let rows = await_observations(&store, "sess-exact-1", 1).await;
         assert_eq!(rows.len(), 1);
         let input = rows[0].4.as_ref().expect("input should be present");
         assert_eq!(input.len(), 4096);
@@ -5599,8 +5620,11 @@ mod tests {
         )
         .await;
 
-        tokio::task::yield_now().await;
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Negative assertion (count must stay 0) — cannot poll for an absence. Keep a
+        // bounded fixed settle, but use `tokio::time::sleep().await` (not
+        // `std::thread::sleep`) so the reactor stays alive and any erroneously-spawned
+        // write lands (and would be caught) instead of being killed by runtime teardown.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // No observation written
         let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM observations")
@@ -5652,8 +5676,9 @@ mod tests {
         )
         .await;
 
-        tokio::task::yield_now().await;
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Negative assertion (no row) — cannot poll for an absence. Bounded fixed settle
+        // via `tokio::time::sleep().await` keeps the reactor alive for any in-flight write.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         let rows = query_observations(&store, "sess-empty-1").await;
         assert_eq!(rows.len(), 0, "no observation for empty query");
@@ -5828,8 +5853,10 @@ mod tests {
         .await;
 
         // Allow any (erroneously) spawned blocking write to land before we count.
-        tokio::task::yield_now().await;
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Negative assertion (zero rows) — cannot poll for an absence; keep a bounded
+        // fixed settle, but via `tokio::time::sleep().await` (not `std::thread::sleep`) so
+        // the reactor stays alive for the in-flight write instead of teardown killing it.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         assert!(
             matches!(resp, HookResponse::Ack),
@@ -5892,11 +5919,19 @@ mod tests {
         )
         .await;
 
-        tokio::task::yield_now().await;
-        std::thread::sleep(std::time::Duration::from_millis(50));
-
         assert!(matches!(resp, HookResponse::Ack), "batch must Ack");
-        // The two non-delta events persist; the delta persists nothing.
+        // The two non-delta events persist (fire-and-forget — poll); the delta persists
+        // nothing. Canonical deadline-poll (5s) + 100ms settle, then assert EXACTLY 2 so a
+        // trailing delta-derived row would still fail.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while count_all_observations(&store).await < 2 {
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for the 2 non-delta rows"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         assert_eq!(
             count_all_observations(&store).await,
             2,
@@ -5954,8 +5989,9 @@ mod tests {
             );
         }
 
-        tokio::task::yield_now().await;
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Negative assertion (zero rows) — cannot poll for an absence; bounded fixed
+        // settle via `tokio::time::sleep().await` keeps the reactor alive for any write.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert_eq!(
             count_all_observations(&store).await,
             0,

--- a/crates/unimatrix-server/src/uds/listener/tests/stamp_read.rs
+++ b/crates/unimatrix-server/src/uds/listener/tests/stamp_read.rs
@@ -72,10 +72,35 @@ async fn query_attribution(
         .collect()
 }
 
-/// Settle any fire-and-forget spawn_blocking write before reading rows.
-async fn settle() {
-    tokio::task::yield_now().await;
-    std::thread::sleep(std::time::Duration::from_millis(50));
+/// Deadline-poll for a fire-and-forget spawn_blocking write to land, then return the
+/// session's attribution rows. Modeled on the canonical loop in `tests/transcript.rs`
+/// (5s deadline + 100ms settle): polls `query_attribution` every ~10ms until it reaches
+/// `expected` rows, then settles 100ms so callers can still assert the EXACT final count.
+/// `tokio::time::sleep().await` (never `std::thread::sleep`) keeps the current-thread
+/// `#[tokio::test]` reactor alive so the in-flight `block_on` INSERT completes before
+/// teardown (the "being shutdown" race). Positive-assertion only — never poll for an
+/// absence.
+async fn await_attribution(
+    store: &Store,
+    session_id: &str,
+    expected: usize,
+) -> Vec<(Option<String>, Option<String>, Option<String>)> {
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let rows = query_attribution(store, session_id).await;
+        if rows.len() >= expected {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for {expected} attribution row(s) for {session_id} (got {})",
+            rows.len()
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    // Settle so a trailing row would still fail an exact-count assertion.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    query_attribution(store, session_id).await
 }
 
 // Boilerplate dispatch wrapper to keep the per-test arrange blocks short.
@@ -122,10 +147,9 @@ async fn stamp_read_site_b_records_declared() {
     );
 
     let resp = dispatch!(HookRequest::RecordEvent { event }, &store, &registry);
-    settle().await;
 
     assert!(matches!(resp, HookResponse::Ack));
-    let rows = query_attribution(&store, "sess-b").await;
+    let rows = await_attribution(&store, "sess-b", 1).await;
     assert_eq!(rows.len(), 1, "exactly one row");
     assert_eq!(
         rows[0].0,
@@ -172,10 +196,9 @@ async fn stamp_read_site_a_records_declared() {
     );
 
     let resp = dispatch!(HookRequest::RecordEvent { event }, &store, &registry);
-    settle().await;
 
     assert!(matches!(resp, HookResponse::Ack));
-    let rows = query_attribution(&store, "sess-a").await;
+    let rows = await_attribution(&store, "sess-a", 1).await;
     assert_eq!(rows.len(), 1, "exactly one row");
     assert_eq!(rows[0].0, Some("vnc-030".to_string()));
     assert_eq!(
@@ -204,10 +227,9 @@ async fn stamp_read_batch_n_declared_rows() {
         .collect();
 
     let resp = dispatch!(HookRequest::RecordEvents { events }, &store, &registry);
-    settle().await;
 
     assert!(matches!(resp, HookResponse::Ack));
-    let rows = query_attribution(&store, "sess-c").await;
+    let rows = await_attribution(&store, "sess-c", 3).await;
     assert_eq!(rows.len(), 3, "N stamped events → N rows (R-06)");
     for r in &rows {
         assert_eq!(r.0, Some("vnc-030".to_string()));
@@ -241,9 +263,8 @@ async fn unstamped_frame_legacy_chain_not_declared() {
     );
 
     let _ = dispatch!(HookRequest::RecordEvent { event }, &store, &registry);
-    settle().await;
 
-    let rows = query_attribution(&store, "sess-unstamped").await;
+    let rows = await_attribution(&store, "sess-unstamped", 1).await;
     assert_eq!(rows.len(), 1);
     assert_ne!(
         rows[0].2,
@@ -268,9 +289,8 @@ async fn stamped_event_declared_even_with_empty_registry() {
 
     let event = make_stamped_event("PostToolUse", "sess-empty", "vnc-030", None, None);
     let _ = dispatch!(HookRequest::RecordEvent { event }, &store, &registry);
-    settle().await;
 
-    let rows = query_attribution(&store, "sess-empty").await;
+    let rows = await_attribution(&store, "sess-empty", 1).await;
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].0, Some("vnc-030".to_string()));
     assert_eq!(rows[0].2, Some("declared".to_string()));
@@ -296,9 +316,8 @@ async fn topic_source_extracted_from_unstamped_with_signal() {
     );
 
     let _ = dispatch!(HookRequest::RecordEvent { event }, &store, &registry);
-    settle().await;
 
-    let rows = query_attribution(&store, "sess-ext").await;
+    let rows = await_attribution(&store, "sess-ext", 1).await;
     assert_eq!(rows[0].0, Some("col-099".to_string()));
     assert_eq!(rows[0].2, Some("extracted".to_string()));
 }
@@ -318,9 +337,8 @@ async fn topic_source_registry_fill_from_enrich() {
     );
 
     let _ = dispatch!(HookRequest::RecordEvent { event }, &store, &registry);
-    settle().await;
 
-    let rows = query_attribution(&store, "sess-fill").await;
+    let rows = await_attribution(&store, "sess-fill", 1).await;
     assert_eq!(rows[0].0, Some("col-100".to_string()));
     assert_eq!(rows[0].2, Some("registry-fill".to_string()));
 }
@@ -346,9 +364,8 @@ async fn topic_source_vote_from_inferred_voted_fill() {
         None, // no extraction → fills from the Voted registry feature
     );
     let _ = dispatch!(HookRequest::RecordEvent { event }, &store, &registry);
-    settle().await;
 
-    let rows = query_attribution(&store, "sess-vote").await;
+    let rows = await_attribution(&store, "sess-vote", 1).await;
     assert_eq!(rows[0].0, Some("col-101".to_string()));
     assert_eq!(
         rows[0].2,
@@ -373,9 +390,8 @@ async fn topic_source_declared_overrides_extraction_unstamped() {
         Some("wrong-feature".to_string()), // contradicting extraction
     );
     let _ = dispatch!(HookRequest::RecordEvent { event }, &store, &registry);
-    settle().await;
 
-    let rows = query_attribution(&store, "sess-decl").await;
+    let rows = await_attribution(&store, "sess-decl", 1).await;
     assert_eq!(
         rows[0].0,
         Some("vnc-030".to_string()),
@@ -396,9 +412,8 @@ async fn topic_source_null_when_unattributed() {
         None,
     );
     let _ = dispatch!(HookRequest::RecordEvent { event }, &store, &registry);
-    settle().await;
 
-    let rows = query_attribution(&store, "sess-null").await;
+    let rows = await_attribution(&store, "sess-null", 1).await;
     assert_eq!(rows[0].2, None, "unattributed → topic_source NULL");
 }
 
@@ -414,10 +429,9 @@ async fn topic_with_sql_metachars_binds_parameterized() {
     let event = make_stamped_event("PostToolUse", "sess-sql", evil, None, None);
 
     let _ = dispatch!(HookRequest::RecordEvent { event }, &store, &registry);
-    settle().await;
 
     // The observations table still exists and holds the literal topic.
-    let rows = query_attribution(&store, "sess-sql").await;
+    let rows = await_attribution(&store, "sess-sql", 1).await;
     assert_eq!(rows.len(), 1, "table intact; one row written");
     assert_eq!(
         rows[0].0,

--- a/product/test/infra-001/suites/test_tools.py
+++ b/product/test/infra-001/suites/test_tools.py
@@ -1033,7 +1033,41 @@ def _seed_observation_sql(db_path, feature_ids, num_records=20):
     return seeded
 
 
-@pytest.mark.xfail(reason="Pre-existing: GH#305 — baseline_comparison null when synthetic features lack delivery counter registration")
+def _wait_for_metrics_committed(db_path, feature_ids, deadline_secs=10.0, poll_interval=0.05):
+    """Poll until MetricVectors for all `feature_ids` are committed to observation_metrics.
+
+    store_metrics is fire-and-forget through the analytics queue, drained only
+    every DRAIN_FLUSH_INTERVAL (500ms). A test that reads baseline history right
+    after generating MetricVectors races that drain (GH#305). This polls the
+    committed observation_metrics table (feature_cycle is its PRIMARY KEY) until
+    every feature_id is present, with a bounded deadline — deterministic rather
+    than a fixed sleep that can lag past 500ms on a loaded host.
+
+    Returns the committed count on success; raises AssertionError on timeout.
+    """
+    placeholders = ",".join("?" for _ in feature_ids)
+    sql = (
+        f"SELECT COUNT(*) FROM observation_metrics WHERE feature_cycle IN ({placeholders})"
+    )
+    deadline = time.monotonic() + deadline_secs
+    committed = 0
+    while time.monotonic() < deadline:
+        conn = sqlite3.connect(db_path)
+        try:
+            committed = conn.execute(sql, tuple(feature_ids)).fetchone()[0]
+        finally:
+            conn.close()
+        if committed >= len(feature_ids):
+            return committed
+        time.sleep(poll_interval)
+
+    raise AssertionError(
+        f"Timed out after {deadline_secs}s waiting for MetricVectors to commit: "
+        f"expected {len(feature_ids)} rows in observation_metrics for {feature_ids}, "
+        f"saw {committed}"
+    )
+
+
 def test_retrospective_baseline_present(server):
     """T-R04 (col-002b): Baseline comparison present with 3+ prior MetricVectors.
 
@@ -1049,6 +1083,12 @@ def test_retrospective_baseline_present(server):
     for fid in features[:3]:
         resp = server.context_cycle_review(fid, agent_id="human", format="json", timeout=30.0)
         result = assert_tool_success(resp)
+
+    # store_metrics is fire-and-forget via the analytics queue (500ms drain).
+    # Wait until the 3 MetricVectors are actually committed before the 4th read,
+    # otherwise col-804's baseline history is < MIN_HISTORY=3 and the (correct)
+    # baseline is null. Deterministic poll-until-committed, not a fixed sleep.
+    _wait_for_metrics_committed(db_path, features[:3])
 
     # Now run on 4th feature -- should have baseline from 3 prior
     resp = server.context_cycle_review(features[3], agent_id="human", format="json", timeout=30.0)


### PR DESCRIPTION
## Summary

Combined fix for three pre-existing, **test-only** failures — no production code changed.

### #691 + #452 — fire-and-forget write race in `#[tokio::test]` listener tests
`spawn_blocking_fire_and_forget` observation writes raced a fixed `yield_now() + std::thread::sleep(50ms)`, giving `left: 0` assertion failures. #452 additionally surfaced *"Tokio context being shutdown"* from `Handle::current().block_on(...)` inside `spawn_blocking` on a current-thread test runtime.

- New shared deadline-poll helpers `await_observations` (listener.rs) and `await_attribution` (stamp_read.rs), modeled on the in-tree canonical `transcript.rs:324` (5s deadline, 10ms poll, 100ms settle).
- **Positive** assertions (count==N / rows.len()==1) converted to poll-until-deadline.
- **Negative** assertions (count==0 / skip-observation) keep a fixed settle but swap `std::thread::sleep` → `tokio::time::sleep().await` so the reactor stays alive until any in-flight write lands. All 12 sleep sites resolved.

### #305 — analytics-drain write-visibility race (Python harness)
The analytics queue drains every 500ms; `test_retrospective_baseline_present` read col-804's baseline before 3 prior MetricVectors committed, so `compute_baselines` correctly returned `None`. Product behavior was correct; the col-020 warning is a cosmetic red herring.

- New `_wait_for_metrics_committed` poll helper waits until 3 `observation_metrics` rows commit before the 4th retrospective; `@pytest.mark.xfail` removed.

## Testing
- Bug-specific loops: col018 20/20, transcript 20/20, stamp_read 20/20, `test_retrospective_baseline_present` 3/3 — all green.
- `cargo test --workspace`: 3746 passed; the sole failure is the pre-existing unrelated flake `http::token::tests::test_concurrent_creation_no_corruption` (10/10 isolated, not in diff).
- Smoke 23/0; tools suite 188 passed.
- Gate: Bug Fix Validation — **PASS 7/7**. Diff is test-only across 3 files.

Fixes #691
Fixes #452
Fixes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)
