### PR TITLE
fix(personal-cloud): release gate pulls prebuilt IMAGE in smoke; gate npm/binary builds off dispatch (#795)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   build-linux-x64:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -110,6 +111,7 @@ jobs:
           retention-days: 1
 
   build-linux-arm64:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -202,6 +204,7 @@ jobs:
 
   package-npm:
     needs: [build-linux-x64, build-linux-arm64]
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/product/test/infra-001/scripts/docker-http-posture-smoke.sh
+++ b/product/test/infra-001/scripts/docker-http-posture-smoke.sh
@@ -19,6 +19,8 @@
 #
 # Requires Docker. Exits 3 (with a clear SKIP reason) when Docker is
 # unavailable so CI flags it as a deferred step rather than false-green.
+# In IMAGE= mode, exits 4 when the prebuilt tag can neither be pulled nor found
+# locally (tag not pushed / network unhealthy) — distinct from fail()'s exit 1.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
@@ -59,8 +61,21 @@ if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
 fi
 
 # -- Build (or reuse) the production image ---------------------------------
+# Precondition for the IMAGE= mode: the caller must set/activate IMAGE; in that
+# mode this script PULLS the tag (or falls back to a present local image) rather
+# than building — the first docker op below is `inspect`, which never pulls, so a
+# cross-runner cache miss would otherwise false-fail the gate (#795).
 if [ -n "${IMAGE:-}" ]; then
   log "using prebuilt image: $IMAGE"
+  # Pull-preferring with local fallback: on a fresh hosted runner this really
+  # pulls the pushed bytes (ADR-002); on a dev box with a locally-built tag (not
+  # in any registry) it falls back to the present image; only when genuinely
+  # unavailable do we exit 4 (distinct from fail()'s exit 1). The `|| ... || {}`
+  # chain is intentionally not routed through fail() and must run all arms before
+  # set -e/pipefail trips.
+  docker pull "$IMAGE" \
+    || docker image inspect "$IMAGE" >/dev/null 2>&1 \
+    || { printf '[783-smoke] FAIL: could not pull %s (confirm the tag was pushed and network is healthy)\n' "$IMAGE" >&2; exit 4; }
 else
   IMAGE="unimatrix:783-smoke"
   log "building image $IMAGE from $REPO_ROOT/Dockerfile (this is slow) ..."

--- a/product/test/infra-001/scripts/release-gate-lib.sh
+++ b/product/test/infra-001/scripts/release-gate-lib.sh
@@ -8,6 +8,7 @@
 #
 # Contracts (VERBATIM — IMPLEMENTATION-BRIEF Data Structures / ADR-003 / ADR-002 / ADR-004):
 #   smoke exit contract : 0 = ran+passed · 1 = ran+failed (fail()) · 3 = self-skipped (Docker absent)
+#                         · 4 = IMAGE= prebuilt tag could not be pulled / not present locally (#795)
 #   positive run-marker : terminal line  [783-smoke] ALL GATES PASSED  (printed only after all gates)
 #   tag resolution      : push    -> TAG="${GITHUB_REF_NAME}"  (UN-stripped, keeps the v) => :v<version>-<arch>
 #                         dispatch -> TAG="latest"                                          => :latest-<arch>
@@ -49,6 +50,7 @@ run_smoke_gate() {
   case "${rc}" in
     0) : ;;
     3) echo "::error::smoke SKIPPED (exit 3): Docker-capable lane mis-provisioned — HARD failure (SR-01)."; return 1 ;;
+    4) echo "::error::smoke FAILED (exit 4): could not pull prebuilt IMAGE — confirm the tag was pushed / network healthy (#795)."; return 1 ;;
     1) echo "::error::smoke FAILED (exit 1): shipped image first-run path is broken."; return 1 ;;
     *) echo "::error::smoke exited unexpectedly (exit ${rc})."; return 1 ;;
   esac

