### PR TITLE
[chore] cargo fmt baseline (#797)

### DIFF
--- a/crates/unimatrix-server/src/http/router/project_resolver/tests.rs
+++ b/crates/unimatrix-server/src/http/router/project_resolver/tests.rs
@@ -69,9 +69,13 @@ async fn test_resolves_slug_to_its_store() {
     let (alpha_input, alpha_store) = make_slug_input("alpha").await;
     let (beta_input, beta_store) = make_slug_input("beta").await;
 
-    let resolver =
-        MultiProjectRouter::from_servers(vec![alpha_input, beta_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
-            .expect("build resolver");
+    let resolver = MultiProjectRouter::from_servers(
+        vec![alpha_input, beta_input],
+        TEST_MAX_BODY,
+        vec![],
+        test_allowed_hosts(),
+    )
+    .expect("build resolver");
 
     let resolved_alpha = resolver
         .resolve_store(&slug_key("alpha"))
@@ -106,8 +110,13 @@ async fn test_resolve_unregistered_slug_unknown_project() {
     // leak (vnc-038 ADR-004).
     let (alpha_input, _alpha_store) = make_slug_input("alpha").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![alpha_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
-        .expect("build resolver");
+    let resolver = MultiProjectRouter::from_servers(
+        vec![alpha_input],
+        TEST_MAX_BODY,
+        vec![],
+        test_allowed_hosts(),
+    )
+    .expect("build resolver");
 
     let err = resolver
         .resolve_store(&slug_key("ghost"))
@@ -128,8 +137,13 @@ async fn test_single_deployment_is_n1() {
     // special-case branch. N=1 is one map entry, not a distinct default path.
     let (only_input, only_store) = make_slug_input("only").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![only_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
-        .expect("build resolver");
+    let resolver = MultiProjectRouter::from_servers(
+        vec![only_input],
+        TEST_MAX_BODY,
+        vec![],
+        test_allowed_hosts(),
+    )
+    .expect("build resolver");
 
     let resolved = resolver
         .resolve_store(&slug_key("only"))
@@ -151,8 +165,9 @@ async fn test_single_deployment_is_n1() {
 async fn test_empty_resolver_no_servable_store() {
     // [[projects]] absent -> empty slug map -> NOTHING servable. Every slug is
     // UnknownProject; there is no default store (R-10 at the resolver layer).
-    let resolver = MultiProjectRouter::from_servers(vec![], TEST_MAX_BODY, vec![], test_allowed_hosts())
-        .expect("build empty resolver");
+    let resolver =
+        MultiProjectRouter::from_servers(vec![], TEST_MAX_BODY, vec![], test_allowed_hosts())
+            .expect("build empty resolver");
 
     assert_eq!(
         resolver
@@ -173,8 +188,13 @@ async fn test_swaps_at_slugrouter_callsite() {
     // resolver at the SlugRouter::new call site, no route-grammar / layer change.
     let (alpha_input, _alpha_store) = make_slug_input("alpha").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![alpha_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
-        .expect("build resolver");
+    let resolver = MultiProjectRouter::from_servers(
+        vec![alpha_input],
+        TEST_MAX_BODY,
+        vec![],
+        test_allowed_hosts(),
+    )
+    .expect("build resolver");
 
     let as_seam: Arc<dyn StoreResolver> = Arc::new(resolver);
     assert!(
@@ -195,8 +215,13 @@ async fn test_two_slugs_route_to_distinct_stores() {
     let (a_input, a_store) = make_slug_input("a").await;
     let (b_input, b_store) = make_slug_input("b").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![a_input, b_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
-        .expect("build resolver");
+    let resolver = MultiProjectRouter::from_servers(
+        vec![a_input, b_input],
+        TEST_MAX_BODY,
+        vec![],
+        test_allowed_hosts(),
+    )
+    .expect("build resolver");
 
     let resolved_a = resolver.resolve_store(&slug_key("a")).expect("a resolves");
     let resolved_b = resolver.resolve_store(&slug_key("b")).expect("b resolves");
@@ -222,8 +247,13 @@ async fn test_resolve_dispatch_same_map() {
     let (a_input, a_store) = make_slug_input("a").await;
     let (b_input, b_store) = make_slug_input("b").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![a_input, b_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
-        .expect("build resolver");
+    let resolver = MultiProjectRouter::from_servers(
+        vec![a_input, b_input],
+        TEST_MAX_BODY,
+        vec![],
+        test_allowed_hosts(),
+    )
+    .expect("build resolver");
 
     let assert_agreement = |key: &ProjectKey, expected: &Arc<Store>| {
         let resolved = resolver.resolve_store(key).expect("resolves");
@@ -259,9 +289,13 @@ async fn test_prefix_related_slugs_no_misresolution() {
     let (proj_input, proj_store) = make_slug_input("proj").await;
     let (project_input, project_store) = make_slug_input("project").await;
 
-    let resolver =
-        MultiProjectRouter::from_servers(vec![proj_input, project_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
-            .expect("build resolver");
+    let resolver = MultiProjectRouter::from_servers(
+        vec![proj_input, project_input],
+        TEST_MAX_BODY,
+        vec![],
+        test_allowed_hosts(),
+    )
+    .expect("build resolver");
 
     let resolved_proj = resolver
         .resolve_store(&slug_key("proj"))
@@ -293,8 +327,13 @@ async fn test_n_clients_one_slug_share_store() {
     // (Arc::ptr_eq) — N clients on one slug share state. No store re-open per call.
     let (alpha_input, alpha_store) = make_slug_input("alpha").await;
 
-    let resolver = MultiProjectRouter::from_servers(vec![alpha_input], TEST_MAX_BODY, vec![], test_allowed_hosts())
-        .expect("build resolver");
+    let resolver = MultiProjectRouter::from_servers(
+        vec![alpha_input],
+        TEST_MAX_BODY,
+        vec![],
+        test_allowed_hosts(),
+    )
+    .expect("build resolver");
 
     let client_a = resolver
         .resolve_store(&slug_key("alpha"))
@@ -323,7 +362,12 @@ async fn test_from_servers_rejects_duplicate_slug() {
     let (dup_a, _a) = make_slug_input("dup").await;
     let (dup_b, _b) = make_slug_input("dup").await;
 
-    let result = MultiProjectRouter::from_servers(vec![dup_a, dup_b], TEST_MAX_BODY, vec![], test_allowed_hosts());
+    let result = MultiProjectRouter::from_servers(
+        vec![dup_a, dup_b],
+        TEST_MAX_BODY,
+        vec![],
+        test_allowed_hosts(),
+    );
     let err = result.expect_err("duplicate slug must fail loud");
     assert!(
         err.contains("duplicate"),

--- a/crates/unimatrix-server/src/infra/slug_config_classification_tests.rs
+++ b/crates/unimatrix-server/src/infra/slug_config_classification_tests.rs
@@ -28,8 +28,8 @@
 //! for `tls`/`http`/`rayon_pool_size` would be a false claim about `merge_configs`.
 
 use super::{
-    is_per_slug_overlayable, merge_configs, ConfidenceWeights, DomainPackConfig, KnowledgeConfig,
-    OverlayDisposition, UnimatrixConfig, PER_SLUG_CONFIG_CLASSIFICATION,
+    ConfidenceWeights, DomainPackConfig, KnowledgeConfig, OverlayDisposition,
+    PER_SLUG_CONFIG_CLASSIFICATION, UnimatrixConfig, is_per_slug_overlayable, merge_configs,
 };
 
 /// GlobalLocked keys whose lock is enforced BY CONSTRUCTION in `per_slug_loop`, NOT by

--- a/crates/unimatrix-server/tests/project_routing_integration.rs
+++ b/crates/unimatrix-server/tests/project_routing_integration.rs
@@ -70,6 +70,8 @@ use unimatrix_server::server::UnimatrixServer;
 use unimatrix_store::{NewEntry, PoolConfig, Status};
 
 // crt-056 Wave 2 behavioral imports — the per-slug tick work-unit seam (ADR-003/004/005).
+use unimatrix_engine::confidence::ConfidenceParams;
+use unimatrix_observe::domain::DomainPackRegistry;
 use unimatrix_server::background::{
     BackgroundJob, Cadence, PerSlugTickContext, ResourceClass, SharedTickResources,
     build_job_registry, run_per_slug_tick_pass,
@@ -79,8 +81,6 @@ use unimatrix_server::infra::nli_handle::NliServiceHandle;
 use unimatrix_server::infra::rayon_pool::RayonPool;
 use unimatrix_server::infra::usage_dedup::UsageDedup;
 use unimatrix_server::services::{FusionWeights, ServiceLayer};
-use unimatrix_engine::confidence::ConfidenceParams;
-use unimatrix_observe::domain::DomainPackRegistry;
 
 const TEST_MAX_BODY: usize = 1024 * 1024;
 
@@ -676,7 +676,12 @@ async fn test_two_slugs_interleaved_no_cross_contamination() {
     let (router, slug_stores) = wired_router(&["alpha", "beta"]).await;
     let (alpha_store, beta_store) = (&slug_stores[0], &slug_stores[1]);
 
-    for path in ["/v1/alpha/mcp", "/v1/beta/mcp", "/v1/alpha/mcp", "/v1/beta/mcp"] {
+    for path in [
+        "/v1/alpha/mcp",
+        "/v1/beta/mcp",
+        "/v1/alpha/mcp",
+        "/v1/beta/mcp",
+    ] {
         assert!(reached_mcp(&drive(&router, path).await), "dispatch {path}");
     }
     // The deleted Default alias is loud-404, interleaved in: it must not dispatch
@@ -695,8 +700,16 @@ async fn test_two_slugs_interleaved_no_cross_contamination() {
         .await
         .expect("beta write");
 
-    assert_eq!(entry_count(alpha_store).await, 1, "alpha holds only its write");
-    assert_eq!(entry_count(beta_store).await, 1, "beta holds only its write");
+    assert_eq!(
+        entry_count(alpha_store).await,
+        1,
+        "alpha holds only its write"
+    );
+    assert_eq!(
+        entry_count(beta_store).await,
+        1,
+        "beta holds only its write"
+    );
     assert!(
         alpha_store.get(2).await.is_err() && beta_store.get(2).await.is_err(),
         "neither store accumulated the other's write"
@@ -778,12 +791,13 @@ impl TickTestHarness {
         // ONE shared rayon pool. RayonPool::new installs `.panic_handler(|_| {})`
         // (#2543) — this is the AC-harness obligation: a panicking job is contained,
         // never SIGABRTs the test process.
-        let rayon_pool =
-            Arc::new(RayonPool::new(1, "crt056-itest-tick").expect("rayon pool with panic_handler"));
+        let rayon_pool = Arc::new(
+            RayonPool::new(1, "crt056-itest-tick").expect("rayon pool with panic_handler"),
+        );
 
         let shared = SharedTickResources {
             embed_service: EmbedServiceHandle::new(), // unloaded — model-free tick
-            nli_handle: NliServiceHandle::new(),       // ONE handle, shared read-only
+            nli_handle: NliServiceHandle::new(),      // ONE handle, shared read-only
             inference_config: Arc::new(InferenceConfig::default()),
             confidence_params: Arc::new(ConfidenceParams::default()),
             rayon_pool,
@@ -919,7 +933,11 @@ async fn test_panicking_job_caught_no_sigabrt() {
     )
     .await;
     // Survived the panic without SIGABRT — the loop continues and we get here.
-    assert_eq!(harness.slugs.len(), 1, "harness survived a contained job panic");
+    assert_eq!(
+        harness.slugs.len(),
+        1,
+        "harness survived a contained job panic"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -932,7 +950,10 @@ async fn test_tick_maintains_slug_a_analytics() {
     let harness = TickTestHarness::new(&["alpha"]).await;
     let before = snapshot_handles(&harness.slugs[0].ctx);
     // Cold start: typed-graph is the empty fallback default.
-    assert_eq!(before.typed_graph_entry_count, 0, "cold-start typed graph empty");
+    assert_eq!(
+        before.typed_graph_entry_count, 0,
+        "cold-start typed graph empty"
+    );
     assert!(before.typed_graph_use_fallback, "cold-start uses fallback");
 
     // Write 5 entries, then run ONE tick over A.
@@ -955,7 +976,10 @@ async fn test_tick_maintains_slug_a_analytics() {
         "effectiveness generation must not regress"
     );
     // The analytics state CHANGED to reflect the write — not merely "handle exists".
-    assert_ne!(before, after, "A's analytics must change after a tick over its write");
+    assert_ne!(
+        before, after,
+        "A's analytics must change after a tick over its write"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1059,10 +1083,22 @@ async fn test_handle_identity_tick_ctx_eq_service_layer_n2() {
 
     // A's context handles are A's ServiceLayer's SAME Arcs (serving == tick instance).
     assert!(Arc::ptr_eq(&a.ctx.typed_graph, &sl_a.typed_graph_handle()));
-    assert!(Arc::ptr_eq(&a.ctx.effectiveness, &sl_a.effectiveness_state_handle()));
-    assert!(Arc::ptr_eq(&a.ctx.confidence, &sl_a.confidence_state_handle()));
-    assert!(Arc::ptr_eq(&a.ctx.contradiction, &sl_a.contradiction_cache_handle()));
-    assert!(Arc::ptr_eq(&a.ctx.phase_freq, &sl_a.phase_freq_table_handle()));
+    assert!(Arc::ptr_eq(
+        &a.ctx.effectiveness,
+        &sl_a.effectiveness_state_handle()
+    ));
+    assert!(Arc::ptr_eq(
+        &a.ctx.confidence,
+        &sl_a.confidence_state_handle()
+    ));
+    assert!(Arc::ptr_eq(
+        &a.ctx.contradiction,
+        &sl_a.contradiction_cache_handle()
+    ));
+    assert!(Arc::ptr_eq(
+        &a.ctx.phase_freq,
+        &sl_a.phase_freq_table_handle()
+    ));
 
     // Cross-slug: A's handles are NOT B's (no shared global singleton — the
     // pre-crt-056 defect). This is the structural complement of AC-4.
@@ -1113,9 +1149,18 @@ async fn test_serving_accessor_reflects_tick_unaffected_by_b() {
         .all_entries
         .len();
 
-    assert_eq!(a_serving, 6, "A's serving read reflects A's post-tick state (6)");
-    assert_eq!(b_serving, 2, "B's serving read reflects B's post-tick state (2)");
-    assert_ne!(a_serving, b_serving, "A and B serving reads are independent");
+    assert_eq!(
+        a_serving, 6,
+        "A's serving read reflects A's post-tick state (6)"
+    );
+    assert_eq!(
+        b_serving, 2,
+        "B's serving read reflects B's post-tick state (2)"
+    );
+    assert_ne!(
+        a_serving, b_serving,
+        "A and B serving reads are independent"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -1129,7 +1174,10 @@ async fn test_adapt_service_no_cross_slug_bleed() {
     // Each slug owns a DISTINCT AdaptationService instance (per-slug independent
     // state). A's adaptation can never reach into B's.
     assert!(
-        !Arc::ptr_eq(&harness.slugs[0].ctx.adapt_service, &harness.slugs[1].ctx.adapt_service),
+        !Arc::ptr_eq(
+            &harness.slugs[0].ctx.adapt_service,
+            &harness.slugs[1].ctx.adapt_service
+        ),
         "each slug must own a distinct adapt_service (no cross-slug bleed, R-11)"
     );
     // And each context's adapt_service is its OWN server's.
@@ -1179,7 +1227,10 @@ async fn test_per_slug_counter_advances_independently_n2() {
         .map(|m| m.tick_counter)
         .unwrap_or(0);
     assert_eq!(a_counter, 4, "A ticked 4 times -> counter at 4");
-    assert_eq!(b_counter, 1, "B ticked once -> counter at 1 (independent of A)");
+    assert_eq!(
+        b_counter, 1,
+        "B ticked once -> counter at 1 (independent of A)"
+    );
 }
 
 // ###########################################################################


### PR DESCRIPTION
## Summary
Brings the workspace to a clean `cargo fmt --check` state. Formatting only — no behavioral changes.

3 files reformatted (all in `unimatrix-server`):
- `src/http/router/project_resolver/tests.rs`
- `src/infra/slug_config_classification_tests.rs`
- `tests/project_routing_integration.rs`

## Validation
- `cargo fmt --all --check` — clean
- `cargo test -p unimatrix-server` — 21 passed, 0 failed (all touched files are tests)

## Notes
Paired with #798 (clippy baseline + guard); land this first to avoid diff collisions.

Closes #797.

🤖 Generated with [Claude Code](https://claude.com/claude-code)