### PR TITLE
fix: self-heal stale cloud MCP session (keep_alive + bridge re-init) (#830)

### DIFF
--- a/crates/unimatrix-server/src/http/router.rs
+++ b/crates/unimatrix-server/src/http/router.rs
@@ -17,6 +17,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use bytes::Bytes;
 use http::{Method, Request, Response};
@@ -38,6 +39,23 @@ use crate::services::ServiceLayer;
 
 /// Maximum request body size default (1 MB). Used when no config override.
 const DEFAULT_MAX_BODY_BYTES: usize = 1_048_576;
+
+/// Idle keep-alive (TTL) for rmcp Streamable-HTTP MCP sessions (#830).
+///
+/// rmcp's `SessionConfig::keep_alive` defaults to `DEFAULT_KEEP_ALIVE = 300s`,
+/// which evicts an idle session after 5 minutes. A normal agent think-gap >5min
+/// then loses its server-side session → the next call with the stale
+/// `Mcp-Session-Id` gets HTTP 404 "Session not found" and the bridge hangs until
+/// a manual `/mcp` re-init (#830 cloud staleness).
+///
+/// We override it to a long FINITE bound (4 hours), set on
+/// `LocalSessionManager.session_config.keep_alive` (NOT
+/// `StreamableHttpServerConfig.sse_keep_alive` — a different SSE-ping field that
+/// would NOT fix this). 4h ≫ any realistic idle gap, while keeping rmcp's
+/// finite-TTL safety net so sessions from clients that drop without a clean
+/// DELETE still self-evict (a `None`/unbounded TTL would leak them forever,
+/// growing the session map without bound — #830 design review B2).
+const SESSION_KEEP_ALIVE: Duration = Duration::from_secs(4 * 60 * 60);
 
 // ---------------------------------------------------------------------------
 // ObserveContext — service handle bundle for /observe handler (ADR-001)
@@ -337,7 +355,14 @@ impl McpAdapter {
         allowed_origins: Vec<String>,
         allowed_hosts: Vec<String>,
     ) -> Self {
-        let session_manager = Arc::new(LocalSessionManager::default());
+        // #830: override rmcp's 300s idle session eviction (DEFAULT_KEEP_ALIVE)
+        // with a long finite TTL so an agent think-gap does not silently kill the
+        // server-side MCP session. The TTL lives on the session manager's
+        // `session_config.keep_alive` (a `pub` field) — NOT on
+        // `StreamableHttpServerConfig`. Set it BEFORE wrapping in the `Arc`.
+        let mut session_manager = LocalSessionManager::default();
+        session_manager.session_config.keep_alive = Some(SESSION_KEEP_ALIVE);
+        let session_manager = Arc::new(session_manager);
         let mut config = StreamableHttpServerConfig::default();
         config.allowed_origins = allowed_origins;
         config.allowed_hosts = allowed_hosts;

--- a/crates/unimatrix-server/src/http/router/tests.rs
+++ b/crates/unimatrix-server/src/http/router/tests.rs
@@ -1146,6 +1146,65 @@ fn mcp_post_with_host(host: &str) -> Request<TestBody> {
 
 const HOST_FORBIDDEN_BODY: &str = "Host header is not allowed";
 
+// ===========================================================================
+// bug #830 (Layer A): MCP session idle keep_alive override.
+//
+// rmcp's LocalSessionManager defaults `session_config.keep_alive` to
+// DEFAULT_KEEP_ALIVE = 300s, evicting idle sessions after 5 minutes → the next
+// call with the stale Mcp-Session-Id gets HTTP 404 and the bridge hangs until a
+// manual /mcp re-init. McpAdapter::new must override it to a long FINITE bound.
+// These tests assert the override is in force WITHOUT waiting 4h: they check the
+// named const and that the manager is built with that TTL the way McpAdapter::new
+// builds it (Default + field mutation on the pub `session_config.keep_alive`).
+// ===========================================================================
+
+/// rmcp's default idle keep_alive (DEFAULT_KEEP_ALIVE). The override must move
+/// off this value — landing on it would mean the bug is unfixed.
+const RMCP_DEFAULT_KEEP_ALIVE: Duration = Duration::from_secs(300);
+
+// T-830-1: the configured keep_alive is the long 4h bound, not rmcp's 300s
+// default, and is finite (Some, not None — None would leak sessions, B2).
+#[test]
+fn test_session_keep_alive_is_long_finite_bound_not_rmcp_default() {
+    assert_eq!(
+        SESSION_KEEP_ALIVE,
+        Duration::from_secs(4 * 60 * 60),
+        "keep_alive must be the 4h bound (#830)"
+    );
+    assert_ne!(
+        SESSION_KEEP_ALIVE, RMCP_DEFAULT_KEEP_ALIVE,
+        "keep_alive must NOT be rmcp's 300s default — that is the bug (#830)"
+    );
+    assert!(
+        SESSION_KEEP_ALIVE > RMCP_DEFAULT_KEEP_ALIVE,
+        "the override must be longer than the 300s default that evicts idle sessions"
+    );
+}
+
+// T-830-2: building the session manager the way McpAdapter::new does yields the
+// long finite TTL on `session_config.keep_alive` — proving the override lands on
+// the correct field (not StreamableHttpServerConfig.sse_keep_alive), and that a
+// fresh LocalSessionManager::default() would otherwise carry the 300s default.
+#[test]
+fn test_session_manager_keep_alive_overridden_to_long_bound() {
+    // The default carries rmcp's 300s eviction — the pre-fix behavior.
+    let default_mgr = LocalSessionManager::default();
+    assert_eq!(
+        default_mgr.session_config.keep_alive,
+        Some(RMCP_DEFAULT_KEEP_ALIVE),
+        "sanity: rmcp's default is the 300s idle eviction this fix overrides"
+    );
+
+    // Mirror McpAdapter::new's construction.
+    let mut mgr = LocalSessionManager::default();
+    mgr.session_config.keep_alive = Some(SESSION_KEEP_ALIVE);
+    assert_eq!(
+        mgr.session_config.keep_alive,
+        Some(SESSION_KEEP_ALIVE),
+        "session_config.keep_alive must hold the long finite bound after override (#830)"
+    );
+}
+
 // T-774-1: a non-localhost public host wired through the adapter is NOT 403'd
 // on the Host gate, while an unrelated Host IS. This is the regression that
 // escaped vnc-034 (the configured public host was rejected before auth/MCP).

--- a/packages/unimatrix/lib/hook-client/mcp-bridge/dispatch.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/dispatch.js
@@ -7,13 +7,25 @@ const { SseParser } = require("./sse-parse.js");
 const { BODY_LIMIT_BYTES } = require("./http-session.js");
 
 const INTERNAL_ERROR = -32603;
+// Bridge-internal sentinel (out of the JSON-RPC reserved range) marking a server
+// 404 "session not found" so lifecycle.js can self-heal (#830, design-review C1).
+// Never reaches the client: lifecycle re-inits + retries before surfacing.
+const SESSION_NOT_FOUND = -32099;
 
 function jsonRpcError(id, code, message) {
   return { jsonrpc: "2.0", id: id === undefined ? null : id, error: { code, message } };
 }
 
-function httpStatusToJsonRpc(status) {
-  return status === 401 || status === 403 ? -32001 : INTERNAL_ERROR;
+// Narrow 404 idle-eviction class (#830): 404 with a "session not found" body.
+// Gated narrowly — NOT all 4xx (401/403 = auth; 5xx = server fault) — to avoid
+// re-init storms (design-review C1).
+function isSessionNotFound(status, body) {
+  return status === 404 && /session not found/i.test(body ? body.toString("utf8") : "");
+}
+
+function httpStatusToJsonRpc(status, body) {
+  if (status === 401 || status === 403) return -32001;
+  return isSessionNotFound(status, body) ? SESSION_NOT_FOUND : INTERNAL_ERROR;
 }
 
 // Read a non-SSE body bounded at `limit`; destroy + return-what-we-have on excess.
@@ -51,7 +63,7 @@ async function dispatchResponse({ status, contentType, res }) {
   if (ct.startsWith("application/json")) {
     const body = await readBounded(res, BODY_LIMIT_BYTES);
     if (status >= 400) {
-      return [jsonRpcError(idFromBody(body), httpStatusToJsonRpc(status), "MCP endpoint returned HTTP " + status)];
+      return [jsonRpcError(idFromBody(body), httpStatusToJsonRpc(status, body), "MCP endpoint returned HTTP " + status)];
     }
     try {
       return [JSON.parse(body.toString("utf8"))];
@@ -77,4 +89,12 @@ function correlateById(messages, id) {
   return null;
 }
 
-module.exports = { dispatchResponse, jsonRpcError, correlateById, readBounded, INTERNAL_ERROR };
+module.exports = {
+  dispatchResponse,
+  jsonRpcError,
+  correlateById,
+  readBounded,
+  isSessionNotFound,
+  INTERNAL_ERROR,
+  SESSION_NOT_FOUND,
+};

--- a/packages/unimatrix/lib/hook-client/mcp-bridge/lifecycle.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/lifecycle.js
@@ -5,65 +5,110 @@
 // STABLE clientInfo.name on initialize (server keys audit attribution on it +
 // the transport session id — vnc-014/#4708; AC-12). Captures the negotiated
 // protocolVersion at initialize for the MCP-Protocol-Version echo (G1).
+//
+// Self-heal (#830, design-review B3/C1-C3): a cloud server evicts idle sessions
+// (rmcp keep_alive); the next post 404s "session not found". On that narrow
+// signal — post-init requests only — drop the dead session id, RE-INITIALIZE
+// through this same path (clientInfo.name stays byte-identical: vnc-039 audit
+// contract holds; the rotating Mcp-Session-Id is fine), then retry the failed
+// call EXACTLY ONCE. Single-flight: concurrent 404s share one re-init. Any other
+// error, a failed re-init, or a second 404 propagates — no storms, no loops.
 
-const { dispatchResponse, jsonRpcError, correlateById, INTERNAL_ERROR } = require("./dispatch.js");
+const { dispatchResponse, jsonRpcError, correlateById, INTERNAL_ERROR, SESSION_NOT_FOUND } = require("./dispatch.js");
 
 const CLIENT_INFO_NAME = "unimatrix-mcp-bridge"; // STABLE, fixed (FR-03a/AC-12)
 
 class Lifecycle {
-  constructor(session) {
+  constructor(session, deps) {
     this.session = session;
+    this.initMessage = null; // captured client initialize, replayed on re-init (B3)
+    this.reinitInFlight = null; // single-flight guard for concurrent 404s (C2)
+    this.errOut = (deps && deps.errOut) || ((s) => process.stderr.write(s));
   }
 
   // handle(msg) -> Promise<jsonRpcMessage | null>  (null for notifications)
   async handle(msg) {
     const isInit = msg && msg.method === "initialize";
     if (isInit) {
+      // Inject the STABLE clientInfo.name (fixed; never per-spawn — R-17/B3).
       if (!msg.params || typeof msg.params !== "object") msg.params = {};
-      if (!msg.params.clientInfo || typeof msg.params.clientInfo !== "object") {
-        msg.params.clientInfo = {};
-      }
-      msg.params.clientInfo.name = CLIENT_INFO_NAME; // fixed; never per-spawn (R-17)
+      if (!msg.params.clientInfo || typeof msg.params.clientInfo !== "object") msg.params.clientInfo = {};
+      msg.params.clientInfo.name = CLIENT_INFO_NAME;
+      this.initMessage = msg; // already-stamped; replayed verbatim on re-init (B3)
     }
 
+    let out = await this._send(msg, isInit);
+
+    // Self-heal post-init only (a 404 on initialize itself is fatal — C1):
+    // re-init once (single-flight), then retry the call once. Heal failure or a
+    // second 404 leaves `out` the original 404 — no loop, no storm (C1/C2).
+    if (!isInit && msg && lostId(out, msg.id)) {
+      let ok = false;
+      try { ok = await this._reinit(); } catch (_e) {}
+      if (ok) out = await this._send(msg, false);
+    }
+
+    if (!msg || msg.id == null) return null; // notification — no response
+    const m = correlateById(out, msg.id) || out[0] || jsonRpcError(msg.id, INTERNAL_ERROR, "empty response");
+    // A leaked sentinel (heal exhausted) is normalized — never reaches a client.
+    return m && m.error && m.error.code === SESSION_NOT_FOUND
+      ? jsonRpcError(msg.id, INTERNAL_ERROR, "MCP session lost, re-init failed")
+      : m;
+  }
+
+  // One request + dispatch -> jsonRpcMessage[]. Transport-class failures (already
+  // exited loud if pin-class) become a per-request JSON-RPC error array; they are
+  // never SESSION_NOT_FOUND, so they neither trigger nor satisfy self-heal.
+  async _send(msg, isInit) {
     let resp;
     try {
       resp = await this.session.request(msg, { isInitialize: isInit });
     } catch (err) {
-      // Pin-class failures already exited loud inside the session. Transport /
-      // connect / timeout class -> JSON-RPC error (per-request, not fatal).
-      return jsonRpcError(msg && msg.id != null ? msg.id : null, INTERNAL_ERROR, classify(err));
+      const id = msg && msg.id != null ? msg.id : null;
+      const why = err && err.code === "ETIMEDOUT" ? "MCP endpoint timed out" : "MCP endpoint unreachable";
+      return [jsonRpcError(id, INTERNAL_ERROR, why)];
     }
-
     const out = await dispatchResponse(resp);
-
     if (isInit) {
-      const pv = extractProtocolVersion(out);
-      if (pv) {
-        this.protocolVersion = pv;
-        this.session.protocolVersion = pv;
+      // Capture the negotiated protocolVersion for the MCP-Protocol-Version echo.
+      for (const m of out) {
+        if (m && m.result && typeof m.result.protocolVersion === "string") {
+          this.session.protocolVersion = m.result.protocolVersion;
+          break;
+        }
       }
     }
-
-    // Notifications (no id) expect no response.
-    if (!msg || msg.id === undefined || msg.id === null) return null;
-    return correlateById(out, msg.id) || out[0] || jsonRpcError(msg.id, INTERNAL_ERROR, "empty response");
+    return out;
   }
-}
 
-function classify(err) {
-  const code = err && err.code;
-  if (code === "ETIMEDOUT") return "MCP endpoint timed out";
-  return "MCP endpoint unreachable";
-}
-
-function extractProtocolVersion(messages) {
-  for (const m of messages) {
-    if (m && m.result && typeof m.result.protocolVersion === "string") {
-      return m.result.protocolVersion;
+  // Single-flight: concurrent 404s await ONE shared re-init (C2). Resolves true
+  // on a fresh session id, false otherwise. Never throws / loops.
+  _reinit() {
+    if (!this.reinitInFlight) {
+      this.reinitInFlight = this._doReinit().finally(() => { this.reinitInFlight = null; });
     }
+    return this.reinitInFlight;
   }
-  return null;
+
+  async _doReinit() {
+    const init = this.initMessage;
+    if (!init) return false; // never saw initialize — cannot heal
+    const prevId = this.session.sessionId;
+    this.errOut("mcp-bridge: session evicted (404); re-init\n");
+    this.session.sessionId = null; // discard the dead id before re-init
+    await this._send(init, true); // protocolVersion re-captured inside
+    const newId = this.session.sessionId;
+    if (newId == null || newId === prevId) return false; // no fresh session
+    this.errOut("mcp-bridge: re-init ok; new session\n");
+    return true;
+  }
 }
 
-module.exports = { Lifecycle, CLIENT_INFO_NAME, extractProtocolVersion };
+// True when the SESSION_NOT_FOUND sentinel is the response for this id (#830).
+// `out` is always a message[] (dispatchResponse / _send both guarantee it).
+function lostId(out, id) {
+  const m = correlateById(out, id) || out[0];
+  return !!(m && m.error && m.error.code === SESSION_NOT_FOUND);
+}
+
+module.exports = { Lifecycle, CLIENT_INFO_NAME };

--- a/packages/unimatrix/test/hook-client/mcp-bridge.test.js
+++ b/packages/unimatrix/test/hook-client/mcp-bridge.test.js
@@ -15,7 +15,7 @@ const path = require("path");
 
 const { StdioFramer } = require("../../lib/hook-client/mcp-bridge/stdio-frame.js");
 const { SseParser } = require("../../lib/hook-client/mcp-bridge/sse-parse.js");
-const { dispatchResponse, correlateById } = require("../../lib/hook-client/mcp-bridge/dispatch.js");
+const { dispatchResponse, correlateById, isSessionNotFound, SESSION_NOT_FOUND } = require("../../lib/hook-client/mcp-bridge/dispatch.js");
 const { Lifecycle, CLIENT_INFO_NAME } = require("../../lib/hook-client/mcp-bridge/lifecycle.js");
 const { HttpSession, SESSION_HEADER_LC } = require("../../lib/hook-client/mcp-bridge/http-session.js");
 const bridge = require("../../lib/hook-client/mcp-bridge.js");
@@ -372,6 +372,158 @@ describe("lifecycle (R-17)", () => {
     const out = await lc.handle({ jsonrpc: "2.0", id: 5, method: "tools/list" });
     assert.strictEqual(out.id, 5);
     assert.ok(out.error);
+  });
+});
+
+// ── self-heal on idle eviction (#830, design-review B3/C1-C3) ────────────────
+
+describe("session self-heal on 404 (#830)", () => {
+  // dispatch.js: the 404 "session not found" body class is distinguishable.
+  it("test_dispatch_404SessionNotFound_classifiedDistinctly", async () => {
+    const body = Buffer.from(JSON.stringify({ error: "Session not found" }));
+    assert.strictEqual(isSessionNotFound(404, body), true);
+    assert.strictEqual(isSessionNotFound(404, Buffer.from("other 404")), false);
+    assert.strictEqual(isSessionNotFound(401, body), false); // auth, not session
+    assert.strictEqual(isSessionNotFound(500, body), false); // server fault
+    const out = await dispatchResponse({ status: 404, contentType: "application/json",
+      res: bodyStream(Buffer.from(JSON.stringify({ id: 7, error: "Session not found" }))) });
+    assert.strictEqual(out[0].error.code, SESSION_NOT_FOUND);
+    assert.strictEqual(out[0].id, 7);
+  });
+
+  // Build a fake session whose responder is wired to the eviction scenario.
+  // The responder returns a {status, contentType, res} triplet; the session
+  // tracks sessionId the way HttpSession would (init mints a new id).
+  function evictingSession(plan) {
+    const sess = {
+      sent: [],
+      sessionId: null,
+      protocolVersion: null,
+      initCount: 0,
+      idCounter: 0,
+      request(body, opts) {
+        sess.sent.push({ body, opts, sessionAtSend: sess.sessionId });
+        if (opts && opts.isInitialize) {
+          sess.initCount += 1;
+          sess.sessionId = "SID-" + ++sess.idCounter; // server mints fresh id
+          return Promise.resolve(jsonRes({ jsonrpc: "2.0", id: body.id, result: { protocolVersion: "2025-06-18" } }));
+        }
+        return Promise.resolve(plan(body, sess));
+      },
+    };
+    return sess;
+  }
+  function jsonRes(obj) {
+    return { status: 200, contentType: "application/json", res: bodyStream(Buffer.from(JSON.stringify(obj))) };
+  }
+  function sessionNotFoundRes(id) {
+    return { status: 404, contentType: "application/json",
+      res: bodyStream(Buffer.from(JSON.stringify({ id, error: "Session not found" }))) };
+  }
+  async function initialized(lc) {
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize", params: { clientInfo: { name: "claude-code" } } });
+  }
+
+  it("test_selfHeal_404OnToolsCall_reinitsOnceAndRetrySucceeds", async () => {
+    let firstCall = true;
+    const sess = evictingSession((body) => {
+      if (firstCall) { firstCall = false; return sessionNotFoundRes(body.id); } // evicted
+      return jsonRes({ jsonrpc: "2.0", id: body.id, result: { ok: true } }); // retry on new id
+    });
+    const errs = [];
+    const lc = new Lifecycle(sess, { errOut: (s) => errs.push(s) });
+    await initialized(lc);
+    assert.strictEqual(sess.initCount, 1);
+
+    const out = await lc.handle({ jsonrpc: "2.0", id: 9, method: "tools/call", params: {} });
+    assert.strictEqual(out.id, 9);
+    assert.deepStrictEqual(out.result, { ok: true }, "retry result surfaced");
+    assert.strictEqual(sess.initCount, 2, "exactly one re-initialize");
+    // vnc-039: the re-init preserved the STABLE clientInfo.name (B3).
+    const reinit = sess.sent.filter((s) => s.opts && s.opts.isInitialize)[1];
+    assert.strictEqual(reinit.body.params.clientInfo.name, CLIENT_INFO_NAME);
+    // The retry went out under the NEW session id, never the dead one.
+    const retry = sess.sent[sess.sent.length - 1];
+    assert.strictEqual(retry.sessionAtSend, "SID-2");
+    assert.match(errs.join(""), /session evicted \(404\); re-init/);
+  });
+
+  it("test_selfHeal_secondConsecutive404_doesNotLoop", async () => {
+    // Server always 404s tools/call (eviction persists) -> heal once, the retry
+    // 404s again, and we surface an error WITHOUT a second re-init or recursion.
+    const sess = evictingSession((body) => sessionNotFoundRes(body.id));
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    await initialized(lc);
+
+    const out = await lc.handle({ jsonrpc: "2.0", id: 11, method: "tools/call", params: {} });
+    assert.strictEqual(out.id, 11);
+    assert.ok(out.error, "error surfaced, not retried forever");
+    assert.notStrictEqual(out.error.code, SESSION_NOT_FOUND, "sentinel never reaches client");
+    assert.strictEqual(sess.initCount, 2, "exactly one re-init (init + one heal), no loop");
+  });
+
+  it("test_selfHeal_reinitFailure_aborts_noLoop", async () => {
+    // tools/call 404s; the re-init transport-fails -> abort, surface original.
+    let reinitTried = false;
+    let initCount = 0;
+    const sess = {
+      sent: [], sessionId: "OLD", protocolVersion: null,
+      request(body, opts) {
+        sess.sent.push({ body, opts });
+        if (opts && opts.isInitialize) {
+          initCount += 1;
+          if (initCount > 1) { // first init = handshake; second = self-heal re-init
+            reinitTried = true;
+            return Promise.reject(Object.assign(new Error("down"), { code: "ECONNREFUSED" }));
+          }
+          sess.sessionId = "SID-NEW";
+          return Promise.resolve(jsonRes({ jsonrpc: "2.0", id: body.id, result: {} }));
+        }
+        return Promise.resolve(sessionNotFoundRes(body.id));
+      },
+    };
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize" });
+    const out = await lc.handle({ jsonrpc: "2.0", id: 13, method: "tools/call", params: {} });
+    assert.ok(reinitTried, "re-init was attempted");
+    assert.ok(out.error, "original error surfaced after failed re-init");
+    assert.strictEqual(out.id, 13);
+  });
+
+  it("test_selfHeal_concurrent404s_singleReinit", async () => {
+    // Two tools/call in flight both 404; only ONE re-init must occur (C2).
+    const evictedIds = new Set();
+    const sess = evictingSession((body) => {
+      if (!evictedIds.has(body.id)) { evictedIds.add(body.id); return sessionNotFoundRes(body.id); }
+      return jsonRes({ jsonrpc: "2.0", id: body.id, result: { id: body.id } });
+    });
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    await initialized(lc);
+
+    const [a, b] = await Promise.all([
+      lc.handle({ jsonrpc: "2.0", id: 21, method: "tools/call", params: {} }),
+      lc.handle({ jsonrpc: "2.0", id: 22, method: "tools/call", params: {} }),
+    ]);
+    assert.deepStrictEqual(a.result, { id: 21 });
+    assert.deepStrictEqual(b.result, { id: 22 });
+    assert.strictEqual(sess.initCount, 2, "one initial + exactly one shared re-init (single-flight)");
+  });
+
+  it("test_selfHeal_404OnInitialize_isFatal_noReinit", async () => {
+    // An initialize that itself 404s must NOT trigger self-heal recursion.
+    const sess = {
+      sent: [], sessionId: null, protocolVersion: null, initCount: 0,
+      request(body, opts) {
+        sess.sent.push({ body, opts });
+        if (opts && opts.isInitialize) sess.initCount += 1;
+        return Promise.resolve(sessionNotFoundRes(body.id));
+      },
+    };
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    const out = await lc.handle({ jsonrpc: "2.0", id: 1, method: "initialize" });
+    assert.strictEqual(sess.initCount, 1, "no re-init triggered for a 404 on initialize");
+    assert.ok(out.error);
+    assert.notStrictEqual(out.error.code, SESSION_NOT_FOUND);
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes #830 — MCP connection from a remote client to a **cloud-deployed** unimatrix goes stale after ~5 min idle and requires a manual \`/mcp\` reconnect. Never reproduced on local STDIO.

## Root cause
The cloud transport serves MCP over rmcp Streamable-HTTP with \`LocalSessionManager\`, whose \`session_config.keep_alive\` defaults to **300s**. The server built it with \`::default()\` and never overrode it, so after ~5 min idle the session is evicted → the next call returns HTTP **404 "Session not found"**. The bridge captured the session id once on \`initialize\` and replayed it for the process lifetime with no re-init path, and \`dispatch.js\` collapsed the 404 into an opaque \`-32603\` — so every later call repeated the failure and the agent parked. The daemon stays up, which is why \`/mcp\` re-init recovers it without a restart.

## Fix (two complementary layers)
- **Layer A — server** (\`crates/unimatrix-server/src/http/router.rs\`): override \`LocalSessionManager.session_config.keep_alive\` to a **4h finite bound**. Removes the routine idle trigger. Finite (not \`None\`) to avoid zombie-session map growth.
- **Layer B — bridge** (\`packages/unimatrix/lib/hook-client/mcp-bridge/{dispatch.js,lifecycle.js}\`): on a 404 session-not-found, drop the cached session id, **re-initialize once** (preserving \`clientInfo.name\` → vnc-039 audit-attribution contract), and **retry the failed call exactly once**. Single-flight guard prevents re-init storms on concurrent 404s; re-init failure aborts (no loops); a 404 on \`initialize\` itself is fatal. Durable self-heal across evictions, redeploys, and infra idle cutoffs.

## Tests
- Rust: 2 new router tests asserting the keep_alive override lands on the correct field at a long finite bound.
- JS: 6 new bridge tests — 404 classification, re-init-once + retry success, no-loop on second failure, abort on re-init failure, single-flight on concurrent 404s, fatal-on-init-404.
- Full suite green: Rust workspace 6689/0, clippy clean, JS 741/0, integration smoke 24/24.

## Reviews
Diagnosis (v2), architecture design review (APPROVED WITH NOTES), and product review all on the issue. v1 diagnosis targeted the local STDIO bridge and was correctly rejected — the remote bug never traverses that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)