### PR TITLE
fix(http): wire rmcp allowed_hosts from UNIMATRIX_PUBLIC_URL (#774)

### DIFF
--- a/crates/unimatrix-server/src/http/public_url.rs
+++ b/crates/unimatrix-server/src/http/public_url.rs
@@ -24,8 +24,9 @@ const PUBLIC_URL_VAR: &str = "UNIMATRIX_PUBLIC_URL";
 /// (FR-A5b pairing) before distributing the bundle.
 const PLACEHOLDER: &str = "https://<EDIT-ME>:8443";
 
-/// Sentinel host emitted when the knob is unset. Triggers permissive-with-warning
-/// `allowed_hosts` posture downstream; never appended to the SAN list.
+/// Sentinel host emitted when the knob is unset. Yields a localhost-restrictive
+/// `allowed_hosts` posture downstream (only the local SANs gate-pass; no public
+/// host is admitted) plus a startup WARN; never appended to the SAN list.
 const PLACEHOLDER_HOST: &str = "<EDIT-ME>";
 
 /// Local SANs always present regardless of the public URL (loopback + wildcard
@@ -120,7 +121,8 @@ pub fn derive_public_url(env: &Env) -> PublicUrl {
 fn placeholder() -> PublicUrl {
     tracing::warn!(
         "UNIMATRIX_PUBLIC_URL unset — emitting placeholder base-url ({PLACEHOLDER}) and \
-         permissive-with-warning allowed_hosts. Set it before distributing the bundle."
+         localhost-restrictive allowed_hosts (no public host admitted). Set it before \
+         distributing the bundle."
     );
     PublicUrl {
         base_url: PLACEHOLDER.to_string(),
@@ -310,9 +312,9 @@ mod tests {
     }
 
     #[test]
-    fn test_unset_public_url_allowed_hosts_permissive_with_warning() {
-        // Permissive-with-warning posture is signalled by the sentinel host;
-        // the real host is NOT appended to the SAN list.
+    fn test_unset_public_url_allowed_hosts_localhost_restrictive() {
+        // Localhost-restrictive posture: the sentinel host is NOT appended to the
+        // SAN list, so allowed_hosts carries only the local SANs (no public host).
         let pu = derive(None);
         assert_eq!(pu.host, "<EDIT-ME>");
         assert_eq!(

--- a/crates/unimatrix-server/src/http/router.rs
+++ b/crates/unimatrix-server/src/http/router.rs
@@ -320,13 +320,27 @@ impl McpAdapter {
     /// Create a new McpAdapter wrapping a `StreamableHttpService`.
     ///
     /// `allowed_origins` configures Origin header validation (ADR-002).
-    /// Empty vec = no origin restriction (backward-compatible default).
-    /// `allowed_hosts` is NOT modified — rmcp defaults it to localhost,
-    /// which is the CVE-2026-42559 fix.
-    fn new(server: UnimatrixServer, max_body_bytes: usize, allowed_origins: Vec<String>) -> Self {
+    /// `allowed_hosts` configures Host header validation (rmcp CVE-2026-42559),
+    /// wired from `PublicUrl.sans` (bug #774 — was previously left at rmcp's
+    /// localhost-only default, 403ing every non-localhost public host).
+    ///
+    /// OPPOSITE EMPTY-SEMANTICS — read before touching either field:
+    /// - empty `allowed_origins` = NO origin restriction (safe default, vnc-023).
+    /// - empty `allowed_hosts`   = ALLOW-ALL (FAIL-OPEN, defeats CVE-2026-42559).
+    ///
+    /// Callers MUST pass a NON-EMPTY `allowed_hosts` (`PublicUrl.sans` is
+    /// structurally non-empty — ≥3 local SANs even when the public URL is unset).
+    /// The wiring site guards this with a `debug_assert!`.
+    fn new(
+        server: UnimatrixServer,
+        max_body_bytes: usize,
+        allowed_origins: Vec<String>,
+        allowed_hosts: Vec<String>,
+    ) -> Self {
         let session_manager = Arc::new(LocalSessionManager::default());
         let mut config = StreamableHttpServerConfig::default();
         config.allowed_origins = allowed_origins;
+        config.allowed_hosts = allowed_hosts;
 
         // Capture the adapter's store BEFORE `server` is moved into the rmcp
         // closure (vnc-034 Wave 2 — resolve/dispatch agreement, OQ-PR-4).

--- a/crates/unimatrix-server/src/http/router/project_resolver.rs
+++ b/crates/unimatrix-server/src/http/router/project_resolver.rs
@@ -76,13 +76,17 @@ impl ProjectEntry {
     /// `McpAdapter::wraps_store` checks this in the funnel's `debug_assert!`
     /// (OQ-PR-4). Passing a mismatched handle would trip that assertion in debug
     /// builds.
+    /// `allowed_hosts` (bug #774) is wired verbatim into rmcp's Host-header gate.
+    /// It MUST be non-empty — an empty vec makes rmcp allow ALL hosts (fail-open,
+    /// defeats CVE-2026-42559). Source it from `PublicUrl.sans` (always non-empty).
     pub(crate) fn from_server(
         store: Arc<Store>,
         server: UnimatrixServer,
         max_body_bytes: usize,
         allowed_origins: Vec<String>,
+        allowed_hosts: Vec<String>,
     ) -> Self {
-        let adapter = McpAdapter::new(server, max_body_bytes, allowed_origins);
+        let adapter = McpAdapter::new(server, max_body_bytes, allowed_origins, allowed_hosts);
         ProjectEntry { store, adapter }
     }
 }
@@ -153,10 +157,15 @@ impl MultiProjectRouter {
     /// Duplicate slugs are already rejected at config-validate
     /// (`validate_projects_config`); this is a defensive re-check that fails loud
     /// rather than panicking. No `.unwrap()`.
+    ///
+    /// `allowed_hosts` (bug #774) is wired into every per-slug adapter's rmcp
+    /// Host-header gate. It MUST be non-empty (empty = rmcp allow-all fail-open).
+    /// Source it from `PublicUrl.sans` (structurally non-empty).
     pub fn from_servers(
         slug_servers: Vec<ProjectServerInput>,
         max_body_bytes: usize,
         allowed_origins: Vec<String>,
+        allowed_hosts: Vec<String>,
     ) -> Result<Self, String> {
         let mut slugs = HashMap::with_capacity(slug_servers.len());
         for input in slug_servers {
@@ -168,6 +177,7 @@ impl MultiProjectRouter {
                 input.server,
                 max_body_bytes,
                 allowed_origins.clone(),
+                allowed_hosts.clone(),
             );
             slugs.insert(input.slug, entry);
         }

--- a/crates/unimatrix-server/src/http/router/project_resolver/tests.rs
+++ b/crates/unimatrix-server/src/http/router/project_resolver/tests.rs
@@ -50,6 +50,13 @@ fn slug_key(s: &str) -> ProjectKey {
 
 const TEST_MAX_BODY: usize = 1024 * 1024;
 
+/// Non-empty `allowed_hosts` for fixtures (bug #774). NEVER pass `Vec::new()`:
+/// rmcp treats an empty `allowed_hosts` as allow-all (fail-open), so baking an
+/// empty vec into fixtures would encode the fail-open shape.
+fn test_allowed_hosts() -> Vec<String> {
+    vec!["localhost".to_string()]
+}
+
 // ===========================================================================
 // §A. Per-slug resolution to the slug's OWN store (R-07 sc.1)
 // ===========================================================================
@@ -63,7 +70,7 @@ async fn test_resolves_slug_to_its_store() {
     let (beta_input, beta_store) = make_slug_input("beta").await;
 
     let resolver =
-        MultiProjectRouter::from_servers(vec![alpha_input, beta_input], TEST_MAX_BODY, vec![])
+        MultiProjectRouter::from_servers(vec![alpha_input, beta_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
             .expect("build resolver");
 
     let resolved_alpha = resolver
@@ -99,7 +106,7 @@ async fn test_resolve_unregistered_slug_unknown_project() {
     // leak (vnc-038 ADR-004).
     let (alpha_input, _alpha_store) = make_slug_input("alpha").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![alpha_input], TEST_MAX_BODY, vec![])
+    let resolver = MultiProjectRouter::from_servers(vec![alpha_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
         .expect("build resolver");
 
     let err = resolver
@@ -121,7 +128,7 @@ async fn test_single_deployment_is_n1() {
     // special-case branch. N=1 is one map entry, not a distinct default path.
     let (only_input, only_store) = make_slug_input("only").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![only_input], TEST_MAX_BODY, vec![])
+    let resolver = MultiProjectRouter::from_servers(vec![only_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
         .expect("build resolver");
 
     let resolved = resolver
@@ -144,7 +151,7 @@ async fn test_single_deployment_is_n1() {
 async fn test_empty_resolver_no_servable_store() {
     // [[projects]] absent -> empty slug map -> NOTHING servable. Every slug is
     // UnknownProject; there is no default store (R-10 at the resolver layer).
-    let resolver = MultiProjectRouter::from_servers(vec![], TEST_MAX_BODY, vec![])
+    let resolver = MultiProjectRouter::from_servers(vec![], TEST_MAX_BODY, vec![], test_allowed_hosts())
         .expect("build empty resolver");
 
     assert_eq!(
@@ -166,7 +173,7 @@ async fn test_swaps_at_slugrouter_callsite() {
     // resolver at the SlugRouter::new call site, no route-grammar / layer change.
     let (alpha_input, _alpha_store) = make_slug_input("alpha").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![alpha_input], TEST_MAX_BODY, vec![])
+    let resolver = MultiProjectRouter::from_servers(vec![alpha_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
         .expect("build resolver");
 
     let as_seam: Arc<dyn StoreResolver> = Arc::new(resolver);
@@ -188,7 +195,7 @@ async fn test_two_slugs_route_to_distinct_stores() {
     let (a_input, a_store) = make_slug_input("a").await;
     let (b_input, b_store) = make_slug_input("b").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![a_input, b_input], TEST_MAX_BODY, vec![])
+    let resolver = MultiProjectRouter::from_servers(vec![a_input, b_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
         .expect("build resolver");
 
     let resolved_a = resolver.resolve_store(&slug_key("a")).expect("a resolves");
@@ -215,7 +222,7 @@ async fn test_resolve_dispatch_same_map() {
     let (a_input, a_store) = make_slug_input("a").await;
     let (b_input, b_store) = make_slug_input("b").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![a_input, b_input], TEST_MAX_BODY, vec![])
+    let resolver = MultiProjectRouter::from_servers(vec![a_input, b_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
         .expect("build resolver");
 
     let assert_agreement = |key: &ProjectKey, expected: &Arc<Store>| {
@@ -253,7 +260,7 @@ async fn test_prefix_related_slugs_no_misresolution() {
     let (project_input, project_store) = make_slug_input("project").await;
 
     let resolver =
-        MultiProjectRouter::from_servers(vec![proj_input, project_input], TEST_MAX_BODY, vec![])
+        MultiProjectRouter::from_servers(vec![proj_input, project_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
             .expect("build resolver");
 
     let resolved_proj = resolver
@@ -286,7 +293,7 @@ async fn test_n_clients_one_slug_share_store() {
     // (Arc::ptr_eq) — N clients on one slug share state. No store re-open per call.
     let (alpha_input, alpha_store) = make_slug_input("alpha").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![alpha_input], TEST_MAX_BODY, vec![])
+    let resolver = MultiProjectRouter::from_servers(vec![alpha_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
         .expect("build resolver");
 
     let client_a = resolver
@@ -316,7 +323,7 @@ async fn test_from_servers_rejects_duplicate_slug() {
     let (dup_a, _a) = make_slug_input("dup").await;
     let (dup_b, _b) = make_slug_input("dup").await;
 
-    let result = MultiProjectRouter::from_servers(vec![dup_a, dup_b], TEST_MAX_BODY, vec![]);
+    let result = MultiProjectRouter::from_servers(vec![dup_a, dup_b], TEST_MAX_BODY, vec![], test_allowed_hosts());
     let err = result.expect_err("duplicate slug must fail loud");
     assert!(
         err.contains("duplicate"),

--- a/crates/unimatrix-server/src/http/router/tests.rs
+++ b/crates/unimatrix-server/src/http/router/tests.rs
@@ -1123,6 +1123,130 @@ fn test_streamable_config_default_allowed_origins_empty() {
 }
 
 // ===========================================================================
+// bug #774: allowed_hosts wired from PublicUrl.sans through the constructor
+// chain (McpAdapter::new). The host gate is rmcp's per-request
+// validate_dns_rebinding_headers → 403 "Forbidden: Host header is not allowed"
+// for any Host not in allowed_hosts. Before the fix, allowed_hosts stayed at
+// rmcp's localhost-only default, so the configured public host 403'd.
+// ===========================================================================
+
+/// Build a minimal MCP POST carrying the given `Host` header. Host validation
+/// runs FIRST in rmcp's service (before method/body), so the Host gate verdict
+/// is observable regardless of body correctness.
+fn mcp_post_with_host(host: &str) -> Request<TestBody> {
+    Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Host", host)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(empty_body())
+        .expect("build request")
+}
+
+const HOST_FORBIDDEN_BODY: &str = "Host header is not allowed";
+
+// T-774-1: a non-localhost public host wired through the adapter is NOT 403'd
+// on the Host gate, while an unrelated Host IS. This is the regression that
+// escaped vnc-034 (the configured public host was rejected before auth/MCP).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_adapter_allows_configured_public_host_rejects_others() {
+    // Simulate PublicUrl.sans for UNIMATRIX_PUBLIC_URL=https://unimatrix:8443:
+    // port-less bare hosts (local SANs + the configured public host).
+    let allowed_hosts = vec![
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "0.0.0.0".to_string(),
+        "unimatrix".to_string(),
+    ];
+    let server = make_server().await;
+    let mut adapter = McpAdapter::new(server, 1024 * 1024, Vec::new(), allowed_hosts);
+
+    // The configured public host (with the deployed port) must clear the gate.
+    // It is NOT the host-forbidden 403 — later MCP processing may reject for
+    // other reasons, but never with the host-gate message.
+    let (allowed_status, allowed_body) = collect_body(
+        adapter
+            .handle(mcp_post_with_host("unimatrix:8443"))
+            .await
+            .expect("infallible"),
+    )
+    .await;
+    assert!(
+        !(allowed_status == StatusCode::FORBIDDEN && allowed_body.contains(HOST_FORBIDDEN_BODY)),
+        "configured public host must pass the rmcp Host gate (bug #774); got {allowed_status} / {allowed_body}"
+    );
+
+    // An unrelated Host must still be rejected by the gate (403 + message).
+    let (denied_status, denied_body) = collect_body(
+        adapter
+            .handle(mcp_post_with_host("evil.example.com"))
+            .await
+            .expect("infallible"),
+    )
+    .await;
+    assert_eq!(
+        denied_status,
+        StatusCode::FORBIDDEN,
+        "an unrelated Host must be 403'd by the rmcp gate; got body {denied_body}"
+    );
+    assert!(
+        denied_body.contains(HOST_FORBIDDEN_BODY),
+        "the 403 must be the Host-gate rejection; got {denied_body}"
+    );
+}
+
+// T-774-2: fail-open guard — an UNSET PublicUrl still yields a non-empty
+// allowed_hosts (localhost-only). An empty vec would make rmcp allow ALL hosts
+// (the opposite of allowed_origins). The placeholder path must stay restrictive.
+#[test]
+fn test_unset_public_url_yields_non_empty_allowed_hosts() {
+    let getter = |_: &str| None; // UNIMATRIX_PUBLIC_URL unset
+    let public_url = crate::http::public_url::derive_public_url(
+        &crate::http::public_url::Env::new(&getter),
+    );
+    let allowed_hosts = public_url.sans.clone();
+
+    assert!(
+        !allowed_hosts.is_empty(),
+        "unset PublicUrl must NOT yield empty allowed_hosts — rmcp treats empty as allow-all (fail-open)"
+    );
+    assert!(
+        allowed_hosts.contains(&"localhost".to_string()),
+        "unset PublicUrl allowed_hosts must stay localhost-restrictive (CVE-2026-42559 posture)"
+    );
+    // The real public host is deliberately omitted when the knob is unset.
+    assert!(
+        !allowed_hosts.iter().any(|h| h.contains("placeholder")),
+        "the placeholder sentinel must never leak into allowed_hosts as a real host"
+    );
+}
+
+// T-774-3: documents the rmcp semantic the fix relies on — a port-less allowlist
+// entry matches an incoming Host that carries a port. PublicUrl.sans is port-less
+// (bare hosts), so "unimatrix" must accept "unimatrix:8443". Driven through the
+// real adapter because rmcp's host_is_allowed is not a public API.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_portless_allowed_host_matches_host_with_port() {
+    // Only a port-less host entry; the local SANs are irrelevant to this case.
+    let allowed_hosts = vec!["unimatrix".to_string()];
+    let server = make_server().await;
+    let mut adapter = McpAdapter::new(server, 1024 * 1024, Vec::new(), allowed_hosts);
+
+    let (status, body) = collect_body(
+        adapter
+            .handle(mcp_post_with_host("unimatrix:8443"))
+            .await
+            .expect("infallible"),
+    )
+    .await;
+    assert!(
+        !(status == StatusCode::FORBIDDEN && body.contains(HOST_FORBIDDEN_BODY)),
+        "a port-less allowlist entry must match a Host carrying a port (rmcp semantic the fix relies on); got {status} / {body}"
+    );
+}
+
+// ===========================================================================
 // vnc-024: /observe content negotiation (AC-07 / AC-08 / AC-09)
 //
 // Unit-level mapper tests. `observe_response_to_http(resp, wants_text)` must
@@ -2563,6 +2687,8 @@ async fn test_observe_per_slug_funnel_isolation_n2() {
         vec![alpha_input, beta_input],
         OBSERVE_MAX_BODY,
         vec![],
+        // bug #774: non-empty allowed_hosts (empty = rmcp fail-open).
+        vec!["localhost".to_string()],
     )
     .expect("build resolver");
 
@@ -2613,9 +2739,13 @@ async fn test_observe_unregistered_slug_is_loud_404_not_default() {
         store: Arc::clone(&only.store),
         server: only,
     };
-    let inner =
-        MultiProjectRouter::from_servers(vec![only_input], OBSERVE_MAX_BODY, vec![])
-            .expect("build resolver");
+    let inner = MultiProjectRouter::from_servers(
+        vec![only_input],
+        OBSERVE_MAX_BODY,
+        vec![],
+        vec!["localhost".to_string()],
+    )
+    .expect("build resolver");
     let (recording, resolved) = RecordingResolver::new(inner);
     let resolver: Arc<dyn StoreResolver> = Arc::new(recording);
     let ctx = observe_ctx_over(resolver, &deps);
@@ -2643,8 +2773,13 @@ async fn test_observe_empty_resolver_first_boot_is_loud_404() {
     // observe is a loud 404 — nothing servable, never a silent default (R-10 /
     // AC-09 at the observe entry point).
     let deps = make_server().await;
-    let inner = MultiProjectRouter::from_servers(vec![], OBSERVE_MAX_BODY, vec![])
-        .expect("build empty resolver");
+    let inner = MultiProjectRouter::from_servers(
+        vec![],
+        OBSERVE_MAX_BODY,
+        vec![],
+        vec!["localhost".to_string()],
+    )
+    .expect("build empty resolver");
     let resolver: Arc<dyn StoreResolver> = Arc::new(inner);
     let ctx = observe_ctx_over(resolver, &deps);
 

--- a/crates/unimatrix-server/src/main.rs
+++ b/crates/unimatrix-server/src/main.rs
@@ -1008,6 +1008,18 @@ async fn tokio_main_daemon(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         //    local UDS/STDIO direct binding (ADR-006); they are not orphaned.
         let max_body = config.http.max_request_body_bytes;
         let allowed_origins = config.http.allowed_origins.clone();
+        // bug #774: wire the rmcp Host-header allowlist from PublicUrl.sans (the
+        // third R-09 consumer vnc-034 documented but never wired). `.sans` carries
+        // the configured public host + ≥3 local SANs, port-less (rmcp treats a
+        // port-less entry as matching any port). FAIL-OPEN GUARD: an EMPTY vec makes
+        // rmcp allow ALL hosts (opposite of allowed_origins), defeating
+        // CVE-2026-42559. `.sans` is structurally non-empty; assert it so a future
+        // refactor can't silently fail open.
+        let allowed_hosts = public_url.sans.clone();
+        debug_assert!(
+            !allowed_hosts.is_empty(),
+            "allowed_hosts must be non-empty: rmcp treats empty as allow-all"
+        );
 
         let resolver: Arc<dyn StoreResolver> = if project_slugs.is_empty() {
             // AC-09 / R-10: loud, actionable, NOTHING servable. The empty-slug-map
@@ -1017,9 +1029,13 @@ async fn tokio_main_daemon(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 "no projects registered — nothing is servable. \
                  Run `unimatrix register <slug>` then restart to begin."
             );
-            let router =
-                MultiProjectRouter::from_servers(Vec::new(), max_body, allowed_origins.clone())
-                    .map_err(ServerError::Config)?;
+            let router = MultiProjectRouter::from_servers(
+                Vec::new(),
+                max_body,
+                allowed_origins.clone(),
+                allowed_hosts.clone(),
+            )
+            .map_err(ServerError::Config)?;
             Arc::new(router)
         } else {
             // Multi-project: build a per-slug `UnimatrixServer` for each validated
@@ -1039,9 +1055,13 @@ async fn tokio_main_daemon(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                 .await?;
                 slug_servers.push(input);
             }
-            let router =
-                MultiProjectRouter::from_servers(slug_servers, max_body, allowed_origins.clone())
-                    .map_err(ServerError::Config)?;
+            let router = MultiProjectRouter::from_servers(
+                slug_servers,
+                max_body,
+                allowed_origins.clone(),
+                allowed_hosts.clone(),
+            )
+            .map_err(ServerError::Config)?;
             tracing::info!(
                 slug_count = project_slugs.len(),
                 "project routing active ([[projects]] declared)"

--- a/crates/unimatrix-server/tests/project_routing_integration.rs
+++ b/crates/unimatrix-server/tests/project_routing_integration.rs
@@ -163,8 +163,14 @@ async fn wired_router(slugs: &[&str]) -> (SlugRouter, Vec<Arc<Store>>) {
         });
     }
 
-    let resolver = MultiProjectRouter::from_servers(inputs, TEST_MAX_BODY, Vec::new())
-        .expect("build MultiProjectRouter");
+    // bug #774: allowed_hosts must be NON-EMPTY (empty = rmcp allow-all fail-open).
+    let resolver = MultiProjectRouter::from_servers(
+        inputs,
+        TEST_MAX_BODY,
+        Vec::new(),
+        vec!["localhost".to_string()],
+    )
+    .expect("build MultiProjectRouter");
 
     let resolver: Arc<dyn StoreResolver> = Arc::new(resolver);
     let router = SlugRouter::new(resolver);


### PR DESCRIPTION
## Summary
Wires rmcp's Streamable-HTTP `allowed_hosts` host-allowlist from `UNIMATRIX_PUBLIC_URL`, fixing `403 Forbidden: Host header is not allowed` for remote clients connecting over direct container HTTPS by their configured public hostname.

Fixes #774.

## Root cause
`McpAdapter::new` set `config.allowed_origins` but left `config.allowed_hosts` at rmcp's localhost-only default. `PublicUrl.sans` — which already contains the configured public host plus the local SANs — was available at the wiring site but dropped, because the constructor chain (`from_servers` → `from_server` → `McpAdapter::new`) only threaded `allowed_origins`. This left the R-09 "single derivation, three consumers" invariant satisfied for only 2 of 3 consumers (cert SAN ✅, bundle base_url ✅, allowed_hosts ❌).

## Fix
- Thread `allowed_hosts: Vec<String>` (= `public_url.sans`) alongside `allowed_origins` through the constructor chain, mirroring the vnc-023/ADR-002 additive-param pattern; set `config.allowed_hosts` in `McpAdapter::new`.
- Add `debug_assert!(!allowed_hosts.is_empty())` at the `main.rs` wiring site — rmcp treats an empty `allowed_hosts` as allow-all (fail-open), and `allowed_hosts`/`allowed_origins` share constructor params with opposite empty-semantics, so the guard prevents a future refactor silently failing open.
- Rewrite the now-stale `router.rs` comment to document the wiring and the empty=fail-open hazard.

`.sans` is structurally non-empty (≥3 local SANs even when `UNIMATRIX_PUBLIC_URL` is unset), so the unset case stays localhost-only and the CVE-2026-42559 posture is preserved. Single-host contract, consistent with cert SAN + bundle base_url.

## Tests
- `test_adapter_allows_configured_public_host_rejects_others` — host-gate regression: configured public host clears the gate, unrelated host 403s.
- `test_unset_public_url_yields_non_empty_allowed_hosts` — fail-open guard: unset still yields a restrictive localhost-only allowlist.
- `test_portless_allowed_host_matches_host_with_port` — rmcp port-less-matches-any-port semantic.

## Validation
- Workspace: 6422 passed / 0 failed. Integration smoke: 24/24. Bug-relevant suites: 207 passed / 1 pre-existing xfail (GH#405).
- `unimatrix-server` clippy clean. (Pre-existing workspace clippy debt in `unimatrix-observe`/`unimatrix-engine` is tracked by GH#756/#688 and untouched here.)
- Bugfix gate: PASS (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
