### PR TITLE
fix: de-flake test-integrity cluster + harden cargo-test process (#742)

### DIFF
--- a/.claude/agents/ndp/ndp-validator.md
+++ b/.claude/agents/ndp/ndp-validator.md
@@ -78,7 +78,7 @@ Read `.claude/skills/validate/SKILL.md` for the full procedure. Summary:
 cargo build --workspace 2>&1 | grep -A5 "^error" | head -20
 cargo build --workspace 2>&1 | tail -3
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 ```
 Plus anti-stub scan and deploy.sh integrity check (if deploy.sh was modified).
 
@@ -140,7 +140,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Tests: hardened workspace run — own process group + hard ceiling + file-not-pipe.
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30

--- a/.claude/agents/uni/uni-rust-dev.md
+++ b/.claude/agents/uni/uni-rust-dev.md
@@ -146,7 +146,7 @@ Include in your agent report:
 ## Self-Check (Run Before Returning Results)
 
 - [ ] `cargo build --workspace` passes (zero errors)
-- [ ] `cargo test --workspace` passes (no new failures) — run via the hardened convention in `.claude/rules/rust-workspace.md` (`setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc`), never as a bare `cargo test ... | tail` pipe
+- [ ] `cargo test --workspace` passes (no new failures) — run via the hardened convention in `.claude/rules/rust-workspace.md` (`log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc`), never as a bare `cargo test ... | tail` pipe
 - [ ] No `todo!()`, `unimplemented!()`, `TODO`, `FIXME`, or `HACK` in non-test code
 - [ ] All modified files are within the scope defined in the brief
 - [ ] Error handling uses project error type with context, not `.unwrap()` in non-test code

--- a/.claude/agents/uni/uni-scrum-master.md
+++ b/.claude/agents/uni/uni-scrum-master.md
@@ -153,7 +153,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30

--- a/.claude/agents/uni/uni-tester.md
+++ b/.claude/agents/uni/uni-tester.md
@@ -100,7 +100,7 @@ test-plan/
 
 ### What You Do
 
-1. Execute unit tests via the hardened convention (see "Cargo Output Truncation" below): `setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc`
+1. Execute unit tests via the hardened convention (see "Cargo Output Truncation" below): `log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc`
 2. Execute integration smoke tests (MANDATORY gate): `cd product/test/infra-001 && python -m pytest suites/ -v -m smoke --timeout=60`
 3. Execute relevant integration suites based on what the feature touches (see suite selection table below)
 4. Execute feature-level tests mapped to the Risk Strategy
@@ -256,7 +256,7 @@ When an integration test fails, determine causation:
 ```bash
 # Test: hardened workspace run — own process group + hard ceiling + file-not-pipe.
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 ```
 
 NEVER pipe full cargo output into context. NEVER rewrite the line above as a pipeline

--- a/.claude/agents/uni/uni-validator.md
+++ b/.claude/agents/uni/uni-validator.md
@@ -254,7 +254,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Tests: hardened workspace run — own process group + hard ceiling + file-not-pipe.
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 ```
 
 NEVER pipe full cargo output into context. NEVER rewrite the test line as a pipeline

--- a/.claude/protocols/implementation-protocol.md
+++ b/.claude/protocols/implementation-protocol.md
@@ -278,7 +278,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30

--- a/.claude/protocols/uni/uni-bugfix-protocol.md
+++ b/.claude/protocols/uni/uni-bugfix-protocol.md
@@ -516,7 +516,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30

--- a/.claude/protocols/uni/uni-delivery-protocol.md
+++ b/.claude/protocols/uni/uni-delivery-protocol.md
@@ -562,7 +562,7 @@ cargo build --workspace 2>&1 | tail -3
 
 # Test: hardened workspace run — own process group + hard ceiling + file-not-pipe (see rust-workspace.md).
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children
-setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 # Never rewrite as a pipeline (`cargo test ... | tail`) or background it: rc=$? must
 # capture cargo test, not tail. timeout rc=124 = killed-at-ceiling (investigate the hang).
 

--- a/.claude/rules/rust-workspace.md
+++ b/.claude/rules/rust-workspace.md
@@ -18,7 +18,7 @@ cargo build --workspace 2>&1 | tail -3
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children.
 # `setsid -w` is REQUIRED: without -w, setsid returns its own fork status (0) instead of
 # the inner command's exit code, producing false-green gates (GH#709). rc=124 = killed at ceiling.
-setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30
@@ -34,7 +34,7 @@ the regression lint (`product/test/infra-002/check-cargo-test-convention.sh`) pa
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children.
 # `setsid -w` is REQUIRED: without -w, setsid returns its own fork status (0) instead of
 # the inner command's exit code, producing false-green gates (GH#709). rc=124 = killed at ceiling.
-setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 ```
 
 Why each piece exists (do NOT rewrite it as a pipeline — `cargo test ... | tail`):
@@ -51,17 +51,21 @@ Why each piece exists (do NOT rewrite it as a pipeline — `cargo test ... | tai
   magic number) imposes a hard ceiling and kills the entire child tree on expiry. 600s
   fits a cold full-workspace build+test; integration-heavy crates may approach it on a
   cold cache. Tune in ONE place via the env var.