--- a/product/test/infra-001/scripts/release-gate-logic-test.sh
+++ b/product/test/infra-001/scripts/release-gate-logic-test.sh
@@ -15,6 +15,7 @@
 #   exit 0 + marker absent (early-exit-0) -> RED  "exited 0 but never printed ALL GATES PASSED"
 #   exit 1                               -> RED  "first-run path is broken"
 #   exit 3                               -> RED  "mis-provisioned ... HARD failure"
+#   exit 4                               -> RED  "could not pull prebuilt IMAGE" (#795)
 #   exit 2 / 139 (unexpected)            -> RED  "exited unexpectedly (exit N)"
 #   marker as a mid-line substring only  -> RED  (anchored grep must not be spoofed — R-03)
 
@@ -83,6 +84,13 @@ run_case test_gate_fail_exit1_no_marker \
 run_case test_gate_skip_exit3_hard_fail \
   3 "SKIP: Docker not available" stdout \
   1 "mis-provisioned"
+
+# Row: (4, could-not-pull) — prebuilt IMAGE unavailable is a distinct HARD failure (#795).
+# Must NOT be mapped to the exit-1 "first-run path is broken" diagnosis (the false
+# diagnosis this bug removed), and is now a KNOWN code — no longer caught by the *) arm.
+run_case test_gate_pull_failed_exit4 \
+  4 "[783-smoke] FAIL: could not pull ghcr.io/x/unimatrix:latest-amd64" stdout \
+  1 "could not pull prebuilt IMAGE"
 
 # Row: (0, no marker) — early-exit-0.
 run_case test_gate_early_exit0_marker_absent \


### PR DESCRIPTION
## Summary

Fixes #795 — the nan-019 release gate blocked **every** `v*` release because the `smoke-amd64`/`smoke-arm64` jobs never `docker pull`ed the resolved image on their fresh runner.

**Root cause:** smoke jobs run on a runner separate from `build-container-*`. They set `IMAGE=ghcr.io/.../:latest-<arch>`, so `docker-http-posture-smoke.sh` takes its prebuilt branch and skips the build — but the first docker op was `docker image inspect` (no implicit pull) → `No such image` → false "image first-run path is broken." Caught by the nan-019 `workflow_dispatch` dry-run ([run 27834008646](https://github.com/dug-21/unimatrix/actions/runs/27834008646)) — the post-merge round-trip the design budgeted (#4796 / AC-07).

## Changes

- **F1 — conditional pull (not unconditional).** `docker-http-posture-smoke.sh` IMAGE= branch now does `docker pull "$IMAGE" || docker image inspect "$IMAGE" || exit 4` **before** inspect. On an ephemeral hosted runner this always really pulls (preserves ADR-002 "test the pushed bytes"); on a dev box with a locally-built tag it falls back to the present local image; only a genuinely unavailable image hits the dedicated **exit 4**. The local-build path is untouched.
- **F1 (lib) — dedicated exit-4 arm** in `run_smoke_gate` (`release-gate-lib.sh`) with a distinct `could not pull` diagnostic, so a never-pushed tag / network failure stays a real, *distinguishable* release defect rather than being masked as "first-run broken."
- **F1 (test) — exit-4 truth-table row** + `test_gate_pull_failed_exit4` in `release-gate-logic-test.sh` (stub-driven, no Docker) — the plumbing regression guard.
- **F2/F3 — dispatch noise gating.** `if: github.event_name != 'workflow_dispatch'` on `package-npm`, `build-linux-x64`, `build-linux-arm64`; `create-release` skips via `needs: package-npm`. A dispatch dry-run now reduces cleanly to `build-container-*` → `smoke-*`.

## Testing

- `release-gate-logic-test.sh` 14/14 · `release-tag-parity-test.sh` 13/13 · `bash -n` clean
- Integration smoke 24/24 · no Rust regression (change touches no Rust)
- **Deferred acceptance gate:** the genuine fresh-runner remote-pull proof is the post-PR `workflow_dispatch` dry-run — expect `smoke-amd64`/`smoke-arm64` green (first true both-arch hosted proof, AC-07; watch arm64 cold-boot vs the 90s deadline), `create-container-manifest` + `package-npm`/`create-release`/`build-linux-*` skipped → overall green.

Diagnosis, design review, product review, and gate report are on #795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
