### PR TITLE
fix: persist per-slug HTTP vector indices on shutdown (#823)

### DIFF
--- a/crates/unimatrix-server/src/http/router/project_resolver.rs
+++ b/crates/unimatrix-server/src/http/router/project_resolver.rs
@@ -130,6 +130,14 @@ pub struct ProjectServerInput {
     pub store: Arc<Store>,
     /// The assembled per-slug MCP server.
     pub server: UnimatrixServer,
+    /// The slug's own vector dump directory (`{base_dir}/{slug}/vector`).
+    ///
+    /// Carried so the listener wiring can register this slug's `VectorIndex`
+    /// (reachable via `server.vector_index()`) for the per-slug shutdown dump
+    /// (#823). Without this, the per-slug HNSW index was an in-memory-only
+    /// dropped local that was never persisted, silently degrading semantic
+    /// search after a restart in multi-project HTTP mode.
+    pub vector_dir: std::path::PathBuf,
 }
 
 impl std::fmt::Debug for ProjectServerInput {

--- a/crates/unimatrix-server/src/http/router/project_resolver/tests.rs
+++ b/crates/unimatrix-server/src/http/router/project_resolver/tests.rs
@@ -35,10 +35,13 @@ async fn make_slug_input(slug: &str) -> (ProjectServerInput, Arc<Store>) {
     // resolved store IS this one.
     let store = Arc::clone(&server.store);
     let slug = ProjectSlug::try_from(slug).expect("valid slug");
+    // #823: inert in resolver tests (no shutdown drive); a faithful per-slug dir.
+    let vector_dir = std::path::PathBuf::from(slug.as_str()).join("vector");
     let input = ProjectServerInput {
         slug,
         store: Arc::clone(&store),
         server,
+        vector_dir,
     };
     (input, store)
 }

--- a/crates/unimatrix-server/src/http/router/tests.rs
+++ b/crates/unimatrix-server/src/http/router/tests.rs
@@ -2676,11 +2676,15 @@ async fn test_observe_per_slug_funnel_isolation_n2() {
         slug: ProjectSlug::try_from("alpha").expect("valid"),
         store: Arc::clone(&alpha.store),
         server: alpha,
+        // #823: inert here (router tests never drive shutdown); carries the
+        // per-slug dump dir only for the listener wiring path.
+        vector_dir: std::path::PathBuf::from("alpha/vector"),
     };
     let beta_input = ProjectServerInput {
         slug: ProjectSlug::try_from("beta").expect("valid"),
         store: Arc::clone(&beta.store),
         server: beta,
+        vector_dir: std::path::PathBuf::from("beta/vector"),
     };
     let inner = MultiProjectRouter::from_servers(
         vec![alpha_input, beta_input],
@@ -2737,6 +2741,8 @@ async fn test_observe_unregistered_slug_is_loud_404_not_default() {
         slug: ProjectSlug::try_from("only").expect("valid"),
         store: Arc::clone(&only.store),
         server: only,
+        // #823: inert here (router tests never drive shutdown).
+        vector_dir: std::path::PathBuf::from("only/vector"),
     };
     let inner = MultiProjectRouter::from_servers(
         vec![only_input],

--- a/crates/unimatrix-server/src/http_provision.rs
+++ b/crates/unimatrix-server/src/http_provision.rs
@@ -31,14 +31,14 @@ use unimatrix_engine::confidence::ConfidenceParams;
 use unimatrix_observe::domain::DomainPackRegistry;
 use unimatrix_server::error::ServerError;
 use unimatrix_server::http::{
-    build_tls_acceptor, derive_public_url, load_or_generate_cert, Env, ProjectServerInput,
-    ProjectSlug, PublicUrl,
+    Env, ProjectServerInput, ProjectSlug, PublicUrl, build_tls_acceptor, derive_public_url,
+    load_or_generate_cert,
 };
 use unimatrix_server::infra::audit::AuditLog;
 use unimatrix_server::infra::categories::CategoryAllowlist;
 use unimatrix_server::infra::config::{
-    is_per_slug_overlayable, load_single_config, merge_configs, validate_config, InferenceConfig,
-    TlsConfig, UnimatrixConfig,
+    InferenceConfig, TlsConfig, UnimatrixConfig, is_per_slug_overlayable, load_single_config,
+    merge_configs, validate_config,
 };
 use unimatrix_server::infra::embed_handle::EmbedServiceHandle;
 use unimatrix_server::infra::nli_handle::NliServiceHandle;
@@ -260,6 +260,9 @@ pub async fn build_project_server(
         slug: slug.clone(),
         store,
         server,
+        // #823: carry the per-slug vector dir into shutdown so this slug's HNSW
+        // index is dumped to its OWN `{slug}/vector/` (it was a dropped local).
+        vector_dir,
     })
 }
 

--- a/crates/unimatrix-server/src/infra/shutdown.rs
+++ b/crates/unimatrix-server/src/infra/shutdown.rs
@@ -12,7 +12,8 @@
 //! 3. `uds_handle`           — abort + join (hook IPC accept loop)
 //! 4. `socket_guard`         — removes `unimatrix.sock`
 //! 5. `tick_handle`          — abort + join (background tick Arc holders)
-//! 6. All `Arc<Store>` holders (services, adapt_service, registry, audit, vector_index)
+//!    5a. daemon + per-slug vector dumps (#823) — dump before the Arc drops below
+//! 6. All `Arc<Store>` holders (services, adapt_service, registry, audit, vector_index, per_slug_vectors)
 //! 7. `Arc::try_unwrap(store)` → compaction
 //!
 //! `PidGuard` is NOT in this struct; it lives in `main()` as a local and drops after
@@ -48,6 +49,15 @@ pub struct LifecycleHandles {
     pub vector_index: Arc<VectorIndex>,
     /// Directory for vector dump files.
     pub vector_dir: PathBuf,
+    /// Per-slug `(VectorIndex, dir)` pairs to dump on shutdown (#823).
+    ///
+    /// In multi-project HTTP mode each registered slug has its OWN in-memory
+    /// `VectorIndex` over `{base}/{slug}/vector`. These were never registered
+    /// for the shutdown dump, so the per-slug HNSW index was lost on restart
+    /// (semantic search silently degraded). Each pair is dumped in Step 1
+    /// (warn-and-continue per entry) BEFORE the Step 2 Arc drops. Empty in
+    /// single-project / stdio mode (the daemon pair above covers those).
+    pub per_slug_vectors: Vec<(Arc<VectorIndex>, PathBuf)>,
     /// Registry (holds Arc<Store>; must drop before try_unwrap).
     pub registry: Arc<AgentRegistry>,
     /// Audit log (holds Arc<Store>; must drop before try_unwrap).
@@ -175,6 +185,26 @@ pub async fn graceful_shutdown(mut handles: LifecycleHandles) -> Result<(), Serv
         Err(e) => tracing::warn!(error = %e, "vector dump failed, continuing shutdown"),
     }
 
+    // Step 1-slug: Dump each per-slug vector index to its OWN dir (#823).
+    // Multi-project HTTP mode only — empty in single-project / stdio.
+    // Warn-and-continue PER ENTRY (N1): one bad slug dir cannot abort the
+    // others, nor block the daemon `try_unwrap` in Step 3. Same step band as the
+    // daemon dump above (BEFORE the Step 2 Arc drops) and the same dump idiom.
+    // These Arcs hold per-slug stores (NOT the daemon `store` Step 3 unwraps), so
+    // they add no try_unwrap hazard — they drop with `handles` at function end.
+    for (index, dir) in &handles.per_slug_vectors {
+        match index.dump(dir) {
+            Ok(()) => {
+                tracing::info!(dir = %dir.display(), "per-slug vector index dumped successfully")
+            }
+            Err(e) => tracing::warn!(
+                error = %e,
+                dir = %dir.display(),
+                "per-slug vector dump failed, continuing shutdown"
+            ),
+        }
+    }
+
     // Step 1b: Save adaptation state (crt-006).
     tracing::info!("saving adaptation state");
     match handles.adapt_service.save_state(&handles.data_dir) {
@@ -192,6 +222,9 @@ pub async fn graceful_shutdown(mut handles: LifecycleHandles) -> Result<(), Serv
     drop(handles.registry);
     drop(handles.audit);
     drop(handles.vector_index);
+    // #823: release the per-slug index Arcs (they hold per-slug stores, not the
+    // daemon store, so this is independent of the Step 3 try_unwrap below).
+    handles.per_slug_vectors.clear();
 
     // Step 3: Try to unwrap Store for compaction.
     match Arc::try_unwrap(handles.store) {
@@ -349,6 +382,7 @@ mod tests {
             store,
             vector_index,
             vector_dir,
+            per_slug_vectors: Vec::new(),
             registry,
             audit,
             adapt_service,
@@ -499,6 +533,7 @@ mod tests {
             store,
             vector_index,
             vector_dir,
+            per_slug_vectors: Vec::new(),
             registry,
             audit,
             adapt_service,
@@ -582,6 +617,7 @@ mod tests {
             store,
             vector_index,
             vector_dir,
+            per_slug_vectors: Vec::new(),
             registry,
             audit,
             adapt_service,
@@ -670,6 +706,7 @@ mod tests {
             store,
             vector_index,
             vector_dir,
+            per_slug_vectors: Vec::new(),
             registry,
             audit,
             adapt_service,
@@ -721,6 +758,7 @@ mod tests {
             store,
             vector_index,
             vector_dir,
+            per_slug_vectors: Vec::new(),
             registry,
             audit,
             adapt_service,
@@ -759,5 +797,171 @@ mod tests {
             Ok(Ok(())) => {}
             Err(_timeout) => panic!("abort + join timed out unexpectedly"),
         }
+    }
+
+    // --- #823: per-slug vector dump regression ---
+
+    /// Read `point_count` out of a dumped `unimatrix-vector.meta` (`-1` if the file
+    /// is missing, so callers can distinguish "never dumped" from "dumped empty").
+    fn meta_point_count(vector_dir: &std::path::Path) -> i64 {
+        let meta_path = vector_dir.join("unimatrix-vector.meta");
+        let Ok(text) = std::fs::read_to_string(&meta_path) else {
+            return -1;
+        };
+        for line in text.lines() {
+            if let Some(v) = line.strip_prefix("point_count=") {
+                return v.trim().parse::<i64>().unwrap_or(-1);
+            }
+        }
+        -1
+    }
+
+    /// Insert one store entry + its embedding into a `VectorIndex` (mirrors the
+    /// vector crate's `seed_vectors` helper without pulling its test-support
+    /// feature). Returns the seeded entry id and the embedding used.
+    async fn seed_one_vector(
+        store: &Arc<SqlxStore>,
+        vi: &VectorIndex,
+        dim: usize,
+    ) -> (u64, Vec<f32>) {
+        use unimatrix_store::{NewEntry, Status};
+
+        let entry = NewEntry {
+            title: "slug vector entry".to_string(),
+            content: "content for the per-slug persistence round-trip".to_string(),
+            topic: "test".to_string(),
+            category: "vector".to_string(),
+            tags: vec![],
+            source: "test".to_string(),
+            status: Status::Active,
+            created_by: String::new(),
+            feature_cycle: String::new(),
+            trust_source: String::new(),
+        };
+        let entry_id = store.insert(entry).await.expect("insert store entry");
+
+        // Deterministic unit vector (one hot dimension) — normalized, valid for HNSW.
+        let mut embedding = vec![0.0f32; dim];
+        embedding[0] = 1.0;
+        vi.insert(entry_id, &embedding)
+            .await
+            .expect("insert vector");
+
+        (entry_id, embedding)
+    }
+
+    /// #823 regression: in multi-project HTTP mode the per-slug `VectorIndex` must
+    /// be dumped to its OWN `{slug}/vector/` dir on graceful shutdown, and that dump
+    /// must NOT land in the daemon's hash-rooted dir.
+    ///
+    /// Drives the REAL `graceful_shutdown` (not a simulated drop sequence) so the
+    /// Step 1 per-slug dump loop actually runs, then asserts:
+    /// 1. `{slug}/vector/unimatrix-vector.meta` exists with a non-zero point_count.
+    /// 2. The daemon hash dir did NOT gain the slug's vectors (its meta is empty).
+    /// 3. Round-trip: `VectorIndex::load` of the slug dir restores the entry and
+    ///    `search` returns it (parity with single-project behavior).
+    #[tokio::test]
+    async fn test_graceful_shutdown_dumps_per_slug_vector_index() {
+        use unimatrix_adapt::{AdaptConfig, AdaptationService};
+        use unimatrix_core::VectorConfig;
+
+        use crate::infra::audit::AuditLog;
+        use crate::infra::registry::AgentRegistry;
+
+        let base = tempfile::TempDir::new().unwrap();
+        let base_path = base.path();
+
+        // --- daemon (hash-rooted) subsystems: empty index, distinct dir ---
+        let hash_dir = base_path.join("deadbeefhash");
+        let daemon_db = hash_dir.join("unimatrix.db");
+        let daemon_vector_dir = hash_dir.join("vector");
+        std::fs::create_dir_all(&daemon_vector_dir).unwrap();
+
+        let daemon_store = open_store(&daemon_db).await;
+        let daemon_index =
+            Arc::new(VectorIndex::new(Arc::clone(&daemon_store), VectorConfig::default()).unwrap());
+        let dim = daemon_index.config().dimension;
+
+        // --- per-slug subsystems: SEEDED index, its OWN `{slug}/vector/` dir ---
+        let slug_dir = base_path.join("alpha");
+        let slug_db = slug_dir.join("unimatrix.db");
+        let slug_vector_dir = slug_dir.join("vector");
+        std::fs::create_dir_all(&slug_vector_dir).unwrap();
+
+        let slug_store = open_store(&slug_db).await;
+        let slug_index =
+            Arc::new(VectorIndex::new(Arc::clone(&slug_store), VectorConfig::default()).unwrap());
+        let (slug_entry_id, query) = seed_one_vector(&slug_store, &slug_index, dim).await;
+        assert!(slug_index.point_count() > 0, "slug index must be seeded");
+
+        // Daemon-side holders required by LifecycleHandles (mirror main.rs wiring).
+        let registry =
+            Arc::new(AgentRegistry::new(Arc::clone(&daemon_store), true, vec![]).unwrap());
+        let audit = Arc::new(AuditLog::new(Arc::clone(&daemon_store)));
+        let adapt_service = Arc::new(AdaptationService::new(AdaptConfig::default()));
+
+        // Keep a slug-store clone for the post-shutdown round-trip `load`.
+        let slug_store_for_load = Arc::clone(&slug_store);
+
+        let handles = LifecycleHandles {
+            store: daemon_store,
+            vector_index: daemon_index,
+            vector_dir: daemon_vector_dir.clone(),
+            // #823: the slug index is registered here for its OWN dir.
+            per_slug_vectors: vec![(slug_index, slug_vector_dir.clone())],
+            registry,
+            audit,
+            adapt_service,
+            data_dir: hash_dir.clone(),
+            mcp_socket_guard: None,
+            mcp_acceptor_handle: None,
+            socket_guard: None,
+            uds_handle: None,
+            tick_handle: None,
+            services: None,
+            http_acceptor_handle: None,
+            http_listener_addr: None,
+        };
+
+        // Drop our local seed handle to the slug store so `slug_store_for_load`
+        // is the only outstanding clone aside from the one inside the slug index.
+        drop(slug_store);
+
+        graceful_shutdown(handles).await.expect("graceful shutdown");
+
+        // 1. The slug's index dumped to its OWN dir with a non-zero point_count.
+        assert!(
+            slug_vector_dir.join("unimatrix-vector.meta").exists(),
+            "per-slug {{slug}}/vector/unimatrix-vector.meta must exist after shutdown (#823)"
+        );
+        assert!(
+            meta_point_count(&slug_vector_dir) > 0,
+            "per-slug vector dump must report a non-zero point_count"
+        );
+
+        // 2. The daemon hash dir did NOT gain the slug's vectors (its meta is empty).
+        assert_eq!(
+            meta_point_count(&daemon_vector_dir),
+            0,
+            "daemon hash-rooted vector dir must NOT contain the slug's vectors"
+        );
+
+        // 3. Round-trip: the slug dir loads and search returns the seeded entry.
+        let loaded = VectorIndex::load(
+            slug_store_for_load,
+            VectorConfig::default(),
+            &slug_vector_dir,
+        )
+        .await
+        .expect("load per-slug index from its dumped dir");
+        assert!(
+            loaded.point_count() > 0,
+            "loaded slug index must be non-empty"
+        );
+        let results = loaded.search(&query, 5, 32).expect("search loaded index");
+        assert!(
+            results.iter().any(|r| r.entry_id == slug_entry_id),
+            "search on the reloaded per-slug index must return the seeded entry"
+        );
     }
 }

--- a/crates/unimatrix-server/src/main.rs
+++ b/crates/unimatrix-server/src/main.rs
@@ -995,6 +995,12 @@ async fn tokio_main_daemon(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Arc::clone(&audit),
     )];
 
+    // #823: per-slug (vector_index, dir) pairs for the shutdown dump. Populated
+    // from each `ProjectServerInput` in the per-slug loop below (multi-project
+    // HTTP only). Empty otherwise — the daemon's own index dumps via the
+    // `vector_index`/`vector_dir` LifecycleHandles pair, exactly as before.
+    let mut per_slug_vectors: Vec<(Arc<VectorIndex>, std::path::PathBuf)> = Vec::new();
+
     // Create daemon CancellationToken (ADR-002).
     let daemon_token = shutdown::new_daemon_token();
 
@@ -1200,6 +1206,9 @@ async fn tokio_main_daemon(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     Arc::clone(&input.server.pending_entries_analysis),
                     input.server.audit_log(),
                 ));
+                // #823: register this slug's index for the shutdown dump to its
+                // OWN `{slug}/vector/` dir (vector_dir was a dropped local before).
+                per_slug_vectors.push((input.server.vector_index(), input.vector_dir.clone()));
             }
             let router = MultiProjectRouter::from_servers(
                 slug_servers,
@@ -1302,6 +1311,7 @@ async fn tokio_main_daemon(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         store,
         vector_index,
         vector_dir: paths.vector_dir.clone(),
+        per_slug_vectors, // #823: per-slug indices (empty unless multi-project HTTP)
         registry,
         audit,
         adapt_service,
@@ -1707,6 +1717,8 @@ async fn tokio_main_stdio(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         store,
         vector_index,
         vector_dir: paths.vector_dir.clone(),
+        // #823: stdio mode has no per-slug servers; the daemon pair above covers it.
+        per_slug_vectors: Vec::new(),
         registry,
         audit,
         adapt_service,

--- a/crates/unimatrix-server/tests/project_routing_integration.rs
+++ b/crates/unimatrix-server/tests/project_routing_integration.rs
@@ -171,10 +171,14 @@ async fn wired_router(slugs: &[&str]) -> (SlugRouter, Vec<Arc<Store>>) {
         let bundle = build_server().await;
         let slug = ProjectSlug::try_from(name).expect("valid test slug");
         slug_stores.push(Arc::clone(&bundle.store));
+        // #823: inert here (routing test never drives shutdown); a faithful
+        // per-slug dump dir for the new ProjectServerInput field.
+        let vector_dir = std::path::PathBuf::from(slug.as_str()).join("vector");
         inputs.push(ProjectServerInput {
             slug,
             store: bundle.store,
             server: bundle.input_server,
+            vector_dir,
         });
     }
 


### PR DESCRIPTION
## Summary
Fixes #823 — in multi-project HTTP mode, per-slug vector (HNSW) indices were never persisted to disk. The per-slug index was an in-memory-only dropped local; only the daemon's hash-rooted index was ever dumped. After a restart, per-slug semantic search silently degraded.

## Root cause
`build_project_server` built each per-slug `VectorIndex` over `vector_dir = {base}/{slug}/vector`, but `vector_dir` was a dropped local and `ProjectServerInput` carried only `{slug, store, server}`. The sole production dump (`shutdown.rs`) was wired to the daemon's hash-rooted index only — per-slug indices were never registered for the shutdown dump. The startup `VectorIndex::load` arm already existed but was dead (no `.meta` was ever written).

## Fix (minimal)
- Add `vector_dir: PathBuf` to `ProjectServerInput`; stop dropping it in `build_project_server`.
- Carry `per_slug_vectors: Vec<(Arc<VectorIndex>, PathBuf)>` into `LifecycleHandles` (empty in stdio / single-project).
- In `graceful_shutdown`, dump each per-slug index to its own `{slug}/vector/` in Step 1 (before the Arc drops), **warn-and-continue per entry** (N1) so one bad slug dir cannot abort the others or block the daemon `try_unwrap`.
- Startup `load` arm needs no change once `.meta` is written.

## Out of scope (tracked as #824)
Heal-on-boot from store, `load`-failure fallback to a fresh index, and atomic (temp+rename) dump (N2 from the design review). The dump→load round-trip restores single-project parity, which is the regression being closed.

## Testing
- New regression test `test_graceful_shutdown_dumps_per_slug_vector_index`: asserts the slug's `{slug}/vector` meta has non-zero points, the daemon `{hash}/vector` did NOT gain the slug's vectors, and a load+search round-trip returns the seeded entry. Fails on `main`.
- Per-crate suites (workspace `cargo test` OOMs the linker in this env — #5023): unimatrix-server 4532 passed, all workspace crates green.
- Clippy `-p unimatrix-server --all-targets -D warnings`: clean.
- Integration smoke: 24 passed; restart/lifecycle: 7 passed.

Gate: Bug Fix Validation — **PASS** (9/9, 1 non-blocking WARN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)