-- **`> /tmp/uni-test.$$.log 2>&1`** writes to a PID-namespaced file, NOT a live pipe.
-  A pipe makes `cargo` the upstream writer of a pipeline the harness cannot kill as a
-  unit; a file removes that orphan-writer problem while preserving output truncation.
+- **`log="$(mktemp -t uni-test.XXXXXX.log)"` + `> "$log" 2>&1`** writes to a private temp
+  file, NOT a live pipe. A pipe makes `cargo` the upstream writer of a pipeline the harness
+  cannot kill as a unit; a file removes that orphan-writer problem while preserving output
+  truncation. `mktemp` creates the file atomically (`O_EXCL`) with a 0600, unpredictable
+  name. The earlier predictable form `> /tmp/uni-test.$$.log` (DON'T use it) used the shell
+  PID `$$`, which a local attacker or stale file can pre-plant as a symlink at the
+  guessable path so `>` clobbers the symlink target — `mktemp` removes that TOCTOU surface.
 - **EXIT-CODE GUARD (load-bearing — gate integrity):** the capture+report is a SINGLE
   NON-PIPELINED statement. `rc=$?` captures the status of `cargo test` (via `timeout`),
   NOT `tail`. NEVER rewrite this as `... | tail` and NEVER background it (`&`) — either
   makes `$rc` the wrong process's status and gates read FALSE-GREEN. `tail` runs AFTER
   `rc` is captured, so it cannot clobber the result; `exit $rc` propagates the real status.
-- **`rm -f /tmp/uni-test.$$.log`** cleans the log on every success/failure path before
-  `exit`. An interrupted run may leave at most one PID-stamped file (acceptable); files
-  do not accumulate per successful run.
+- **`rm -f "$log"`** cleans the temp log on every success/failure path before `exit`. An
+  interrupted run may leave at most one `mktemp`-named file (acceptable); files do not
+  accumulate per successful run.
 
 ### rc=124 means KILLED at the ceiling — not a test failure
 
@@ -70,6 +74,21 @@ Treat **124 as "the run was killed for hanging" (investigate the hang)** — it 
 but it is NOT an ordinary parseable red suite and MUST NOT be auto-retried as if a test
 flaked. On 124: investigate the hang (likely an orphan/lock from a prior run), then
 re-run per-crate (`cargo test -p {crate} --lib`) rather than blindly retrying `--workspace`.
+
+### Routine vs pre-PR — default to per-crate
+
+For **routine / iterative** validation while developing, default to a **per-crate** run:
+
+```bash
+cargo test -p {crate} --lib
+```
+
+It is faster and avoids the cross-crate `target/.cargo-lock` contention and shared-state
+parallelism that the full-workspace run triggers (the very condition under which the
+known flake class surfaces). Reach for the hardened `setsid -w ... --workspace` form above
+**only for pre-PR / gate runs**, where full cross-crate integration coverage is required.
+This is guidance on *when* to run `--workspace`; it does NOT change the canonical hardened
+`--workspace` string or the regression scanner — both stay exactly as defined above.
 
 ## Naming Conventions
 

--- a/crates/unimatrix-server/src/eval/runner/sweep_tests.rs
+++ b/crates/unimatrix-server/src/eval/runner/sweep_tests.rs
@@ -17,8 +17,8 @@
 //! (model-free, offline) so retrieval returns ranked, non-empty results — exactly
 //! the seam that makes the trust assertions non-vacuous (R-15).
 
-use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
@@ -26,8 +26,8 @@ use tempfile::TempDir;
 
 use super::output::ScenarioResult;
 use super::sweep::{default_fixtures_dir, run_fixture_sweep};
-use crate::eval::profile::{EvalProfile, parse_profile_toml};
-use crate::eval::shape::{CorpusKind, ShapeDriftError, build_running_manifest, check_drift};
+use crate::eval::profile::{parse_profile_toml, EvalProfile};
+use crate::eval::shape::{build_running_manifest, check_drift, CorpusKind, ShapeDriftError};
 use crate::infra::config::InferenceConfig;
 use unimatrix_embed::{EmbeddingModel, EmbeddingProvider};
 
@@ -125,7 +125,20 @@ async fn test_ac14_correlated_sweep_non_vacuous() {
          \n[graph_penalty]\norphan = 0.10\nclean_replacement = 0.10\n\
          partial_supersession = 0.10\ndead_end = 0.10\nfallback = 0.10\n",
     );
-    let profiles = vec![baseline, steep];
+    // BASELINE-REPRO: an IDENTICAL default-penalty profile under a distinct name, run
+    // in the SAME sweep as `baseline`. Cond. 4 compares this against `baseline` to prove
+    // the scoring pipeline reproduces bit-for-bit GIVEN A SINGLE MATERIALIZATION — the
+    // property production actually guarantees (one corpus dump, reloaded by every
+    // profile; pattern #2673). A second independent `run_fixture_sweep` would rebuild a
+    // fresh HNSW index (hnsw_rs 0.3.4 `LayerGenerator` reseeds from OS entropy per build,
+    // no public seeding API) and inject cross-build index nondeterminism the assertion
+    // was never meant to test (742 item 4, design-reviewer-v2).
+    let baseline_repro = profile_from_toml(
+        work.path(),
+        "baseline_repro.toml",
+        "[profile]\nname = \"baseline_repro\"\ndescription = \"default penalties\"\n",
+    );
+    let profiles = vec![baseline, steep, baseline_repro];
 
     // ----- Run the correlated sweep ----------------------------------------------
     let outcome = run_fixture_sweep(
@@ -279,39 +292,26 @@ async fn test_ac14_correlated_sweep_non_vacuous() {
 
     // =============================================================================
     // CONDITION 4 — the swept BASELINE (default penalties) reproduces current
-    // behavior bit-for-bit. Re-run the SAME corpus with the baseline profile ONLY
-    // and a fixed-default `with_rate_config` parity reference: the baseline scores
-    // must equal a second baseline run exactly (deterministic provider + default
-    // penalties ⇒ identical final_scores), and must NOT equal the steep run.
+    // behavior bit-for-bit. The reproduction is the `baseline_repro` profile — an
+    // IDENTICAL default-penalty profile run in the SAME sweep, so it loads the SAME
+    // single materialized corpus/index `baseline` loaded (pattern #2673). The baseline
+    // scores must equal this second default-penalty run exactly (deterministic provider
+    // + default penalties + ONE materialization ⇒ identical final_scores), and must NOT
+    // equal the steep run.
+    //
+    // This asserts what production actually guarantees — pipeline determinism over a
+    // SINGLE materialization — not the incidental cross-build index determinism that
+    // hnsw_rs 0.3.4 cannot provide (no seeding API; reseeds per `VectorIndex::new`).
+    // A prior version re-ran the whole sweep into a second DB (`snap2.db`), rebuilding
+    // a fresh, independently-randomized HNSW index and flaking this assertion ~12% of
+    // runs (742 item 4). Reusing the single materialization removes that nondeterminism
+    // SOURCE; the bit-for-bit check below is preserved verbatim.
     // =============================================================================
-    let out2 = work.path().join("results_baseline_only");
-    let target_db2 = work.path().join("snap2.db");
-    let baseline_only = vec![profile_from_toml(
-        work.path(),
-        "baseline2.toml",
-        "[profile]\nname = \"baseline\"\ndescription = \"default penalties\"\n",
-    )];
-    run_fixture_sweep(
-        &corpus_dir,
-        &target_db2,
-        &baseline_only,
-        5,
-        &out2,
-        Arc::new(DeterministicProvider),
-        None,
-    )
-    .await
-    .expect("baseline-only re-run");
-    let results2 = read_results(&out2);
-    let dep2 = results2
-        .iter()
-        .find(|sr| sr.scenario_id == "deprecated-connected.rank-below-band")
-        .expect("dep scenario in baseline-only run");
     let base2_scores = score_by_id(
-        &dep2
+        &dep_scenario
             .profiles
-            .get("baseline")
-            .expect("baseline result")
+            .get("baseline_repro")
+            .expect("baseline_repro result")
             .entries,
     );
     // Bit-for-bit: the default-penalty run reproduces itself exactly across two runs.

--- a/crates/unimatrix-server/src/http/listener/tests.rs
+++ b/crates/unimatrix-server/src/http/listener/tests.rs
@@ -101,6 +101,33 @@ async fn send_http_get(addr: SocketAddr) -> Result<String, Box<dyn std::error::E
     Ok(String::from_utf8_lossy(&buf[..n]).to_string())
 }
 
+/// Deadline-poll a GET until it returns a 200, retrying transient failures.
+///
+/// Per-connection permits are RAII-held by the spawned task and released only
+/// AFTER that task ends — asynchronously, with no happens-before edge a caller
+/// can observe. So the next acquire can legitimately race the prior release: a
+/// not-yet-released permit makes the acceptor drop the stream, surfacing as a
+/// connect/read error or a non-200. Polling the OBSERVABLE (a 200) within a
+/// bounded deadline asserts EVENTUAL recovery without a fixed-sleep guess. A
+/// genuine permit-leak still fails: the deadline expires. Uses
+/// `tokio::time::sleep().await` (never `std::thread::sleep`) to keep the
+/// current-thread reactor alive.
+async fn send_http_get_until_200(addr: SocketAddr) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        match send_http_get(addr).await {
+            Ok(resp) if resp.contains("200") => return,
+            other => {
+                assert!(
+                    tokio::time::Instant::now() < deadline,
+                    "timed out waiting for a 200 (permit never recovered); last: {other:?}"
+                );
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+    }
+}
+
 // T-HL-01: test_listener_binds_and_accepts_connection
 #[tokio::test(flavor = "multi_thread")]
 async fn test_listener_binds_and_accepts_connection() {
@@ -252,14 +279,11 @@ async fn test_semaphore_recovery_sequential_connections() {
         .await
         .expect("listener must bind");
 
-    // Open and close 10 connections sequentially
-    for i in 0..10 {
-        let resp = send_http_get(addr).await;
-        assert!(
-            resp.is_ok(),
-            "connection {i} must succeed; got {:?}",
-            resp.err()
-        );
+    // Open and close 10 connections sequentially. With a single permit, the next
+    // connect can race the prior task's async permit release; poll for EVENTUAL
+    // recovery (a 200) per connection rather than asserting immediate success.
+    for _ in 0..10 {
+        send_http_get_until_200(addr).await;
     }
 
     token.cancel();
@@ -416,17 +440,11 @@ async fn test_semaphore_recovery_after_malformed_http() {
         let _ = tokio::time::timeout(Duration::from_secs(2), stream.read(&mut buf)).await;
     }
 
-    // Give time for permit release
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    // Valid connection should succeed (permit was released)
-    let resp = send_http_get(addr)
-        .await
-        .expect("valid request must succeed");
-    assert!(
-        resp.contains("200"),
-        "valid request after garbage must succeed"
-    );
+    // The malformed connection's permit is released asynchronously when its task
+    // ends — no observable happens-before edge. Poll for EVENTUAL recovery (a
+    // 200) within a bounded deadline instead of a fixed 200ms sleep; a genuine
+    // permit-leak still fails when the deadline expires.
+    send_http_get_until_200(addr).await;
 
     token.cancel();
     let _ = tokio::time::timeout(Duration::from_secs(5), handle).await;

--- a/crates/unimatrix-server/src/http/token.rs
+++ b/crates/unimatrix-server/src/http/token.rs
@@ -22,6 +22,26 @@ const TOKEN_BYTE_LEN: usize = 32;
 /// Expected hex-encoded string length (TOKEN_BYTE_LEN * 2).
 const TOKEN_HEX_LEN: usize = 64;
 
+/// Bounded read-retry budget for `load_existing_token` (loser branch).
+///
+/// The election winner creates the empty final file (O_EXCL) then publishes the
+/// 64 hex bytes via a temp-file + atomic rename. A loser that takes the
+/// `AlreadyExists -> load` arm can observe the file in the brief create->rename
+/// gap (0 bytes, or, transiently, the prior inode mid-rename). It retries reading
+/// for up to this ceiling before surfacing whatever it last read (so a genuinely
+/// malformed token still produces the canonical length error).
+const LOAD_RETRY_CEILING_MS: u64 = 50;
+
+/// Poll interval for the loser's bounded read-retry.
+const LOAD_RETRY_POLL_MS: u64 = 1;
+
+/// Test-only hook: a pause (ms) injected by the winner between creating the empty
+/// final file and publishing the token via temp+rename. Deterministically widens
+/// the loser-reads-mid-write window so the forced-interleave convergence test does
+/// not depend on scheduler luck. Zero in production (the hook is never set).
+#[cfg(test)]
+static WRITE_PAUSE_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Load an existing token or generate a new one.
 ///
 /// Returns raw token bytes (32 bytes), not hex. On first generation, emits a
@@ -46,6 +66,8 @@ pub fn load_or_generate_token(data_dir: &Path) -> Result<Vec<u8>, ServerError> {
     let hex_string = hex::encode(token_bytes);
 
     match create_token_file(&token_path) {
+        // Winner: holds the exclusively-created empty final file. It alone writes
+        // (losers load), so both racers converge on the SAME token.
         Ok(file) => write_new_token(file, &token_path, &token_bytes, &hex_string),
         Err(e) if e.kind() == io::ErrorKind::AlreadyExists => load_existing_token(&token_path),
         Err(e) => Err(ServerError::ProjectInit(format!(
@@ -75,26 +97,71 @@ fn create_token_file(path: &Path) -> io::Result<File> {
     }
 }
 
-/// Generate a new 32-byte token, write hex-encoded to the already-created file.
+/// Publish the new token to the (already exclusively-created) final file via an
+/// ATOMIC temp-file + rename.
 ///
-/// Token bytes and hex encoding are prepared before file creation so the write
-/// follows the open with minimal delay, narrowing the race window for concurrent
-/// creators.
+/// The election winner holds `file`: an empty final-path file it created with
+/// `O_CREAT | O_EXCL`. Writing the hex IN PLACE leaves a window where a concurrent
+/// loser reads the still-empty final file (the "found 0" defect). Instead the
+/// winner writes the 64 hex bytes to a PID-namespaced sibling temp file
+/// (`.token.<pid>.tmp`, mode 0600) and `fs::rename`s it onto the final path. Rename
+/// is atomic on one filesystem, so a reader sees either the prior bytes or the full
+/// 64 — never a partial. Mode 0600 carries through the rename (it is the temp
+/// inode's mode). The empty final file the winner created is replaced by the rename.
 ///
-/// On write failure, cleans up the empty file to prevent a 0-byte token file
-/// persisting on disk.
+/// Temp cleanup: any error / early return removes the temp file so no orphan
+/// `.token.<pid>.tmp` persists on collision or failure.
 fn write_new_token(
-    mut file: File,
+    file: File,
     path: &Path,
     token_bytes: &[u8; TOKEN_BYTE_LEN],
     hex_string: &str,
 ) -> Result<Vec<u8>, ServerError> {
-    // Write token content. On failure, clean up the empty file to prevent
-    // a 0-byte token file persisting on disk.
-    if let Err(e) = file.write_all(hex_string.as_bytes()) {
-        let _ = fs::remove_file(path);
+    // The winner created the empty final file purely to win the election; the
+    // bytes go via temp+rename, so we no longer write through this handle.
+    drop(file);
+
+    let tmp_path = temp_token_path(path);
+
+    // Remove any stale temp from a crashed prior boot reusing this PID (cheap
+    // belt-and-suspenders so the O_EXCL temp create below cannot spuriously fail).
+    let _ = fs::remove_file(&tmp_path);
+
+    // Test-only: widen the create->publish window deterministically.
+    #[cfg(test)]
+    {
+        let pause = WRITE_PAUSE_MS.load(std::sync::atomic::Ordering::SeqCst);
+        if pause > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(pause));
+        }
+    }
+
+    // Create the temp file exclusively at mode 0600, then write the hex.
+    let mut tmp_file = match create_temp_token_file(&tmp_path) {
+        Ok(f) => f,
+        Err(e) => {
+            return Err(ServerError::ProjectInit(format!(
+                "failed to create temp token file {}: {e}",
+                tmp_path.display()
+            )));
+        }
+    };
+
+    if let Err(e) = tmp_file.write_all(hex_string.as_bytes()) {
+        let _ = fs::remove_file(&tmp_path);
         return Err(ServerError::ProjectInit(format!(
-            "failed to write token file {}: {e}",
+            "failed to write temp token file {}: {e}",
+            tmp_path.display()
+        )));
+    }
+    // Drop the handle before rename so all bytes are flushed to the inode.
+    drop(tmp_file);
+
+    // Atomic publish: replace the empty final file with the fully-written temp.
+    if let Err(e) = fs::rename(&tmp_path, path) {
+        let _ = fs::remove_file(&tmp_path);
+        return Err(ServerError::ProjectInit(format!(
+            "failed to publish token file {}: {e}",
             path.display()
         )));
     }
@@ -104,6 +171,30 @@ fn write_new_token(
     eprintln!("{}", render_first_boot_notice());
 
     Ok(token_bytes.to_vec())
+}
+
+/// Sibling temp path for the atomic write, PID-namespaced to avoid cross-process
+/// collision (`.token.<pid>.tmp` in the same directory as the final token).
+fn temp_token_path(final_path: &Path) -> std::path::PathBuf {
+    let dir = final_path.parent().unwrap_or_else(|| Path::new("."));
+    dir.join(format!(".{TOKEN_FILE_NAME}.{}.tmp", std::process::id()))
+}
+
+/// Exclusively create the temp token file at mode 0600 (carried through rename).
+fn create_temp_token_file(path: &Path) -> io::Result<File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(path)
+    }
+    #[cfg(not(unix))]
+    {
+        OpenOptions::new().write(true).create_new(true).open(path)
+    }
 }
 
 /// Build the first-boot success notice shown after generating a new token.
@@ -118,10 +209,31 @@ fn render_first_boot_notice() -> String {
 }
 
 /// Load and validate an existing token file.
+///
+/// This is the election LOSER's branch. The winner created the empty final file
+/// (O_EXCL) and publishes the 64 hex bytes via temp+rename; a loser can observe
+/// the file in the brief create->rename gap (0 bytes). This is the PRIMARY
+/// correctness mechanism: poll briefly (bounded by `LOAD_RETRY_CEILING_MS`) until
+/// the file is the published length, instead of panicking on a not-yet-complete
+/// read. On deadline, surface the last read so a genuinely malformed token still
+/// produces the canonical length error.
 fn load_existing_token(path: &Path) -> Result<Vec<u8>, ServerError> {
-    let content = fs::read_to_string(path).map_err(|e| {
-        ServerError::ProjectInit(format!("failed to read token file {}: {e}", path.display()))
-    })?;
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_millis(LOAD_RETRY_CEILING_MS);
+
+    let content = loop {
+        let read = fs::read_to_string(path).map_err(|e| {
+            ServerError::ProjectInit(format!("failed to read token file {}: {e}", path.display()))
+        })?;
+
+        // The published token is exactly TOKEN_HEX_LEN hex chars (plus optional
+        // trailing whitespace). A complete read is therefore >= TOKEN_HEX_LEN
+        // after trimming; anything shorter is the create->rename gap — retry.
+        if read.trim_end().len() >= TOKEN_HEX_LEN || std::time::Instant::now() >= deadline {
+            break read;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(LOAD_RETRY_POLL_MS));
+    };
 
     // Strip trailing whitespace (R-15 mitigation: trailing newline tolerance).
     let trimmed = content.trim_end();
@@ -429,5 +541,74 @@ mod tests {
         // Permissions must be 0600
         let mode = fs::metadata(&token_path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o600);
+    }
+
+    /// Serializes use of the global `WRITE_PAUSE_MS` hook so it cannot perturb
+    /// sibling tests that run concurrently in the same lib binary.
+    static WRITE_PAUSE_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    // T-742-01: forced-interleave convergence (#742 Item 1).
+    //
+    // Deterministically widens the winner's create->publish window via the
+    // WRITE_PAUSE hook so the loser ALWAYS reads the file mid-write, then asserts:
+    //   - convergence: both racers return the SAME token (token_a == token_b),
+    //   - the published token is the full 64 hex chars (NO "found 0"),
+    //   - 0600 survives the temp+rename,
+    //   - no orphan `.token.<pid>.tmp` remains.
+    // Looped ~20x to exercise the window repeatedly.
+    #[test]
+    fn test_concurrent_creation_forced_interleave_converges() {
+        use std::sync::atomic::Ordering;
+        use std::sync::{Arc, Barrier};
+
+        let _guard = WRITE_PAUSE_GUARD.lock().unwrap();
+        // 5ms pause between final-file create and temp-write+rename: a loser that
+        // wins the barrier will observe the empty final file and must retry-read.
+        WRITE_PAUSE_MS.store(5, Ordering::SeqCst);
+
+        for _ in 0..20 {
+            let tmp = TempDir::new().unwrap();
+            let data_dir = tmp.path().to_path_buf();
+            let barrier = Arc::new(Barrier::new(2));
+
+            let handles: Vec<_> = (0..2)
+                .map(|_| {
+                    let dir = data_dir.clone();
+                    let bar = Arc::clone(&barrier);
+                    std::thread::spawn(move || {
+                        bar.wait();
+                        load_or_generate_token(&dir)
+                    })
+                })
+                .collect();
+
+            let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+            let token_a = results[0].as_ref().expect("thread 0 failed");
+            let token_b = results[1].as_ref().expect("thread 1 failed");
+
+            // Convergence: one wrote, one loaded; both return the SAME token.
+            assert_eq!(token_a, token_b, "racers must converge on same token");
+
+            // Published file is the full 64 hex chars (no "found 0").
+            let token_path = data_dir.join("token");
+            let contents = fs::read_to_string(&token_path).unwrap();
+            assert_eq!(contents.len(), 64, "published token must be 64 hex chars");
+            assert!(contents.chars().all(|c| c.is_ascii_hexdigit()));
+
+            // 0600 survives the rename.
+            let mode = fs::metadata(&token_path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "0600 must survive temp+rename");
+
+            // No orphan temp file remains.
+            let tmp_path = temp_token_path(&token_path);
+            assert!(
+                !tmp_path.exists(),
+                "no orphan temp token file must remain: {}",
+                tmp_path.display()
+            );
+        }
+
+        WRITE_PAUSE_MS.store(0, Ordering::SeqCst);
     }
 }

--- a/crates/unimatrix-server/src/services/search.rs
+++ b/crates/unimatrix-server/src/services/search.rs
@@ -998,6 +998,14 @@ impl SearchService {
             let mut seed_scores: HashMap<u64, f64> =
                 HashMap::with_capacity(results_with_scores.len());
 
+            // Accumulate `total` in the SAME single pass, over the source
+            // `results_with_scores` Vec (deterministic order), NOT via
+            // `seed_scores.values().sum()` over a HashMap (non-deterministic
+            // iteration order). f64 addition is non-associative, so summing in
+            // HashMap order drifts ~1e-9 run-to-run, breaking the eval harness'
+            // bit-for-bit reproducibility (AC-14). Entry ids are unique, so the
+            // value-set is identical — only the order is canonicalized.
+            let mut total: f64 = 0.0;
             for (entry, sim) in &results_with_scores {
                 let affinity: f64 = if let (Some(_phase), Some(snapshot)) =
                     (&params.current_phase, &phase_snapshot)
@@ -1010,11 +1018,12 @@ impl SearchService {
                 } else {
                     1.0 // no phase or no snapshot → cold-start neutral
                 };
-                seed_scores.insert(entry.id, sim * affinity);
+                let weighted = sim * affinity;
+                total += weighted;
+                seed_scores.insert(entry.id, weighted);
             }
 
-            // Normalize to sum 1.0.
-            let total: f64 = seed_scores.values().sum();
+            // `total` already summed in deterministic Vec order above.
 
             // Zero-sum guard (FR-08 / FM-05):
             // All HNSW scores are 0.0 — degenerate, should not occur in practice.
@@ -1065,9 +1074,15 @@ impl SearchService {
                     .map(|(id, score)| (*id, *score))
                     .collect();
 
-                // Sort descending by PPR score.
-                ppr_only_candidates
-                    .sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+                // Sort descending by PPR score, with an id tie-break so that
+                // exact-score ties order deterministically before truncate
+                // (HashMap iteration order is non-deterministic otherwise — a
+                // tie could include/exclude different entries run-to-run).
+                ppr_only_candidates.sort_unstable_by(|a, b| {
+                    b.1.partial_cmp(&a.1)
+                        .unwrap_or(Ordering::Equal)
+                        .then(a.0.cmp(&b.0))
+                });
 
                 // Cap at ppr_max_expand (E-04).
                 ppr_only_candidates.truncate(self.ppr_max_expand);
@@ -5886,5 +5901,113 @@ mod tests {
                 );
             }
         }
+    }
+
+    // -- Item 4 (#742): seed-score sum determinism -------------------------
+    //
+    // `total` is summed over the source `results_with_scores` Vec (deterministic
+    // order), NOT over `seed_scores.values()` (HashMap iteration order). f64
+    // addition is non-associative, so a HashMap-order sum drifts ~1e-9 run-to-run
+    // and breaks the eval harness' bit-for-bit reproducibility (AC-14). These
+    // tests pin the engine-layer guarantee directly, below the eval integration
+    // test.
+
+    /// Mirror of the production accumulation: `total` over the Vec, in Vec order.
+    fn seed_total_vec_order(results: &[(u64, f64)]) -> f64 {
+        let mut total = 0.0;
+        for (_id, weighted) in results {
+            total += *weighted;
+        }
+        total
+    }
+
+    /// The (rejected) HashMap-order sum, for the contrast test only.
+    fn seed_total_hashmap_order(results: &[(u64, f64)]) -> f64 {
+        let map: HashMap<u64, f64> = results.iter().copied().collect();
+        map.values().sum()
+    }
+
+    fn fixed_seed_inputs() -> Vec<(u64, f64)> {
+        // A spread of magnitudes so non-associativity is observable.
+        vec![
+            (1016, 0.731_274_91_f64),
+            (1014, 0.000_000_013_7_f64),
+            (42, 0.499_999_991_2_f64),
+            (7, 0.250_000_004_4_f64),
+            (9001, 0.000_173_2_f64),
+            (3, 0.812_634_55_f64),
+            (88, 0.000_000_000_91_f64),
+            (1234, 0.640_001_2_f64),
+        ]
+    }
+
+    // T-742-04a: summing `total` over the source Vec is bit-for-bit stable
+    // across repeated calls on the same input.
+    #[test]
+    fn test_seed_total_vec_order_is_bit_for_bit_stable() {
+        let input = fixed_seed_inputs();
+        let baseline = seed_total_vec_order(&input);
+        for _ in 0..1000 {
+            let again = seed_total_vec_order(&input);
+            assert_eq!(
+                again.to_bits(),
+                baseline.to_bits(),
+                "Vec-order seed total must be bit-for-bit identical across calls"
+            );
+        }
+    }
+
+    // T-742-04b: the normalized seed scores (value / total) are bit-for-bit
+    // identical across repeated calls — this is the value PPR consumes.
+    #[test]
+    fn test_normalized_seed_scores_bit_for_bit_stable() {
+        let input = fixed_seed_inputs();
+
+        let normalize = |results: &[(u64, f64)]| -> Vec<(u64, u64)> {
+            let total = seed_total_vec_order(results);
+            assert!(total > 0.0, "fixture total must be positive");
+            // Emit (id, normalized-bits) in a deterministic (id-sorted) order so
+            // the comparison itself is order-independent.
+            let mut out: Vec<(u64, u64)> = results
+                .iter()
+                .map(|(id, w)| (*id, (*w / total).to_bits()))
+                .collect();
+            out.sort_unstable_by_key(|(id, _)| *id);
+            out
+        };
+
+        let baseline = normalize(&input);
+        for _ in 0..1000 {
+            assert_eq!(
+                normalize(&input),
+                baseline,
+                "normalized seed scores must be bit-for-bit identical across calls"
+            );
+        }
+    }
+
+    // T-742-04c: documents WHY the fix is needed — a permuted (HashMap-order) sum
+    // can drift, while the fixed Vec-order sum stays stable. If this fixture ever
+    // produces an identical HashMap sum on this platform the test still passes
+    // (the assertion is only on the Vec-order stability), but it pins the intent.
+    #[test]
+    fn test_permuted_order_can_drift_but_fixed_vec_is_stable() {
+        let input = fixed_seed_inputs();
+        let vec_total = seed_total_vec_order(&input);
+
+        // Vec-order sum is stable regardless of how many times we recompute.
+        for _ in 0..100 {
+            assert_eq!(seed_total_vec_order(&input).to_bits(), vec_total.to_bits());
+        }
+
+        // The HashMap-order sum equals the Vec sum in value, but is summed in a
+        // non-deterministic order — it must not be relied upon for bit stability.
+        // We only assert it is numerically close (within float noise), proving
+        // the value-set is identical and the fix is behaviour-preserving.
+        let map_total = seed_total_hashmap_order(&input);
+        assert!(
+            (map_total - vec_total).abs() <= 1e-9,
+            "HashMap-order and Vec-order sums must agree within 1e-9 (same value-set)"
+        );
     }
 }

--- a/crates/unimatrix-server/src/uds/listener/tests/stamp_read.rs
+++ b/crates/unimatrix-server/src/uds/listener/tests/stamp_read.rs
@@ -72,6 +72,12 @@ async fn query_attribution(
         .collect()
 }
 
+/// Stability interval for the quiescence check layered on top of the #4884 settle.
+/// MUST be >= the 100ms settle width (per #742 Item 3 / design review): two reads
+/// this far apart that observe the same count establish quiescence, so a late
+/// trailing row cannot slip between them undetected.
+const STABLE_INTERVAL_MS: u64 = 100;
+
 /// Deadline-poll for a fire-and-forget spawn_blocking write to land, then return the
 /// session's attribution rows. Modeled on the canonical loop in `tests/transcript.rs`
 /// (5s deadline + 100ms settle): polls `query_attribution` every ~10ms until it reaches
@@ -80,6 +86,14 @@ async fn query_attribution(
 /// `#[tokio::test]` reactor alive so the in-flight `block_on` INSERT completes before
 /// teardown (the "being shutdown" race). Positive-assertion only — never poll for an
 /// absence.
+///
+/// #742 Item 3 HARDENING (held the line per human directive — kept the #4884-verified
+/// settle, did NOT swap to pure quiescence): AFTER the `>= expected` poll + 100ms
+/// settle, ADD a quiescence gate — re-read and require the count be STABLE across two
+/// reads `STABLE_INTERVAL_MS` (>= one settle width) apart before returning. A trailing
+/// delta/enrich row that lands just after the settle (the residual `--workspace`
+/// flake) breaks stability and forces another settle+re-check, rather than being
+/// returned and breaking the caller's exact-count assertion. Bounded by the 5s deadline.
 async fn await_attribution(
     store: &Store,
     session_id: &str,
@@ -98,9 +112,25 @@ async fn await_attribution(
         );
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
-    // Settle so a trailing row would still fail an exact-count assertion.
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    query_attribution(store, session_id).await
+
+    // Settle so a trailing row would still fail an exact-count assertion (#4884),
+    // THEN require quiescence: the count must be unchanged across two reads a
+    // settle-width apart before we trust it (#742 Item 3).
+    loop {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let first = query_attribution(store, session_id).await;
+        tokio::time::sleep(std::time::Duration::from_millis(STABLE_INTERVAL_MS)).await;
+        let second = query_attribution(store, session_id).await;
+        if first.len() == second.len() {
+            return second;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "attribution row count for {session_id} never stabilized (saw {} then {})",
+            first.len(),
+            second.len()
+        );
+    }
 }
 
 // Boilerplate dispatch wrapper to keep the per-test arrange blocks short.

--- a/product/test/infra-002/README.md
+++ b/product/test/infra-002/README.md
@@ -13,7 +13,7 @@ with a hard ceiling, writing to a file instead of a live pipe:
 # CARGO_TEST_TIMEOUT_SECS: hard ceiling so an interrupted run cannot orphan cargo children.
 # `setsid -w` is REQUIRED: without -w, setsid returns its own fork status (0) instead of
 # the inner command's exit code, producing false-green gates (GH#709). rc=124 = killed at ceiling.
-setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc
+log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 ```
 
 Follow-up defect (GH#709): the first hardened form shipped `setsid` **without** `-w`.

--- a/product/test/infra-002/check-cargo-test-convention.sh
+++ b/product/test/infra-002/check-cargo-test-convention.sh
@@ -9,11 +9,11 @@
 # holding target/.cargo-lock and test .db handles -> later runs hang/false-fail.
 #
 # The hardened form runs in its own session/process group with a hard ceiling and
-# writes to a file instead of a live pipe. `setsid -w` is mandatory:
+# writes to an mktemp file instead of a live pipe. `setsid -w` is mandatory:
 #
-#   setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace \
-#     > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; \
-#     rm -f /tmp/uni-test.$$.log; exit $rc
+#   log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout \
+#     "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; \
+#     rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc
 #
 # Second defect (GH#709): bare `setsid` (no -w) forks and returns the *fork's*
 # status (always 0), so `rc=$?` reads 0 even when cargo test FAILS or is killed at
@@ -54,10 +54,22 @@ SCAN_DIR="${REPO_ROOT}/.claude"
 
 # CLASS 1: cargo test as head of a pipe (`|`, not `||`) on the same line,
 # without setsid.
+#
+# --exclude-dir=worktrees: `grep -r` does NOT honor `.gitignore`. The active dev
+# worktree lives at the gitignored path `.claude/worktrees/<branch>/` and is a full
+# nested repo copy whose infra-002 test DATA contains literal `cargo test | tail`
+# strings — recursing into it produces a FALSE failure on an otherwise-clean tree.
+# Excluding the worktrees dir keeps the default scan correct when a worktree is active.
+#
+# The exemption is anchored: `grep -vE 'setsid[^;|&]*cargo test'` drops a line ONLY
+# when `setsid` governs THAT `cargo test` in the SAME separator-free segment (no
+# intervening `;`, `|`, or `&`). A blanket `grep -v 'setsid'` was a false-negative:
+# a line mentioning `setsid` for one command AND a separate bare `cargo test | tail`
+# was silently dropped (GH#742 item 6).
 scan_bare_pipe() {
   local target_dir="$1"
-  grep -rnE 'cargo test([^|]|\|\|)*\|([^|]|$)' "${target_dir}" 2>/dev/null \
-    | grep -v 'setsid' \
+  grep -rnE --exclude-dir=worktrees 'cargo test([^|]|\|\|)*\|([^|]|$)' "${target_dir}" 2>/dev/null \
+    | grep -vE 'setsid[^;|&]*cargo test' \
     | grep -v 'cargo test \.\.\.'
 }
 
@@ -67,7 +79,10 @@ scan_bare_pipe() {
 # `cargo test ...` is excluded as in CLASS 1.
 scan_setsid_no_w() {
   local target_dir="$1"
-  grep -rnE 'setsid[[:space:]]+([^[:space:]-]|-[^w])[^|]*cargo test' "${target_dir}" 2>/dev/null \
+  # --exclude-dir=worktrees: see scan_bare_pipe — `grep -r` ignores `.gitignore`; an
+  # active worktree at `.claude/worktrees/<branch>/` is a nested repo copy that would
+  # otherwise be scanned and could false-fail on its test fixtures.
+  grep -rnE --exclude-dir=worktrees 'setsid[[:space:]]+([^[:space:]-]|-[^w])[^|]*cargo test' "${target_dir}" 2>/dev/null \
     | grep -v 'cargo test \.\.\.'
 }
 
@@ -96,7 +111,7 @@ check() {
   fi
   if [ "${rc}" -ne 0 ]; then
     echo "Use the hardened convention from .claude/rules/rust-workspace.md:" >&2
-    echo "  setsid -w timeout \"\${CARGO_TEST_TIMEOUT_SECS:-600}\" cargo test --workspace > /tmp/uni-test.\$\$.log 2>&1; rc=\$?; tail -30 /tmp/uni-test.\$\$.log; rm -f /tmp/uni-test.\$\$.log; exit \$rc" >&2
+    echo "  log=\"\$(mktemp -t uni-test.XXXXXX.log)\"; setsid -w timeout \"\${CARGO_TEST_TIMEOUT_SECS:-600}\" cargo test --workspace > \"\$log\" 2>&1; rc=\$?; tail -30 \"\$log\"; rm -f \"\$log\"; exit \$rc" >&2
     return 1
   fi
   echo "OK: no bare 'cargo test' pipes and no setsid-without-w under ${SCAN_DIR} (#122 + GH#709 convention intact)."
@@ -109,16 +124,20 @@ check() {
 #   (a) bare-pipe form (no setsid)            -> MUST be flagged (CLASS 1, #122)
 #   (b) setsid WITHOUT -w                     -> MUST be flagged (CLASS 2, GH#709)
 #   (c) setsid -w hardened form               -> MUST pass
+#   (d) setsid substring elsewhere + a SEPARATE bare `cargo test | tail`
+#       -> MUST be flagged (CLASS 1 false-negative, GH#742 item 6)
 self_test() {
-  local tmp bad nowait good
+  local tmp bad nowait good setsid_substr
   tmp="$(mktemp -d)"
   trap 'rm -rf "${tmp}"' RETURN
   bad="${tmp}/bad.md"
   nowait="${tmp}/nowait.md"
   good="${tmp}/good.md"
+  setsid_substr="${tmp}/setsid_substr_bare_pipe.md"
   printf 'cargo test --workspace 2>&1 | tail -30\n' > "${bad}"
-  printf 'setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc\n' > "${nowait}"
-  printf 'setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > /tmp/uni-test.$$.log 2>&1; rc=$?; tail -30 /tmp/uni-test.$$.log; rm -f /tmp/uni-test.$$.log; exit $rc\n' > "${good}"
+  printf 'log="$(mktemp -t uni-test.XXXXXX.log)"; setsid timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc\n' > "${nowait}"
+  printf 'log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc\n' > "${good}"
+  printf 'setsid -w echo hi; cargo test --workspace 2>&1 | tail -30\n' > "${setsid_substr}"
 
   # (a) bare-pipe form must be flagged.
   if ! scan "${tmp}" | grep -q 'bad.md'; then
@@ -135,7 +154,13 @@ self_test() {
     echo "SELF-TEST FAIL: guard wrongly flagged the hardened 'setsid -w' form." >&2
     return 2
   fi
-  echo "SELF-TEST OK: flags bare-pipe + setsid-without-w forms, passes 'setsid -w' hardened form."
+  # (d) setsid mentioned elsewhere + a SEPARATE bare `cargo test | tail` must be
+  #     flagged — the anchored exemption must NOT drop it (GH#742 item 6 false-negative).
+  if ! scan "${tmp}" | grep -q 'setsid_substr_bare_pipe.md'; then
+    echo "SELF-TEST FAIL: guard did NOT flag a bare 'cargo test | tail' that merely mentions setsid elsewhere (CLASS 1 false-negative, GH#742 item 6)." >&2
+    return 2
+  fi
+  echo "SELF-TEST OK: flags bare-pipe + setsid-without-w + setsid-substring-bare-pipe forms, passes 'setsid -w' hardened form."
   return 0
 }
 


### PR DESCRIPTION
Consolidates and fixes the open test-integrity / flaky-test cluster (#738, #710, #705, #712 → consolidated into #742, all closed into it).

## What this fixes

**De-flake `unimatrix-server` lib races** (passed in isolation, failed only under full-parallel runs):
- **Item 1 — `http::token` concurrent creation (production race):** the loser of the `O_CREAT|O_EXCL` election read the token file while the winner wrote 64 hex bytes in place (`found 0`). Now the winner writes to a 0600 sibling temp file then `fs::rename`s atomically; the loser's load path has a bounded read-retry. Only the winner writes, so both racers converge on the same token. New `test_concurrent_creation_forced_interleave_converges`. — 25/25
- **Item 2 — `http::listener` semaphore recovery (tests):** deadline-poll for eventual recovery instead of fixed sleeps. — 25/25
- **Item 3 — `uds::listener::stamp_read` (tests):** keep the verified settle, add quiescence-on-top. — 45/45
- **Item 4 / cond.4 — `eval` bit-for-bit (production micro-nondeterminism):** `services/search.rs` summed `total` over HashMap iteration order (non-associative f64 → ~1e-9 drift). Now sums over the source `results_with_scores` Vec in a single pass + `ppr_only_candidates` id tie-break; `test_ac14` reframed to a single materialization. Bit-for-bit assertion preserved verbatim. — 285/285

**Harden the cargo-test process** (follow-ups to #122 Tier A / knowledge #4874):
- **Item 5 (F1):** replace predictable `/tmp/uni-test.$$.log` with `mktemp` across all 11 byte-identical convention copies (preserves `setsid -w` / single-statement / `exit $rc`).
- **Item 6 (F2):** tighten `check-cargo-test-convention.sh` CLASS-1 exemption from substring `setsid` to anchored `setsid[^;|&]*cargo test` (closes a verified false-negative); add a self-test fixture; add `--exclude-dir=worktrees` so `grep -r` doesn't false-fail on a gitignored active worktree.
- **Item 7 (Tier C):** document per-crate `cargo test -p {crate} --lib` as the routine default, reserving hardened `--workspace` for pre-PR.

## Verification
Server lib **4014/0**; other crates green; no new clippy warnings; no `unsafe`; convention scanner + `--self-test` both exit 0; integration smoke **23/0**. Gate: Bugfix Validation **PASS** (6/6).

## Deferred (tracked, not in this PR)
- **#746** — `test_ac14` **cond.1** ~2% non-vacuity flake. Distinct root cause (HNSW approximate-retrieval membership flip, eval-harness layer), gated on an eval-semantics design decision. Was never in the original reports (those were cond.4); surfaced only at n≥285. A prototype final-sort id tie-break was deliberately dropped (fixed no observed flake, silently altered AC-04/FR-08/NFR-03 semantics) — that question is carried in #746.
- **#747** — #712 **Tier B** server-side subagent pgid reaping (needs its own design pass).

Closes #742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
