### PR TITLE
fix(release): make npm publish steps idempotent on re-run (#821)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,17 +263,53 @@ jobs:
             fi
           done
 
+      # INVARIANT: every publish/push step in this workflow MUST be safe to
+      # re-run on an already-completed version. Re-running the same tag is the
+      # standard release-recovery path (see #812, #818) — a non-idempotent step
+      # breaks recovery and cascades (e.g. skips create-release via `needs:`).
+      # npm versions are immutable, so each publish below is guarded: gate on
+      # NON-EMPTY `npm view` stdout, never exit code — `npm view pkg@ver version`
+      # exits 0 with empty stdout when the version is missing but the package
+      # name exists, and only exits non-zero (E404) when the name was never
+      # published; gating on $? would silently skip a new package's first publish.
       - name: Publish @dug-21/unimatrix-linux-arm64
         working-directory: packages/unimatrix-linux-arm64
-        run: npm publish --access public --provenance
+        run: |
+          set -euo pipefail
+          PKG=$(node -p "require('./package.json').name")
+          VER=$(node -p "require('./package.json').version")
+          if [ -n "$(npm view "${PKG}@${VER}" version 2>/dev/null)" ]; then
+            echo "skip: ${PKG}@${VER} already published"
+          else
+            echo "publish: ${PKG}@${VER}"
+            npm publish --access public --provenance
+          fi
 
       - name: Publish @dug-21/unimatrix-linux-x64
         working-directory: packages/unimatrix-linux-x64
-        run: npm publish --access public --provenance
+        run: |
+          set -euo pipefail
+          PKG=$(node -p "require('./package.json').name")
+          VER=$(node -p "require('./package.json').version")
+          if [ -n "$(npm view "${PKG}@${VER}" version 2>/dev/null)" ]; then
+            echo "skip: ${PKG}@${VER} already published"
+          else
+            echo "publish: ${PKG}@${VER}"
+            npm publish --access public --provenance
+          fi
 
       - name: Publish @dug-21/unimatrix
         working-directory: packages/unimatrix
-        run: npm publish --access public --provenance
+        run: |
+          set -euo pipefail
+          PKG=$(node -p "require('./package.json').name")
+          VER=$(node -p "require('./package.json').version")
+          if [ -n "$(npm view "${PKG}@${VER}" version 2>/dev/null)" ]; then
+            echo "skip: ${PKG}@${VER} already published"
+          else
+            echo "publish: ${PKG}@${VER}"
+            npm publish --access public --provenance
+          fi
 
   create-release:
     needs: package-npm
@@ -319,6 +355,10 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # INVARIANT: re-run-safe. softprops/action-gh-release@v2 updates an
+      # existing release rather than erroring, so re-running the same tag is OK.
+      # Do not switch to `gh release create` (errors if the release exists)
+      # without adding a view-or-create / --clobber guard.
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
Fixes #821.

## Problem
The last v0.8.3 Release run failed at `package-npm` → Publish `@dug-21/unimatrix-linux-arm64`:
```
npm error You cannot publish over the previously published versions: 0.8.3.
```
All three `@dug-21` packages were already published at 0.8.3 (they succeeded in an earlier run). The smoke-gate fixes (#812, #818) re-ran the whole Release workflow on the unchanged `v0.8.3` tag, but the publish steps ran `npm publish` unconditionally. npm versions are immutable, so every re-run after the first success died at the first publish — and `create-release` (`needs: package-npm`) was skipped, so no GitHub Release was cut.

## Fix
Guard each of the three publish steps: derive name+version from the package's own `package.json`, query the registry, and publish (`--access public --provenance`) only when the version is absent.

**Load-bearing detail:** gate on **non-empty `npm view` stdout**, never exit code. `npm view pkg@ver version` exits 0 with empty stdout when the version is missing but the package name exists, and only E404s when the name was never published — gating on `$?` would silently skip a new package's first publish.

`create-release` verified re-run-safe (`softprops/action-gh-release@v2` updates an existing release); added invariant comments documenting the workflow-wide rule.

## Scope & verification
- `.github/workflows/release.yml` only (+43/-3). No Rust/JS/source changes.
- YAML parses; guard logic verified by a 3-branch shell simulation under `set -euo pipefail` (skip-on-exists / publish-on-missing-version / publish-on-E404-without-abort) plus a negative control confirming `set -e` is active.
- Bugfix Gate: PASS (7/7).

## Effect on v0.8.3
v0.8.3's npm packages are already fully published; once merged, re-running the v0.8.3 tag will skip the publishes and finally cut the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
