### PR TITLE
fix: capture init --bundle stderr in release smoke Gate 6 (#812)

### DIFF
--- a/product/test/infra-001/scripts/docker-http-posture-smoke.sh
+++ b/product/test/infra-001/scripts/docker-http-posture-smoke.sh
@@ -80,15 +80,24 @@ emit_bundle() {
 }
 
 # consume_bundle <blob> -> rc only (hermetic; HOME on the CHILD, never in-process).
+# #812: the init child's stderr+stdout are NO LONGER discarded — they are captured
+# to $SANDBOX/init.out (reaped by the cleanup() trap, hermetic). The file is the
+# diagnostic surface the caller tail-dumps ON FAILURE ONLY (Gate 6 was undiagnosable
+# by construction while this went to /dev/null). Safe to capture: init's stderr on a
+# Ping failure is a connect/URL/fingerprint string and NEVER the token (NFR-06; the
+# bearer is flushed to the request body only after the pin verifies, never to a
+# stream). This captures ONLY the init child — emit_bundle's blob-bearing stderr
+# (L78) stays dropped. Redirect to a FILE, never a pipe, so set -e/pipefail and the
+# rc capture (#4873 class) are unaffected.
 consume_bundle() {
   local blob="$1"
   if [ -n "${SMOKE_INIT_CMD:-}" ]; then
     # shellcheck disable=SC2086
-    HOME="$SANDBOX/home" $SMOKE_INIT_CMD "$blob" "$SANDBOX/proj" >/dev/null 2>&1
+    HOME="$SANDBOX/home" $SMOKE_INIT_CMD "$blob" "$SANDBOX/proj" >"$SANDBOX/init.out" 2>&1
   else
     HOME="$SANDBOX/home" \
       node "$REPO_ROOT/packages/unimatrix/bin/unimatrix.js" \
-        init --bundle "$blob" --project-dir "$SANDBOX/proj" >/dev/null 2>&1
+        init --bundle "$blob" --project-dir "$SANDBOX/proj" >"$SANDBOX/init.out" 2>&1
   fi
 }
 
@@ -179,8 +188,22 @@ bundle_attach_gates() {
   consume_bundle "$BUNDLE"
   init_rc=$?
   set -e
-  [ "$init_rc" -eq 0 ] \
-    || fail "init --bundle failed (rc=$init_rc) — bundle attach broken"
+  if [ "$init_rc" -ne 0 ]; then
+    # #812: surface the init child's captured streams (was /dev/null — undiagnosable
+    # by construction). FAILURE PATH ONLY (happy path stays quiet, no stdout pollution).
+    # Tail-bounded to cap CI-log volume. The dump is init's stream only — never the
+    # blob (emit_bundle's token-bearing stderr is dropped at L78), so no token leak.
+    log "---- init --bundle stderr/stdout (tail, on failure) ----"
+    if [ -s "$SANDBOX/init.out" ]; then
+      tail -n 50 "$SANDBOX/init.out" | while IFS= read -r line; do
+        log "init: $line"
+      done
+    else
+      log "init: (no output captured)"
+    fi
+    log "---- end init --bundle output ----"
+    fail "init --bundle failed (rc=$init_rc) — bundle attach broken"
+  fi
   log "init --bundle attached against the booted image (hermetic HOME). PASS gate 6"
 
   # ---- GATE 7: fire one hook event through the wired client; assert observe + store grow ----


### PR DESCRIPTION
## Summary
Release smoke **Gate 6** (`product/test/infra-001/scripts/docker-http-posture-smoke.sh`) failed on arm64 with `init --bundle` rc=1, but `consume_bundle()` routed the child's stderr to `/dev/null` — the failure was **undiagnosable by construction**. This is **Step 1 (diagnostic capture) only**.

## Change
- `consume_bundle()`: capture the `init --bundle` child's stderr+stdout to `$SANDBOX/init.out` (was `>/dev/null 2>&1`) — a file under the hermetic sandbox reaped by the existing `cleanup()` trap; redirect to a file (not a pipe) so `rc` capture and `set -e`/`pipefail` are unaffected. Both real-node and `SMOKE_INIT_CMD` stub branches capture identically.
- Gate 6: on `init_rc != 0`, dump a tail-bounded (last 50 lines) excerpt to the smoke log under the `[783-smoke] init:` prefix, then the existing `fail()` (exit 1). Exit semantics unchanged.
- `emit_bundle`'s token-bearing stderr (L78) left **untouched** — no token can reach the logs.

## Why Step 1 alone
The client `init --bundle` path reproduced clean (rc=0) on Node 24 — the bug is environmental to the CI arm64 published-port topology. The real corrective (Step 2) is **conditional** on the mechanism the captured stderr reveals on the next tagged run:
- connect/timeout via dual-stack `localhost`→`::1` + dropped v6 SYN + Happy-Eyeballs > 750ms → **a same-host operator hits the identical failure**. Open product question: do we support client-and-server-same-box `localhost` attach? If yes, the durable fix is **client-side loopback address-family handling** (hot-path-safe), not a harness IPv4-pin and **not** a `connectMs`/`syncMs` widen (those fire fail-open on every production hook event).
- fp-mismatch / bad-Pong → real client/server defect at the cert-pin/transport site.

See #812 human-checkpoint comment for the full decision tree.

## Validation
- Stub-seam dual-branch (failure dump surfaced under `[783-smoke] init:` rc=1; success quiet, no dump) — PASS
- Integration smoke suite 24/24 PASS; gate-logic stub-driver 19/19 PASS
- shellcheck: new lines clean (3 findings proven pre-existing); `bash -n` OK
- Gate 3 Bugfix Validation: **PASS** (9/9)
- Token-leak check: capture scoped to init child only, dumped on failure only — PASS

## Notes
- #812 alone does **not** unblock v0.8.3 — the x64 anndists `simdeez_f` compile break (via #798) is a separate failure that must also land before a clean re-tag.
- Pre-existing static-gate failure `test_no_new_smoke_script` (caused by #810, not this change) filed as #815.
- Prevention follow-up: real-server `init --bundle` delivery-gate round-trip filed as #814.

## GH Issue
Refs #812