### PR TITLE
fix: atomic vector dump + boot load-fallback for torn per-slug index (#824)

### DIFF
--- a/crates/unimatrix-server/src/http_provision.rs
+++ b/crates/unimatrix-server/src/http_provision.rs
@@ -186,11 +186,27 @@ pub async fn build_project_server(
     let vector_config = VectorConfig::default();
     let meta_path = vector_dir.join("unimatrix-vector.meta");
     let vector_index = if meta_path.exists() {
-        Arc::new(
-            VectorIndex::load(Arc::clone(&store), vector_config, &vector_dir)
-                .await
-                .map_err(|e| ServerError::Core(CoreError::Vector(e)))?,
-        )
+        // Graceful degradation (Architectural Principle 5): a torn/missing dump
+        // (e.g. SIGKILL mid-dump leaving a meta over a missing graph) must NOT
+        // hard-abort this slug's boot. Fall back to an empty index; the capped
+        // run_maintenance heal pass (services/status.rs) re-populates it from
+        // the store on the next tick. See GH-824 / lesson #5272.
+        match VectorIndex::load(Arc::clone(&store), vector_config.clone(), &vector_dir).await {
+            Ok(idx) => Arc::new(idx),
+            Err(e) => {
+                tracing::warn!(
+                    slug = %slug,
+                    vector_dir = %vector_dir.display(),
+                    error = %e,
+                    "failed to load per-slug vector index; booting empty and \
+                     deferring to maintenance heal pass"
+                );
+                Arc::new(
+                    VectorIndex::new(Arc::clone(&store), vector_config)
+                        .map_err(|e| ServerError::Core(CoreError::Vector(e)))?,
+                )
+            }
+        }
     } else {
         Arc::new(
             VectorIndex::new(Arc::clone(&store), vector_config)
@@ -448,3 +464,6 @@ fn flatten_present_keys(raw: &toml::Value) -> Vec<String> {
 
 #[cfg(test)]
 mod slug_config_tests;
+
+#[cfg(test)]
+mod boot_fallback_tests;

--- a/crates/unimatrix-server/src/http_provision/boot_fallback_tests.rs
+++ b/crates/unimatrix-server/src/http_provision/boot_fallback_tests.rs
@@ -1,0 +1,140 @@
+//! GH-824 Item 1 boot-resilience test: a torn per-slug vector dump must NOT
+//! hard-abort `build_project_server`; the slug boots with an EMPTY index and
+//! self-heals via the existing maintenance heal pass.
+//!
+//! Drives the REAL `build_project_server` boot path (the F1 acceptance site
+//! `http_provision.rs`) over a slug whose `{slug}/vector/` dir carries a
+//! `point_count > 0` meta but a DELETED `.hnsw.graph` — the exact on-disk state
+//! a SIGKILL mid-dump leaves. Asserts `Ok` with an empty index, not `Err`.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use unimatrix_core::{VectorConfig, VectorIndex};
+use unimatrix_engine::confidence::ConfidenceParams;
+use unimatrix_observe::domain::DomainPackRegistry;
+use unimatrix_server::http::ProjectSlug;
+use unimatrix_server::infra::categories::CategoryAllowlist;
+use unimatrix_server::infra::config::InferenceConfig;
+use unimatrix_server::infra::embed_handle::EmbedServiceHandle;
+use unimatrix_server::infra::nli_handle::NliServiceHandle;
+use unimatrix_server::infra::rayon_pool::RayonPool;
+use unimatrix_store::{NewEntry, PoolConfig, SqlxStore, Status};
+
+use super::{PROJECT_DB_NAME, PROJECT_VECTOR_DIR, build_project_server};
+
+/// Deterministic 384-dim normalized embedding (no ONNX) — for seeding the dump.
+fn det_embedding(text: &str) -> Vec<f32> {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    text.hash(&mut hasher);
+    let seed = hasher.finish();
+    let mut v = vec![0.0f32; 384];
+    for (i, val) in v.iter_mut().enumerate() {
+        let h = seed
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(i as u64);
+        *val = (h as f32) / (u64::MAX as f32) * 2.0 - 1.0;
+    }
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in &mut v {
+            *x /= norm;
+        }
+    } else {
+        v[0] = 1.0;
+    }
+    v
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_build_project_server_torn_dump_boots_empty_not_err() {
+    let base = tempfile::TempDir::new().unwrap();
+    let base_path = base.path();
+    let slug = ProjectSlug::try_from("alpha").expect("valid slug");
+
+    // The slug's store must already exist (build_project_server never creates it).
+    let slug_dir = base_path.join(slug.as_str());
+    let db_path = slug_dir.join(PROJECT_DB_NAME);
+    let vector_dir = slug_dir.join(PROJECT_VECTOR_DIR);
+    std::fs::create_dir_all(&vector_dir).unwrap();
+
+    let store = Arc::new(
+        SqlxStore::open(&db_path, PoolConfig::default())
+            .await
+            .expect("open slug store"),
+    );
+
+    // Seed a NON-EMPTY index and dump it to the slug's vector dir.
+    let index = VectorIndex::new(Arc::clone(&store), VectorConfig::default()).expect("vi");
+    for i in 0..4 {
+        let entry_id = store
+            .insert(NewEntry {
+                title: format!("entry {i}"),
+                content: format!("content {i}"),
+                topic: "test".to_string(),
+                category: "convention".to_string(),
+                tags: vec![],
+                source: "test".to_string(),
+                status: Status::Active,
+                created_by: "test".to_string(),
+                feature_cycle: "bugfix-824".to_string(),
+                trust_source: "agent".to_string(),
+            })
+            .await
+            .expect("insert");
+        index
+            .insert(entry_id, &det_embedding(&format!("entry {i}content {i}")))
+            .await
+            .expect("insert vector");
+    }
+    index.dump(&vector_dir).expect("dump");
+    drop(index);
+
+    // TORN DUMP: meta claims point_count > 0 but the graph file is gone (the
+    // exact SIGKILL-mid-dump artifact). Load would Err on this set.
+    let meta = std::fs::read_to_string(vector_dir.join("unimatrix-vector.meta")).unwrap();
+    assert!(
+        meta.contains("point_count=4"),
+        "precondition: meta claims a non-empty index"
+    );
+    std::fs::remove_file(vector_dir.join("unimatrix.hnsw.graph")).expect("delete graph");
+    assert!(vector_dir.join("unimatrix-vector.meta").exists());
+
+    // Drive the real boot path. With Item 1, this returns Ok (empty index +
+    // warn), NOT Err — graceful degradation (Architectural Principle 5).
+    let embed_handle = EmbedServiceHandle::new();
+    let rayon_pool = Arc::new(RayonPool::new(1, "test-pool").expect("rayon pool"));
+    let nli_handle = NliServiceHandle::new();
+    let inference_config = Arc::new(InferenceConfig::default());
+    let confidence_params = Arc::new(ConfidenceParams::default());
+    let categories = Arc::new(CategoryAllowlist::new());
+    let observation_registry = Arc::new(DomainPackRegistry::with_builtin_claude_code());
+    let boosted: HashSet<String> = HashSet::new();
+
+    let result = build_project_server(
+        base_path,
+        &slug,
+        &embed_handle,
+        true, // permissive
+        None, // instructions
+        &rayon_pool,
+        &nli_handle,
+        20,    // nli_top_k
+        false, // nli_enabled
+        &inference_config,
+        &confidence_params,
+        &categories,
+        &observation_registry,
+        &boosted,
+    )
+    .await;
+
+    let input = result.expect("torn per-slug dump must NOT hard-abort boot (GH-824 Item 1)");
+    assert_eq!(
+        input.server.vector_index().point_count(),
+        0,
+        "torn dump must degrade to an EMPTY per-slug index, not Err"
+    );
+}

--- a/crates/unimatrix-server/src/main.rs
+++ b/crates/unimatrix-server/src/main.rs
@@ -734,11 +734,27 @@ async fn tokio_main_daemon(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     let vector_index = if meta_path.exists() {
         tracing::info!("loading existing vector index");
-        Arc::new(
-            VectorIndex::load(Arc::clone(&store), vector_config, &paths.vector_dir)
-                .await
-                .map_err(|e| ServerError::Core(CoreError::Vector(e)))?,
-        )
+        // Graceful degradation (Architectural Principle 5): a torn/missing dump
+        // (e.g. SIGKILL mid-dump leaving a meta over a missing graph) must NOT
+        // hard-abort boot. Fall back to an empty index; the capped
+        // run_maintenance heal pass re-populates it from the store on the next
+        // tick. See GH-824 / lesson #5272.
+        match VectorIndex::load(Arc::clone(&store), vector_config.clone(), &paths.vector_dir).await
+        {
+            Ok(idx) => Arc::new(idx),
+            Err(e) => {
+                tracing::warn!(
+                    vector_dir = %paths.vector_dir.display(),
+                    error = %e,
+                    "failed to load vector index; booting empty and deferring to \
+                     maintenance heal pass"
+                );
+                Arc::new(
+                    VectorIndex::new(Arc::clone(&store), vector_config)
+                        .map_err(|e| ServerError::Core(CoreError::Vector(e)))?,
+                )
+            }
+        }
     } else {
         tracing::info!("creating new vector index");
         Arc::new(
@@ -1448,11 +1464,27 @@ async fn tokio_main_stdio(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     let vector_index = if meta_path.exists() {
         tracing::info!("loading existing vector index");
-        Arc::new(
-            VectorIndex::load(Arc::clone(&store), vector_config, &paths.vector_dir)
-                .await
-                .map_err(|e| ServerError::Core(CoreError::Vector(e)))?,
-        )
+        // Graceful degradation (Architectural Principle 5): a torn/missing dump
+        // (e.g. SIGKILL mid-dump leaving a meta over a missing graph) must NOT
+        // hard-abort boot. Fall back to an empty index; the capped
+        // run_maintenance heal pass re-populates it from the store on the next
+        // tick. See GH-824 / lesson #5272.
+        match VectorIndex::load(Arc::clone(&store), vector_config.clone(), &paths.vector_dir).await
+        {
+            Ok(idx) => Arc::new(idx),
+            Err(e) => {
+                tracing::warn!(
+                    vector_dir = %paths.vector_dir.display(),
+                    error = %e,
+                    "failed to load vector index; booting empty and deferring to \
+                     maintenance heal pass"
+                );
+                Arc::new(
+                    VectorIndex::new(Arc::clone(&store), vector_config)
+                        .map_err(|e| ServerError::Core(CoreError::Vector(e)))?,
+                )
+            }
+        }
     } else {
         tracing::info!("creating new vector index");
         Arc::new(

--- a/crates/unimatrix-server/src/services/status.rs
+++ b/crates/unimatrix-server/src/services/status.rs
@@ -2486,6 +2486,182 @@ mod bugfix_444_tests {
         }
     }
 
+    /// Deterministic 384-dim normalized embedding provider — no ONNX model.
+    /// Mirrors the eval `DeterministicProvider` pattern; `unimatrix-embed`'s
+    /// `MockProvider` is behind a `test-support` feature this crate does not
+    /// enable, so the provider is defined inline (the established convention).
+    struct HealTestProvider;
+
+    impl unimatrix_embed::EmbeddingProvider for HealTestProvider {
+        fn embed(&self, text: &str) -> unimatrix_embed::Result<Vec<f32>> {
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::{Hash, Hasher};
+            let mut hasher = DefaultHasher::new();
+            text.hash(&mut hasher);
+            let seed = hasher.finish();
+            let mut v = vec![0.0f32; 384];
+            for (i, val) in v.iter_mut().enumerate() {
+                let h = seed
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(i as u64);
+                *val = (h as f32) / (u64::MAX as f32) * 2.0 - 1.0;
+            }
+            let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            if norm > 0.0 {
+                for x in &mut v {
+                    *x /= norm;
+                }
+            } else {
+                v[0] = 1.0;
+            }
+            Ok(v)
+        }
+
+        fn embed_batch(&self, texts: &[&str]) -> unimatrix_embed::Result<Vec<Vec<f32>>> {
+            texts.iter().map(|t| self.embed(t)).collect()
+        }
+
+        fn dimension(&self) -> usize {
+            384
+        }
+
+        fn name(&self) -> &str {
+            "heal-test"
+        }
+    }
+
+    /// Build a `StatusService` over `vector_index` whose embed handle is READY
+    /// with a deterministic provider, so the heal pass actually re-embeds and
+    /// inserts (not the "adapter unavailable, skipping" branch).
+    async fn make_status_service_with_ready_embed(
+        store: &Arc<Store>,
+        vector_index: Arc<VectorIndex>,
+    ) -> StatusService {
+        let embed_service = EmbedServiceHandle::new();
+        embed_service
+            .set_ready_with_provider(Arc::new(HealTestProvider))
+            .await;
+        let adapt_service = Arc::new(AdaptationService::new(
+            unimatrix_adapt::AdaptConfig::default(),
+        ));
+        let confidence_state = Arc::new(std::sync::RwLock::new(ConfidenceState::default()));
+        let contradiction_cache = new_contradiction_cache_handle();
+        let test_rayon_pool = Arc::new(
+            crate::infra::rayon_pool::RayonPool::new(1, "test_pool").expect("test rayon pool"),
+        );
+        let observation_registry =
+            Arc::new(unimatrix_observe::domain::DomainPackRegistry::with_builtin_claude_code());
+        let confidence_params = Arc::new(unimatrix_engine::confidence::ConfidenceParams::default());
+        let category_allowlist = Arc::new(crate::infra::categories::CategoryAllowlist::new());
+        StatusService::new(
+            Arc::clone(store),
+            vector_index,
+            embed_service,
+            adapt_service,
+            confidence_state,
+            confidence_params,
+            contradiction_cache,
+            test_rayon_pool,
+            observation_registry,
+            category_allowlist,
+        )
+    }
+
+    /// GH-824 Test 3 (HARD ACCEPTANCE): per-slug heal-after-degrade.
+    ///
+    /// Simulates the post-load-fallback state of a PER-SLUG index in
+    /// multi-project mode: a slug whose store is populated (entries already
+    /// embedded, `embedding_dim > 0`, VECTOR_MAP rows present) but whose
+    /// `VectorIndex` booted EMPTY because its dump was torn (Item 1 fallback).
+    /// One maintenance heal tick (run_maintenance Sub-case B) must re-populate
+    /// the index from the store — proving the Item-1 degradation is recoverable
+    /// WITHOUT the deferred Item 2 eager boot rebuild.
+    ///
+    /// Proves per-slug recovery DIRECTLY (not by analogy to the daemon index —
+    /// the #823 / crt-056 failure mode).
+    #[tokio::test]
+    async fn test_per_slug_index_heals_after_degrade_to_empty() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // The slug's OWN store (per-slug isolation): populate it as if the slug
+        // had been serving and embedding entries before the crash.
+        let slug_store = open_store(&dir).await;
+
+        // A "populated" index that embedded N entries into the slug store.
+        let populated_index = Arc::new(
+            VectorIndex::new(Arc::clone(&slug_store), VectorConfig::default()).expect("vi"),
+        );
+        let provider = HealTestProvider;
+        let mut entry_ids = Vec::new();
+        for i in 0..5 {
+            let entry_id = slug_store
+                .insert(NewEntry {
+                    title: format!("slug entry {i}"),
+                    content: format!("content {i}"),
+                    topic: "test".to_string(),
+                    category: "convention".to_string(),
+                    tags: vec![],
+                    source: "test".to_string(),
+                    status: Status::Active,
+                    created_by: "test".to_string(),
+                    feature_cycle: "bugfix-824".to_string(),
+                    trust_source: "agent".to_string(),
+                })
+                .await
+                .expect("insert");
+            let emb = unimatrix_embed::EmbeddingProvider::embed(
+                &provider,
+                &format!("slug entry {i}content {i}"),
+            )
+            .expect("embed");
+            // insert() writes VECTOR_MAP + HNSW point + sets embedding_dim > 0.
+            populated_index
+                .insert(entry_id, &emb)
+                .await
+                .expect("insert vector");
+            entry_ids.push(entry_id);
+        }
+        // Confirm the store now records embedded entries (embedding_dim > 0).
+        for id in &entry_ids {
+            assert!(
+                slug_store.get_vector_mapping(*id).await.unwrap().is_some(),
+                "store must have a VECTOR_MAP row for embedded entry"
+            );
+        }
+        drop(populated_index);
+
+        // DEGRADE: boot a FRESH EMPTY per-slug index over the SAME populated
+        // store — exactly the Item-1 load-fallback outcome (torn dump → empty).
+        let degraded_index = Arc::new(
+            VectorIndex::new(Arc::clone(&slug_store), VectorConfig::default()).expect("vi"),
+        );
+        assert_eq!(
+            degraded_index.point_count(),
+            0,
+            "per-slug index boots empty after load-fallback"
+        );
+
+        // One maintenance heal tick over the per-slug index.
+        let svc =
+            make_status_service_with_ready_embed(&slug_store, Arc::clone(&degraded_index)).await;
+        let config = make_inference_config_batch(20);
+        run_maintenance_simple(&svc, &slug_store, &config).await;
+
+        // The per-slug index self-healed: point_count rose from the store.
+        assert!(
+            degraded_index.point_count() > 0,
+            "per-slug index must self-heal via the maintenance heal pass; \
+             point_count stayed {}",
+            degraded_index.point_count()
+        );
+        // Specifically, the previously-embedded entries are back in the index.
+        for id in &entry_ids {
+            assert!(
+                degraded_index.contains(*id),
+                "healed per-slug index must contain previously-embedded entry {id}"
+            );
+        }
+    }
+
     async fn run_maintenance_simple(
         svc: &StatusService,
         store: &Arc<Store>,

--- a/crates/unimatrix-vector/src/persistence.rs
+++ b/crates/unimatrix-vector/src/persistence.rs
@@ -18,46 +18,115 @@ impl VectorIndex {
     ///
     /// Creates `.hnsw.graph`, `.hnsw.data`, and `.meta` files in `dir`.
     /// The directory is created if it does not exist.
+    ///
+    /// The publish is atomic against a SIGKILL mid-dump: the graph/data files
+    /// are written to sibling temp files inside `dir` and then `rename`d into
+    /// place, with the `.meta` (which claims `point_count`) renamed LAST. A
+    /// crash at any point therefore never leaves a `.meta` overclaiming a
+    /// missing/torn graph — an observer sees either the prior dump or the new
+    /// complete one.
+    ///
+    /// NOTE: power-loss durability (fsync of files + directory before/after
+    /// rename) is intentionally OUT OF SCOPE. `rename(2)` is atomic for
+    /// observers but not guaranteed durable across a power-loss without fsync;
+    /// the bug this guards (GH-824, SIGKILL mid-dump) is fully covered by
+    /// temp+rename alone.
     pub fn dump(&self, dir: &Path) -> Result<()> {
         // Create directory if needed
         std::fs::create_dir_all(dir).map_err(|e| {
             VectorError::Persistence(format!("failed to create directory {}: {e}", dir.display()))
         })?;
 
-        // Dump hnsw_rs index (read lock)
+        // Dump hnsw_rs index to SIBLING temp files inside `dir` (read lock).
+        // Temp files MUST live in `dir` so the rename below is intra-filesystem
+        // (a cross-device rename fails with EXDEV).
         let point_count;
         let actual_basename;
+        let temp_graph = dir.join(format!(".{DUMP_BASENAME}.hnsw.graph.tmp"));
+        let temp_data = dir.join(format!(".{DUMP_BASENAME}.hnsw.data.tmp"));
         {
             let hnsw = self.hnsw_read();
             point_count = hnsw.get_nb_point();
 
             if point_count > 0 {
-                actual_basename = hnsw.file_dump(dir, DUMP_BASENAME).map_err(|e| {
+                // hnsw_rs writes `{basename}.hnsw.graph` / `.hnsw.data` directly;
+                // it cannot target arbitrary temp names, so dump under a temp
+                // basename and rename the produced files into their final names.
+                let temp_basename = format!(".{DUMP_BASENAME}.tmp");
+                let produced = hnsw.file_dump(dir, &temp_basename).map_err(|e| {
                     VectorError::Persistence(format!(
                         "failed to dump hnsw index to {}: {e}",
                         dir.display()
                     ))
                 })?;
+                // hnsw_rs may return a basename distinct from the one requested
+                // (datamap_opt path); the produced files use `{produced}.hnsw.*`.
+                let produced_graph = dir.join(format!("{produced}.hnsw.graph"));
+                let produced_data = dir.join(format!("{produced}.hnsw.data"));
+                std::fs::rename(&produced_graph, &temp_graph).map_err(|e| {
+                    VectorError::Persistence(format!(
+                        "failed to stage graph temp {}: {e}",
+                        temp_graph.display()
+                    ))
+                })?;
+                std::fs::rename(&produced_data, &temp_data).map_err(|e| {
+                    VectorError::Persistence(format!(
+                        "failed to stage data temp {}: {e}",
+                        temp_data.display()
+                    ))
+                })?;
+                // Final published basename is the stable DUMP_BASENAME.
+                actual_basename = DUMP_BASENAME.to_string();
             } else {
                 // hnsw_rs cannot dump an empty index (no entry point).
-                // Write empty placeholder files so load detects "empty" cleanly.
+                // The published set is meta-only.
                 actual_basename = DUMP_BASENAME.to_string();
             }
         }
 
-        // Write metadata file with the actual basename used by file_dump.
-        // hnsw_rs may generate a unique basename when datamap_opt is set
-        // (true after load_hnsw, even without mmap).
         let next = self.next_data_id_value();
+        let final_graph = dir.join(format!("{actual_basename}.hnsw.graph"));
+        let final_data = dir.join(format!("{actual_basename}.hnsw.data"));
         let meta_path = dir.join(METADATA_FILENAME);
+        let temp_meta = dir.join(format!(".{METADATA_FILENAME}.tmp"));
+
         let meta_content = format!(
             "basename={actual_basename}\npoint_count={point_count}\ndimension={}\nnext_data_id={next}\n",
             self.config().dimension,
         );
-
-        std::fs::write(&meta_path, meta_content).map_err(|e| {
+        std::fs::write(&temp_meta, meta_content).map_err(|e| {
             VectorError::Persistence(format!(
-                "failed to write metadata to {}: {e}",
+                "failed to write metadata temp {}: {e}",
+                temp_meta.display()
+            ))
+        })?;
+
+        // Publish. Graph/data first, meta LAST: a crash before the meta rename
+        // leaves the prior (consistent) meta in place over the prior graph.
+        if point_count > 0 {
+            std::fs::rename(&temp_graph, &final_graph).map_err(|e| {
+                VectorError::Persistence(format!(
+                    "failed to publish graph {}: {e}",
+                    final_graph.display()
+                ))
+            })?;
+            std::fs::rename(&temp_data, &final_data).map_err(|e| {
+                VectorError::Persistence(format!(
+                    "failed to publish data {}: {e}",
+                    final_data.display()
+                ))
+            })?;
+        } else {
+            // Empty dump (meta-only): remove any stale graph/data left by a
+            // prior non-empty dump so the published set is self-consistent —
+            // a `point_count=0` meta must never sit beside an orphan graph (F3).
+            remove_if_exists(&final_graph)?;
+            remove_if_exists(&final_data)?;
+        }
+
+        std::fs::rename(&temp_meta, &meta_path).map_err(|e| {
+            VectorError::Persistence(format!(
+                "failed to publish metadata {}: {e}",
                 meta_path.display()
             ))
         })?;
@@ -139,6 +208,19 @@ impl VectorIndex {
             next_data_id,
             mappings,
         ))
+    }
+}
+
+/// Remove a file if present; absence is not an error. ENOENT is tolerated so
+/// the atomic empty-dump cleanup is idempotent across repeated empty dumps.
+fn remove_if_exists(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(VectorError::Persistence(format!(
+            "failed to remove stale file {}: {e}",
+            path.display()
+        ))),
     }
 }
 
@@ -238,6 +320,100 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(loaded.point_count(), 0);
+    }
+
+    // -- GH-824: Atomic dump crash-safety --
+
+    /// After a normal non-empty dump, the published set uses the EXACT final
+    /// filenames and leaves no sibling `.tmp` artifacts — the published dir is
+    /// internally self-consistent (meta + graph + data, no stragglers).
+    #[tokio::test]
+    async fn test_dump_atomic_no_temp_artifacts() {
+        let tvi = TestVectorIndex::new().await;
+        seed_vectors(tvi.vi(), tvi.store(), 20).await;
+        let dump_dir = tvi.dir().join("index");
+        tvi.vi().dump(&dump_dir).unwrap();
+
+        // Exact final names present.
+        assert!(dump_dir.join("unimatrix.hnsw.graph").exists());
+        assert!(dump_dir.join("unimatrix.hnsw.data").exists());
+        assert!(dump_dir.join("unimatrix-vector.meta").exists());
+
+        // No leftover temp siblings.
+        for entry in std::fs::read_dir(&dump_dir).unwrap() {
+            let name = entry.unwrap().file_name();
+            let name = name.to_string_lossy();
+            assert!(
+                !name.ends_with(".tmp"),
+                "atomic dump left a temp artifact: {name}"
+            );
+        }
+    }
+
+    /// An empty (meta-only) dump that follows a prior NON-EMPTY dump must remove
+    /// the stale `.hnsw.graph` / `.hnsw.data` so a `point_count=0` meta never
+    /// sits beside an orphan graph (F3). The published set must always be
+    /// self-consistent: a non-zero meta implies present graph+data; a zero meta
+    /// implies neither.
+    #[tokio::test]
+    async fn test_empty_dump_removes_stale_graph_data() {
+        let tvi = TestVectorIndex::new().await;
+        seed_vectors(tvi.vi(), tvi.store(), 15).await;
+        let dump_dir = tvi.dir().join("index");
+
+        // First: a non-empty dump leaves graph + data on disk.
+        tvi.vi().dump(&dump_dir).unwrap();
+        assert!(dump_dir.join("unimatrix.hnsw.graph").exists());
+        assert!(dump_dir.join("unimatrix.hnsw.data").exists());
+
+        // Now dump a fresh EMPTY index into the same dir.
+        let empty = VectorIndex::new(tvi.store().clone(), VectorConfig::default()).unwrap();
+        empty.dump(&dump_dir).unwrap();
+
+        // Meta now claims zero points...
+        let meta = std::fs::read_to_string(dump_dir.join("unimatrix-vector.meta")).unwrap();
+        assert!(meta.contains("point_count=0"));
+        // ...and the stale graph/data are gone — no orphan beside the empty meta.
+        assert!(!dump_dir.join("unimatrix.hnsw.graph").exists());
+        assert!(!dump_dir.join("unimatrix.hnsw.data").exists());
+
+        // Self-consistency: load must succeed and return an empty index, not Err.
+        let loaded = VectorIndex::load(tvi.store().clone(), VectorConfig::default(), &dump_dir)
+            .await
+            .unwrap();
+        assert_eq!(loaded.point_count(), 0);
+    }
+
+    /// Crash-safety contract: an interrupted dump (we simulate the failure
+    /// window by aborting BEFORE the meta is published) never leaves a meta
+    /// overclaiming a missing/torn graph. With temp+rename the meta is the LAST
+    /// thing published, so a crash before it leaves the prior good meta in place
+    /// — the on-disk set load() observes is always self-consistent.
+    #[tokio::test]
+    async fn test_interrupted_dump_keeps_prior_consistent_set() {
+        let tvi = TestVectorIndex::new().await;
+        seed_vectors(tvi.vi(), tvi.store(), 12).await;
+        let dump_dir = tvi.dir().join("index");
+
+        // A first, complete dump — the "prior good" published set.
+        tvi.vi().dump(&dump_dir).unwrap();
+        let prior_meta = std::fs::read_to_string(dump_dir.join("unimatrix-vector.meta")).unwrap();
+        assert!(prior_meta.contains("point_count=12"));
+
+        // Simulate a crash mid-dump: a NEW staged graph temp exists but the meta
+        // was never republished. The published meta still describes the prior set.
+        std::fs::write(dump_dir.join(".unimatrix.hnsw.graph.tmp"), b"torn").unwrap();
+
+        // load() reads only the PUBLISHED names and must see the prior consistent
+        // set — it must NOT pick up the torn temp, and must NOT Err.
+        let loaded = VectorIndex::load(tvi.store().clone(), VectorConfig::default(), &dump_dir)
+            .await
+            .unwrap();
+        assert_eq!(loaded.point_count(), 12);
+
+        // The published meta still matches the prior good dump.
+        let meta_now = std::fs::read_to_string(dump_dir.join("unimatrix-vector.meta")).unwrap();
+        assert_eq!(meta_now, prior_meta);
     }
 
     // -- AC-10: Load Restores Index --


### PR DESCRIPTION
Fixes #824 (N2 follow-up from #823).

## Root cause
`VectorIndex::dump` was non-atomic (wrote `hnsw.graph` + `hnsw.data`, then `.meta` last, no temp+rename). A crash mid-dump left a `.meta` claiming `point_count > 0` over a torn/missing graph. On next boot `VectorIndex::load` returned `Err`, and the boot path `?`-propagated it as a **hard boot abort for that slug** — violating Architectural Principle 5 (graceful degradation).

## Fix (Items 1 + 3; Item 2 deferred)
- **Item 1 — boot load-fallback (3 sites):** at `http_provision.rs:194`, `main.rs:742`, `main.rs:1472`, replace `?` with a `match` that `warn!`s and falls back to `VectorIndex::new` on load `Err`. The slug boots empty and self-heals via the existing capped maintenance heal pass.
- **Item 3 — atomic dump:** write the 3-file set to sibling temp files inside the target dir, then `rename` into place publishing `.meta` **last**; empty-dump path removes stale graph/data files. Covers both daemon and per-slug dumps. Power-loss/fsync durability explicitly out of scope (temp+rename covers the SIGKILL repro).
- **Eval load site (`layer.rs:232`) intentionally left `?`-propagating** — a silent empty index over a corrupt eval snapshot is the bug #2673 was created to prevent.
- **Item 2 (eager boot-time heal-from-store) deferred** as a separate `goal:personal-cloud` feature (re-embed budget, model dependency, boot latency); the existing capped heal pass already delivers incremental self-heal. To be filed as a follow-up.

## Tests (5 new)
- `test_dump_atomic_no_temp_artifacts`, `test_empty_dump_removes_stale_graph_data`, `test_interrupted_dump_keeps_prior_consistent_set` (unimatrix-vector)
- `test_build_project_server_torn_dump_boots_empty_not_err` (server bin) — drives real `build_project_server` over a torn dump, asserts `Ok` + empty
- `test_per_slug_index_heals_after_degrade_to_empty` (server lib) — per-slug, multi-project heal-after-degrade proven directly (not by daemon analogy)

## Verification
5031 unit tests pass, 0 failed. Smoke 24/24. Clippy clean. Gate: Bug Fix Validation — PASS (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)