### PR TITLE
fix: redact bearer token from first-boot stdout (#736)

### DIFF
--- a/crates/unimatrix-server/src/http/token.rs
+++ b/crates/unimatrix-server/src/http/token.rs
@@ -24,8 +24,10 @@ const TOKEN_HEX_LEN: usize = 64;
 
 /// Load an existing token or generate a new one.
 ///
-/// Returns raw token bytes (32 bytes), not hex. When generating a new token,
-/// prints it to stdout with a `[UNIMATRIX TOKEN]` label exactly once.
+/// Returns raw token bytes (32 bytes), not hex. On first generation, emits a
+/// non-sensitive pointer to the retrieval command on stderr; the token hex is
+/// never written to stdout, stderr, or any log line (NFR-06). The token is
+/// recoverable only from the 0600 file or `unimatrix client-bundle`.
 ///
 /// The flow is generate-first: attempt atomic file creation, and on
 /// `AlreadyExists` fall back to loading the existing file. This eliminates
@@ -97,10 +99,22 @@ fn write_new_token(
         )));
     }
 
-    // Print token to stdout exactly once (FR-08).
-    println!("[UNIMATRIX TOKEN] {hex_string}");
+    // Confirm generation on stderr with a non-sensitive pointer. The token hex
+    // is NEVER emitted (NFR-06) — render-then-emit keeps the message testable.
+    eprintln!("{}", render_first_boot_notice());
 
     Ok(token_bytes.to_vec())
+}
+
+/// Build the first-boot success notice shown after generating a new token.
+///
+/// Pure string builder (render-then-emit): it confirms the token was generated
+/// and stored, and points to the supported retrieval command. It MUST NOT
+/// contain the token hex, the token-file path, or any secret (NFR-06).
+fn render_first_boot_notice() -> String {
+    "[unimatrix] bearer token generated and stored (0600). \
+     Retrieve it with: unimatrix client-bundle"
+        .to_string()
 }
 
 /// Load and validate an existing token file.
@@ -147,6 +161,25 @@ mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
     use tempfile::TempDir;
+
+    // T-TM-15: first-boot notice never contains the token hex (NFR-06) and
+    // points to the retrieval command. Mirrors client_bundle.rs token-absence
+    // unit test — render-then-emit makes this a true unit test (no binary spawn).
+    #[test]
+    fn test_first_boot_notice_token_absent_and_points_to_retrieval() {
+        // A representative 64-hex token; the notice must not echo it.
+        let hex_string = "ab".repeat(32);
+        let notice = render_first_boot_notice();
+
+        assert!(
+            !notice.contains(&hex_string),
+            "first-boot notice must never contain the token hex (NFR-06)"
+        );
+        assert!(
+            notice.contains("client-bundle"),
+            "notice must point operators to the retrieval command"
+        );
+    }
 
     // T-TM-01: test_generate_token_creates_file_with_correct_length
     #[test]


### PR DESCRIPTION
## Summary
Eliminates the cleartext bearer-token leak to stdout on server first boot (NFR-06). `write_new_token` printed the freshly-generated token hex via `println!("[UNIMATRIX TOKEN] {hex_string}")` at `token.rs:101`, where `docker logs`/log shippers persist the sole auth credential in plaintext outside the `0600` token file.

Surfaced by the vnc-034 security review (finding **N1**, low) and the PR #734 product review. Pre-existing — predates vnc-034.

## Change
- `token.rs:101` `println!`(token hex) → `eprintln!(render_first_boot_notice())` — a pointer-only message to **stderr**: `"[unimatrix] bearer token generated and stored (0600). Retrieve it with: unimatrix client-bundle"`. No hex, no file path.
- New pure `render_first_boot_notice()` builder (render-then-emit split, per established `client_bundle.rs` pattern) so the absence assertion is a true unit test.
- Doc comment (`token.rs:25-28`) updated; stale `(FR-08)` comment removed.
- Sole leak site — confirmed by investigator + architect scope checks (`main.rs` hash prints are model SHA-256s; "daemon token" traces are `CancellationToken`; client-bundle reads read-only and redacts).

## Test
- New unit test `test_first_boot_notice_token_absent_and_points_to_retrieval` asserts the rendered notice contains no token hex and includes the retrieval pointer.
- `cargo test -p unimatrix-server --lib http::token`: 17 passed.
- Workspace: 4002 passed; the 1 failure is pre-existing flake #710 (untouched code). Integration smoke 23 passed; security+protocol 35 passed.

## Reviews
- Diagnosis + design (APPROVED WITH NOTES) + product review + bugfix gate (PASS 7/7) — all on issue #736.

## Provenance note
On merge, strike the superseded N1 token-print item from #735 (its remaining scope is the two minor code cleanups).

Closes #736. Refs #733, #734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)