### PR TITLE
fix: arm transport/connect timeout + silent-eviction self-heal in HTTPS mcp-bridge (#839)

### DIFF
--- a/packages/unimatrix/lib/hook-client/mcp-bridge/dispatch.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/dispatch.js
@@ -15,9 +15,20 @@ const SESSION_NOT_FOUND = -32099;
 // timed out (#839). Heals through the same single-flight re-init as 404, then
 // normalizes to a generic error if exhausted — never reaches the client.
 const TRANSPORT_TIMEOUT = -32098;
+// Idle-read deadline (#839 F6): a connection that establishes, streams, then
+// stalls mid-frame bounds BYTES but not stall TIME. On expiry destroy + throw an
+// ETIMEDOUT-coded error so _send maps it to the SAME TRANSPORT_TIMEOUT sentinel
+// as the connect/request path (N1: routes the SSE branch into self-heal).
+const DEFAULT_READ_MS = 120000;
 
 function jsonRpcError(id, code, message) {
   return { jsonrpc: "2.0", id: id === undefined ? null : id, error: { code, message } };
+}
+
+// ETIMEDOUT-coded (mid-stream read stall) — same code as the connect/request
+// path, so lifecycle._send routes it into self-heal via TRANSPORT_TIMEOUT.
+function readTimedOut() {
+  return Object.assign(new Error("MCP endpoint timed out"), { code: "ETIMEDOUT" });
 }
 
 // Narrow 404 idle-eviction class (#830): 404 with a "session not found" body.
@@ -32,23 +43,32 @@ function httpStatusToJsonRpc(status, body) {
   return isSessionNotFound(status, body) ? SESSION_NOT_FOUND : INTERNAL_ERROR;
 }
 
-// Read a non-SSE body bounded at `limit`; destroy + return-what-we-have on excess.
-function readBounded(res, limit) {
-  return new Promise((resolve) => {
+// Read a non-SSE body bounded at `limit` bytes AND `readMs` idle-stall (#839 F6).
+// Byte overflow / end / error / close resolve with what we have; an idle-read
+// stall rejects ETIMEDOUT (the throw routes into self-heal via _send). The idle
+// timer resets per chunk.
+function readBounded(res, limit, readMs) {
+  return new Promise((resolve, reject) => {
     const chunks = [];
     let received = 0;
+    let t;
+    const stop = () => { if (t) { clearTimeout(t); t = null; } };
+    const arm = () => { stop(); t = setTimeout(() => { try { res.destroy(); } catch (_e) {} reject(readTimedOut()); }, readMs || DEFAULT_READ_MS); if (t.unref) t.unref(); };
+    const ok = () => { stop(); resolve(Buffer.concat(chunks)); };
+    arm();
     res.on("data", (c) => {
       if (received < limit) {
         chunks.push(c);
         received += c.length;
+        arm();
       } else {
         try { res.destroy(); } catch (_e) {}
-        resolve(Buffer.concat(chunks));
+        ok();
       }
     });
-    res.on("end", () => resolve(Buffer.concat(chunks)));
-    res.on("error", () => resolve(Buffer.concat(chunks)));
-    res.on("close", () => resolve(Buffer.concat(chunks)));
+    res.on("end", ok);
+    res.on("error", ok);
+    res.on("close", ok);
   });
 }
 
@@ -61,11 +81,12 @@ function idFromBody(buf) {
   }
 }
 
-// dispatchResponse({ status, contentType, res }) -> Promise<jsonRpcMessage[]>
-async function dispatchResponse({ status, contentType, res }) {
+// dispatchResponse({ status, contentType, res }, readMs?) -> Promise<jsonRpcMessage[]>
+// An idle-read stall in either branch rejects ETIMEDOUT (caught by _send -> heal).
+async function dispatchResponse({ status, contentType, res }, readMs) {
   const ct = contentType || "";
   if (ct.startsWith("application/json")) {
-    const body = await readBounded(res, BODY_LIMIT_BYTES);
+    const body = await readBounded(res, BODY_LIMIT_BYTES, readMs);
     if (status >= 400) {
       return [jsonRpcError(idFromBody(body), httpStatusToJsonRpc(status, body), "MCP endpoint returned HTTP " + status)];
     }
@@ -76,7 +97,7 @@ async function dispatchResponse({ status, contentType, res }) {
     }
   }
   if (ct.startsWith("text/event-stream")) {
-    const messages = await SseParser.collect(res, BODY_LIMIT_BYTES);
+    const messages = await SseParser.collect(res, BODY_LIMIT_BYTES, readMs);
     if (status >= 400 && messages.length === 0) {
       return [jsonRpcError(null, httpStatusToJsonRpc(status), "MCP endpoint returned HTTP " + status)];
     }
@@ -102,4 +123,5 @@ module.exports = {
   INTERNAL_ERROR,
   SESSION_NOT_FOUND,
   TRANSPORT_TIMEOUT,
+  DEFAULT_READ_MS,
 };

--- a/packages/unimatrix/lib/hook-client/mcp-bridge/dispatch.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/dispatch.js
@@ -11,6 +11,10 @@ const INTERNAL_ERROR = -32603;
 // 404 "session not found" so lifecycle.js can self-heal (#830, design-review C1).
 // Never reaches the client: lifecycle re-inits + retries before surfacing.
 const SESSION_NOT_FOUND = -32099;
+// Bridge-internal sentinel for a silent (hung-socket) eviction: the transport
+// timed out (#839). Heals through the same single-flight re-init as 404, then
+// normalizes to a generic error if exhausted — never reaches the client.
+const TRANSPORT_TIMEOUT = -32098;
 
 function jsonRpcError(id, code, message) {
   return { jsonrpc: "2.0", id: id === undefined ? null : id, error: { code, message } };
@@ -97,4 +101,5 @@ module.exports = {
   isSessionNotFound,
   INTERNAL_ERROR,
   SESSION_NOT_FOUND,
+  TRANSPORT_TIMEOUT,
 };

--- a/packages/unimatrix/lib/hook-client/mcp-bridge/http-session.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/http-session.js
@@ -12,18 +12,13 @@ const { applyCertPin, verifyPeerFingerprint } = require("../cert-pin.js");
 // rmcp 1.7.0 wire constants (OVERVIEW "VERIFIED WIRE VALUES"; CONFIRM LIVE).
 const SESSION_HEADER = "Mcp-Session-Id";
 const SESSION_HEADER_LC = "mcp-session-id";
-const ACCEPT_VALUE = "application/json, text/event-stream";
-const CONTENT_TYPE_REQUEST = "application/json";
 const BODY_LIMIT_BYTES = 1048576;
+// Generous defaults (ms) so slow-but-healthy calls (large embeddings) are never
+// aborted; the tighter connect/TLS-handshake deadline catches the half-open
+// socket (agent:false → secureConnect can hang; socket `timeout` misses it).
 
 function stripIPv6Brackets(h) {
   return h && h.startsWith("[") && h.endsWith("]") ? h.slice(1, -1) : h;
-}
-
-// Fail-loud exit on pin mismatch; token-free message (NFR-06).
-function failLoud(session, message) {
-  try { session.errOut("mcp-bridge: " + message + "\n"); } catch (_e) {}
-  session.exit(1);
 }
 
 class HttpSession {
@@ -31,7 +26,7 @@ class HttpSession {
     return new HttpSession(opts);
   }
 
-  constructor({ mcpUrl, token, pinnedFp, exit, errOut }) {
+  constructor({ mcpUrl, token, pinnedFp, exit, errOut, connectMs, idleMs }) {
     this.url = new URL(mcpUrl); // POSTed VERBATIM (AC-05)
     this.token = token;
     this.pinnedFp = pinnedFp;
@@ -40,13 +35,15 @@ class HttpSession {
     this.exit = exit || ((c) => process.exit(c));
     this.errOut = errOut || ((s) => process.stderr.write(s));
     this.requester = (o) => https.request(o); // injectable for tests
+    this.connectMs = connectMs || 15000;
+    this.idleMs = idleMs || 120000;
   }
 
   _headers(body, opts) {
     const headers = {
-      "Content-Type": CONTENT_TYPE_REQUEST,
+      "Content-Type": "application/json",
       "Content-Length": body.length,
-      Accept: ACCEPT_VALUE,
+      Accept: "application/json, text/event-stream",
       Authorization: "Bearer " + this.token,
     };
     if (this.sessionId !== null) headers[SESSION_HEADER] = this.sessionId;
@@ -66,6 +63,7 @@ class HttpSession {
         method,
         headers,
         agent: false, // no pool — fresh re-pinned socket per request (R-02)
+        timeout: this.idleMs, // idle on an established socket; emits "timeout" only
       },
       true,
       this.pinnedFp
@@ -75,9 +73,10 @@ class HttpSession {
   // Re-pin THIS socket on secureConnect, BEFORE any body byte. onPin() runs the
   // body flush (req.end) only on a match; mismatch → destroy + fail-loud. The
   // sole place req.end is reached — an unwritten request cannot leak the token.
-  _pinThenFlush(req, onPin, onMismatch) {
+  _pinThenFlush(req, onPin, onMismatch, onConnect) {
     req.on("socket", (s) => {
       s.once("secureConnect", () => {
+        if (onConnect) onConnect(); // clear the connect/TLS deadline (F4)
         let err;
         try {
           err = verifyPeerFingerprint(s, this.pinnedFp);
@@ -104,26 +103,39 @@ class HttpSession {
       }
       const req = this.requester(this._options("POST", this._headers(body, opts)));
       let flushed = false;
+      let settled = false; // single settle-guard (F3, vnc-039 C2 double-settle)
+      // ETIMEDOUT-coded so lifecycle.js maps it to "MCP endpoint timed out".
+      const kill = () => { try { req.destroy(Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })); } catch (_e) {} };
+      // Connect/TLS-handshake deadline (F4): armed before connect, cleared in
+      // secureConnect (clearCt) — covers the half-open-socket stall the socket
+      // `timeout` option does NOT. Idle (post-connect): Node emits "timeout".
+      const ct = setTimeout(kill, this.connectMs);
+      ct.unref();
+      const clearCt = () => clearTimeout(ct);
+      const settle = (fn, v) => { if (settled) return; settled = true; clearCt(); fn(v); };
+      req.on("timeout", kill);
       this._pinThenFlush(
         req,
         () => { flushed = true; req.end(body); }, // pin OK — flush Bearer body
-        (err) => {
-          // Production: failLoud exits non-zero. Tests inject a recording exit;
-          // settle the promise (token-free) so awaiting callers do not hang.
-          failLoud(this, err.message); // token-free expected-vs-presented
-          reject(err);
-        }
+        (err) => { // fail-loud exit on pin mismatch, token-free (NFR-06); settle under injected exit
+          try { this.errOut("mcp-bridge: " + err.message + "\n"); } catch (_e) {}
+          this.exit(1);
+          settle(reject, err);
+        },
+        clearCt
       );
       req.on("response", (res) => {
         if (opts && opts.isInitialize) {
           const sid = res.headers[SESSION_HEADER_LC];
           if (sid) this.sessionId = sid; // stable for process life (R-17)
         }
-        resolve({ status: res.statusCode, contentType: res.headers["content-type"] || "", res });
+        settle(resolve, { status: res.statusCode, contentType: res.headers["content-type"] || "", res });
       });
       req.on("error", (err) => {
-        if (!flushed && this.pinnedFp) return; // mismatch already exited loud
-        reject(err);
+        // Swallow the post-pin-mismatch destroy (no body byte written), BUT never
+        // swallow a timeout reject — gate on the error code, not `flushed` (F3).
+        if (!flushed && this.pinnedFp && err.code !== "ETIMEDOUT") return;
+        settle(reject, err);
       });
     });
   }
@@ -151,8 +163,5 @@ module.exports = {
   HttpSession,
   SESSION_HEADER,
   SESSION_HEADER_LC,
-  ACCEPT_VALUE,
-  CONTENT_TYPE_REQUEST,
   BODY_LIMIT_BYTES,
-  stripIPv6Brackets,
 };

--- a/packages/unimatrix/lib/hook-client/mcp-bridge/lifecycle.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/lifecycle.js
@@ -14,9 +14,11 @@
 // call EXACTLY ONCE. Single-flight: concurrent 404s share one re-init. Any other
 // error, a failed re-init, or a second 404 propagates — no storms, no loops.
 
-const { dispatchResponse, jsonRpcError, correlateById, INTERNAL_ERROR, SESSION_NOT_FOUND } = require("./dispatch.js");
+const { dispatchResponse, jsonRpcError, correlateById, INTERNAL_ERROR, SESSION_NOT_FOUND, TRANSPORT_TIMEOUT } = require("./dispatch.js");
 
 const CLIENT_INFO_NAME = "unimatrix-mcp-bridge"; // STABLE, fixed (FR-03a/AC-12)
+// Exhausted-heal normalization: an internal sentinel never reaches the client.
+const SENTINEL_TEXT = { [SESSION_NOT_FOUND]: "MCP session lost, re-init failed", [TRANSPORT_TIMEOUT]: "MCP endpoint timed out" };
 
 class Lifecycle {
   constructor(session, deps) {
@@ -51,9 +53,8 @@ class Lifecycle {
     if (!msg || msg.id == null) return null; // notification — no response
     const m = correlateById(out, msg.id) || out[0] || jsonRpcError(msg.id, INTERNAL_ERROR, "empty response");
     // A leaked sentinel (heal exhausted) is normalized — never reaches a client.
-    return m && m.error && m.error.code === SESSION_NOT_FOUND
-      ? jsonRpcError(msg.id, INTERNAL_ERROR, "MCP session lost, re-init failed")
-      : m;
+    const why = SENTINEL_TEXT[m && m.error && m.error.code];
+    return why ? jsonRpcError(msg.id, INTERNAL_ERROR, why) : m;
   }
 
   // One request + dispatch -> jsonRpcMessage[]. Transport-class failures (already
@@ -65,8 +66,10 @@ class Lifecycle {
       resp = await this.session.request(msg, { isInitialize: isInit });
     } catch (err) {
       const id = msg && msg.id != null ? msg.id : null;
-      const why = err && err.code === "ETIMEDOUT" ? "MCP endpoint timed out" : "MCP endpoint unreachable";
-      return [jsonRpcError(id, INTERNAL_ERROR, why)];
+      // A transport TIMEOUT gets a distinct sentinel so handle() can self-heal it
+      // like a 404 (#839 F2); any other transport fault is a terminal error.
+      if (err && err.code === "ETIMEDOUT") return [jsonRpcError(id, TRANSPORT_TIMEOUT, "MCP endpoint timed out")];
+      return [jsonRpcError(id, INTERNAL_ERROR, "MCP endpoint unreachable")];
     }
     const out = await dispatchResponse(resp);
     if (isInit) {
@@ -98,17 +101,16 @@ class Lifecycle {
     this.session.sessionId = null; // discard the dead id before re-init
     await this._send(init, true); // protocolVersion re-captured inside
     const newId = this.session.sessionId;
-    if (newId == null || newId === prevId) return false; // no fresh session
-    this.errOut("mcp-bridge: re-init ok; new session\n");
-    return true;
+    return !(newId == null || newId === prevId); // fresh session id minted?
   }
 }
 
-// True when the SESSION_NOT_FOUND sentinel is the response for this id (#830).
-// `out` is always a message[] (dispatchResponse / _send both guarantee it).
+// True when a heal-triggering sentinel is the response for this id: a 404
+// eviction (#830) OR a transport timeout / silent eviction (#839) — ONLY the two
+// SENTINEL_TEXT keys, never auth/5xx (avoids re-init storms). `out` is message[].
 function lostId(out, id) {
   const m = correlateById(out, id) || out[0];
-  return !!(m && m.error && m.error.code === SESSION_NOT_FOUND);
+  return !!(m && m.error && m.error.code in SENTINEL_TEXT);
 }
 
 module.exports = { Lifecycle, CLIENT_INFO_NAME };

--- a/packages/unimatrix/lib/hook-client/mcp-bridge/lifecycle.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/lifecycle.js
@@ -61,9 +61,14 @@ class Lifecycle {
   // exited loud if pin-class) become a per-request JSON-RPC error array; they are
   // never SESSION_NOT_FOUND, so they neither trigger nor satisfy self-heal.
   async _send(msg, isInit) {
-    let resp;
+    let out;
     try {
-      resp = await this.session.request(msg, { isInitialize: isInit });
+      const resp = await this.session.request(msg, { isInitialize: isInit });
+      // N1 (#839): dispatchResponse reads the body; an idle-read stall mid-stream
+      // (SSE or JSON) rejects ETIMEDOUT. Keep it INSIDE the try so the mid-stream
+      // timeout routes into the SAME TRANSPORT_TIMEOUT self-heal as the connect
+      // path — the SSE branch reaches parity with the connect/request branch.
+      out = await dispatchResponse(resp, this.session.idleMs);
     } catch (err) {
       const id = msg && msg.id != null ? msg.id : null;
       // A transport TIMEOUT gets a distinct sentinel so handle() can self-heal it
@@ -71,7 +76,6 @@ class Lifecycle {
       if (err && err.code === "ETIMEDOUT") return [jsonRpcError(id, TRANSPORT_TIMEOUT, "MCP endpoint timed out")];
       return [jsonRpcError(id, INTERNAL_ERROR, "MCP endpoint unreachable")];
     }
-    const out = await dispatchResponse(resp);
     if (isInit) {
       // Capture the negotiated protocolVersion for the MCP-Protocol-Version echo.
       for (const m of out) {

--- a/packages/unimatrix/lib/hook-client/mcp-bridge/sse-parse.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/sse-parse.js
@@ -5,27 +5,43 @@
 // event. Multi-line data: joins with "\n"; blank line = record boundary; ":"
 // lines = keep-alive. Chunk-split-invariant (records emit only on terminator).
 
+// Local copy (avoids a dispatch<->sse-parse require cycle). Generous default;
+// the caller threads its configured idle budget.
+const DEFAULT_READ_MS = 120000;
+
 class SseParser {
-  // Collect every JSON-RPC object carried by data: events. Bounded at `limit`.
-  static async collect(res, limit) {
+  // Collect every JSON-RPC object carried by data: events. Bounded at `limit`
+  // bytes AND `readMs` idle-stall (#839 F6): a connect-then-stall-mid-stream
+  // bounds bytes but not stall time. On idle expiry the stream is destroyed with
+  // an ETIMEDOUT-coded error; the for-await rethrows it so _send maps it to the
+  // SAME TRANSPORT_TIMEOUT sentinel as the connect/request path (N1 -> self-heal).
+  static async collect(res, limit, readMs) {
     const messages = [];
     let buffer = "";
     let total = 0;
-    for await (const chunk of res) {
-      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      total += buf.length;
-      buffer += buf.toString("utf8");
-      buffer = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
-      let sep;
-      while ((sep = buffer.indexOf("\n\n")) !== -1) {
-        const record = buffer.slice(0, sep);
-        buffer = buffer.slice(sep + 2);
-        SseParser._emit(record, messages);
+    let t;
+    const arm = () => { if (t) clearTimeout(t); t = setTimeout(() => { try { res.destroy(Object.assign(new Error("MCP endpoint timed out"), { code: "ETIMEDOUT" })); } catch (_e) {} }, readMs || DEFAULT_READ_MS); if (t.unref) t.unref(); };
+    arm();
+    try {
+      for await (const chunk of res) {
+        arm();
+        const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        total += buf.length;
+        buffer += buf.toString("utf8");
+        buffer = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+        let sep;
+        while ((sep = buffer.indexOf("\n\n")) !== -1) {
+          const record = buffer.slice(0, sep);
+          buffer = buffer.slice(sep + 2);
+          SseParser._emit(record, messages);
+        }
+        if (total > limit) {
+          try { res.destroy(); } catch (_e) {}
+          break;
+        }
       }
-      if (total > limit) {
-        try { res.destroy(); } catch (_e) {}
-        break;
-      }
+    } finally {
+      if (t) clearTimeout(t);
     }
     // Flush a trailing record with no terminating blank line.
     if (buffer.trim() !== "") SseParser._emit(buffer, messages);

--- a/packages/unimatrix/test/check-hook-client-size.js
+++ b/packages/unimatrix/test/check-hook-client-size.js
@@ -31,7 +31,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const PRIMARY_LIMIT = 101000; // comment-stripped bytes (decimal) — TEMP raise 100000→101000 for #839 critical availability fix (transport/connect timeout + silent-eviction self-heal): irreducible +579 stripped after ~1420B in-bridge reclaim + F6 deferral. Reclaim to 100000 tracked in #840; F6 in #841. Human-approved, recorded on #839.
+const PRIMARY_LIMIT = 102000; // comment-stripped bytes (decimal) — TEMP raise 100000→102000 for the COMPLETE #839 critical availability fix (transport/connect timeout + silent-eviction self-heal + F6 mid-stream idle-read deadline + SSE-timeout heal routing): stripped 101483 after ~1420B in-bridge reclaim. Reclaim to 100000 tracked in #840. Human-approved, recorded on #839.
 const BACKSTOP_LIMIT = 180000; // raw bytes (decimal) — raised 160000→180000 for the vnc-039 stdio→HTTPS MCP bridge (~24KB new pure-JS); PRIMARY/stripped budget still passes. Human-approved, recorded on #775.
 const ROOT = path.resolve(__dirname, "..", "lib", "hook-client");
 

--- a/packages/unimatrix/test/check-hook-client-size.js
+++ b/packages/unimatrix/test/check-hook-client-size.js
@@ -31,7 +31,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const PRIMARY_LIMIT = 100000; // comment-stripped bytes (decimal)
+const PRIMARY_LIMIT = 101000; // comment-stripped bytes (decimal) — TEMP raise 100000→101000 for #839 critical availability fix (transport/connect timeout + silent-eviction self-heal): irreducible +579 stripped after ~1420B in-bridge reclaim + F6 deferral. Reclaim to 100000 tracked in #840; F6 in #841. Human-approved, recorded on #839.
 const BACKSTOP_LIMIT = 180000; // raw bytes (decimal) — raised 160000→180000 for the vnc-039 stdio→HTTPS MCP bridge (~24KB new pure-JS); PRIMARY/stripped budget still passes. Human-approved, recorded on #775.
 const ROOT = path.resolve(__dirname, "..", "lib", "hook-client");
 

--- a/packages/unimatrix/test/hook-client/mcp-bridge.test.js
+++ b/packages/unimatrix/test/hook-client/mcp-bridge.test.js
@@ -13,6 +13,8 @@ const fs = require("fs");
 const os = require("os");
 const path = require("path");
 
+const http = require("http");
+const { startSilentTcpServer } = require("../helpers/stub-server.js");
 const { StdioFramer } = require("../../lib/hook-client/mcp-bridge/stdio-frame.js");
 const { SseParser } = require("../../lib/hook-client/mcp-bridge/sse-parse.js");
 const { dispatchResponse, correlateById, isSessionNotFound, SESSION_NOT_FOUND } = require("../../lib/hook-client/mcp-bridge/dispatch.js");
@@ -524,6 +526,128 @@ describe("session self-heal on 404 (#830)", () => {
     assert.strictEqual(sess.initCount, 1, "no re-init triggered for a 404 on initialize");
     assert.ok(out.error);
     assert.notStrictEqual(out.error.code, SESSION_NOT_FOUND);
+  });
+});
+
+// ── transport timeout + silent-eviction self-heal (#839) ─────────────────────
+
+describe("transport timeout self-heal (#839)", () => {
+  // (a) Connect/TLS-handshake stall fails fast within the configured deadline,
+  // not forever. TLS-stall trick (#4768): an https-shaped request to a silent
+  // plain-TCP listener connects but secureConnect never fires, so the connect
+  // timer is the only thing that can settle the Promise.
+  it("test_timeout_connectStall_failsFastWithinDeadline", async () => {
+    const silent = await startSilentTcpServer();
+    try {
+      const s = HttpSession.create({
+        mcpUrl: "https://127.0.0.1:" + silent.port + "/v1/slug",
+        token: "TKN", pinnedFp: "sha256:" + "a".repeat(64),
+        connectMs: 80, idleMs: 5000,
+      });
+      // Real socket to the silent listener; secureConnect never fires.
+      s.requester = (opts) => http.request({ host: "127.0.0.1", port: silent.port, method: opts.method });
+      const t0 = Date.now();
+      await assert.rejects(
+        s.request({ method: "tools/call", id: 1 }, {}),
+        (e) => e && e.code === "ETIMEDOUT"
+      );
+      assert.ok(Date.now() - t0 < 4000, "settled near the 80ms deadline, not at test-runner timeout");
+    } finally {
+      await silent.close();
+    }
+  });
+
+  // _send maps an ETIMEDOUT throw to the distinct TRANSPORT_TIMEOUT sentinel so
+  // handle() can heal it (F2) — and normalizes it on the surface (never leaks).
+  it("test_timeout_mapsToTransportTimeoutSentinel_normalizedOnExhaustion", async () => {
+    // No initialize captured -> heal cannot fire -> sentinel must be normalized.
+    const sess = { sent: [], sessionId: null, protocolVersion: null,
+      request: () => Promise.reject(Object.assign(new Error("x"), { code: "ETIMEDOUT" })) };
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    const out = await lc.handle({ jsonrpc: "2.0", id: 7, method: "tools/call", params: {} });
+    assert.strictEqual(out.id, 7);
+    assert.ok(out.error);
+    assert.notStrictEqual(out.error.code, -32098, "internal TRANSPORT_TIMEOUT sentinel never reaches client");
+    assert.match(out.error.message, /timed out/);
+  });
+
+  // (b) A transport timeout on the first call triggers EXACTLY ONE transparent
+  // re-init through the existing single-flight; the retry under the new session
+  // succeeds. The re-init POST shares request(), so it cannot re-hang.
+  it("test_timeout_singleTransparentReinitThenSuccess", async () => {
+    let initCount = 0, firstCall = true;
+    const sess = {
+      sent: [], sessionId: null, protocolVersion: null,
+      request(body, opts) {
+        sess.sent.push({ opts });
+        if (opts && opts.isInitialize) {
+          initCount += 1; sess.sessionId = "SID-" + initCount;
+          return Promise.resolve({ status: 200, contentType: "application/json",
+            res: bodyStream(Buffer.from(JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocolVersion: "2025-06-18" } }))) });
+        }
+        if (firstCall) { firstCall = false; return Promise.reject(Object.assign(new Error("stall"), { code: "ETIMEDOUT" })); }
+        return Promise.resolve({ status: 200, contentType: "application/json",
+          res: bodyStream(Buffer.from(JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { ok: true } }))) });
+      },
+    };
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize" });
+    assert.strictEqual(initCount, 1);
+    const out = await lc.handle({ jsonrpc: "2.0", id: 9, method: "tools/call", params: {} });
+    assert.deepStrictEqual(out.result, { ok: true }, "retry succeeded after one re-init");
+    assert.strictEqual(initCount, 2, "exactly one transparent re-init on a transport timeout");
+  });
+
+  // (c) When the re-init ALSO times out, surface a bounded error with no loop:
+  // request() bounds the re-init POST (same timeout), newId stays null -> false.
+  it("test_timeout_reinitAlsoStalls_boundedError_noLoop", async () => {
+    let initCount = 0;
+    const sess = {
+      sent: [], sessionId: "OLD", protocolVersion: null,
+      request(body, opts) {
+        sess.sent.push({ opts });
+        if (opts && opts.isInitialize) {
+          initCount += 1;
+          if (initCount === 1) { // first handshake ok
+            sess.sessionId = "SID-1";
+            return Promise.resolve({ status: 200, contentType: "application/json",
+              res: bodyStream(Buffer.from(JSON.stringify({ jsonrpc: "2.0", id: body.id, result: {} }))) });
+          }
+          return Promise.reject(Object.assign(new Error("stall"), { code: "ETIMEDOUT" })); // re-init stalls
+        }
+        return Promise.reject(Object.assign(new Error("stall"), { code: "ETIMEDOUT" })); // call stalls
+      },
+    };
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize" });
+    const out = await lc.handle({ jsonrpc: "2.0", id: 13, method: "tools/call", params: {} });
+    assert.strictEqual(out.id, 13);
+    assert.ok(out.error, "bounded error surfaced");
+    assert.notStrictEqual(out.error.code, -32098, "sentinel normalized, never leaked");
+    assert.strictEqual(initCount, 2, "exactly one re-init attempt; no loop/storm");
+  });
+
+  // The widened heal trigger is NARROW: it must NOT fire on auth/5xx errors.
+  it("test_timeout_doesNotHealOnGenericTransportError", async () => {
+    let initCount = 0, calls = 0;
+    const sess = {
+      sent: [], sessionId: null, protocolVersion: null,
+      request(body, opts) {
+        if (opts && opts.isInitialize) {
+          initCount += 1; sess.sessionId = "SID-1";
+          return Promise.resolve({ status: 200, contentType: "application/json",
+            res: bodyStream(Buffer.from(JSON.stringify({ jsonrpc: "2.0", id: body.id, result: {} }))) });
+        }
+        calls += 1;
+        return Promise.reject(Object.assign(new Error("refused"), { code: "ECONNREFUSED" }));
+      },
+    };
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize" });
+    const out = await lc.handle({ jsonrpc: "2.0", id: 5, method: "tools/call", params: {} });
+    assert.ok(out.error);
+    assert.strictEqual(initCount, 1, "no re-init on a non-timeout transport fault (no storm)");
+    assert.strictEqual(calls, 1, "the call was not retried");
   });
 });
 

--- a/packages/unimatrix/test/hook-client/mcp-bridge.test.js
+++ b/packages/unimatrix/test/hook-client/mcp-bridge.test.js
@@ -649,6 +649,96 @@ describe("transport timeout self-heal (#839)", () => {
     assert.strictEqual(initCount, 1, "no re-init on a non-timeout transport fault (no storm)");
     assert.strictEqual(calls, 1, "the call was not retried");
   });
+
+  // ── mid-stream stall (F6 + N1): connect ok, stream starts, then stalls ──────
+  // An SSE response that yields a priming chunk then HANGS mid-frame (no end),
+  // exactly like a server that accepts + starts streaming then goes silent. The
+  // for-await rethrows whatever res.destroy(err) is called with (mirrors Node), so
+  // the idle-read deadline in SseParser.collect routes ETIMEDOUT into _send.
+  function stallingSse(primer) {
+    const r = new EventEmitter();
+    let onKill;
+    const killed = new Promise((res) => { onKill = res; });
+    r.destroy = (err) => onKill(err || new Error("destroyed"));
+    r.resume = () => {};
+    r[Symbol.asyncIterator] = async function* () {
+      yield Buffer.from(primer); // priming event arrives, then the stream stalls
+      throw await killed; // resolves only when collect's idle timer destroys us
+    };
+    r.on = EventEmitter.prototype.on.bind(r);
+    return r;
+  }
+  function sseStall() {
+    return { status: 200, contentType: "text/event-stream", res: stallingSse(": keep-alive\n\n") };
+  }
+
+  // (d) Mid-stream stall is BOUNDED by the idle-read deadline, not forever.
+  it("test_timeout_midStreamStall_boundedByIdleReadDeadline", async () => {
+    // No initialize captured -> heal cannot fire -> sentinel normalized; the call
+    // must still SETTLE (within the 60ms idle budget), not hang to runner-timeout.
+    const sess = { sent: [], sessionId: null, protocolVersion: null, idleMs: 60,
+      request: () => Promise.resolve(sseStall()) };
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    const t0 = Date.now();
+    const out = await lc.handle({ jsonrpc: "2.0", id: 7, method: "tools/call", params: {} });
+    assert.ok(Date.now() - t0 < 4000, "settled near the 60ms idle deadline, not forever");
+    assert.strictEqual(out.id, 7);
+    assert.ok(out.error);
+    assert.notStrictEqual(out.error.code, -32098, "TRANSPORT_TIMEOUT sentinel normalized, never leaked");
+    assert.match(out.error.message, /timed out/);
+  });
+
+  // (e) Mid-stream timeout -> EXACTLY ONE transparent re-init then success
+  // (parity with the connect-stall case; the re-init reply is a clean JSON 200).
+  it("test_timeout_midStreamStall_singleReinitThenSuccess", async () => {
+    let initCount = 0, firstCall = true;
+    const sess = {
+      sent: [], sessionId: null, protocolVersion: null, idleMs: 60,
+      request(body, opts) {
+        if (opts && opts.isInitialize) {
+          initCount += 1; sess.sessionId = "SID-" + initCount;
+          return Promise.resolve({ status: 200, contentType: "application/json",
+            res: bodyStream(Buffer.from(JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { protocolVersion: "2025-06-18" } }))) });
+        }
+        if (firstCall) { firstCall = false; return Promise.resolve(sseStall()); } // mid-stream stall
+        return Promise.resolve({ status: 200, contentType: "application/json",
+          res: bodyStream(Buffer.from(JSON.stringify({ jsonrpc: "2.0", id: body.id, result: { ok: true } }))) });
+      },
+    };
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize" });
+    assert.strictEqual(initCount, 1);
+    const out = await lc.handle({ jsonrpc: "2.0", id: 9, method: "tools/call", params: {} });
+    assert.deepStrictEqual(out.result, { ok: true }, "retry succeeded after one re-init");
+    assert.strictEqual(initCount, 2, "exactly one transparent re-init on a mid-stream timeout");
+  });
+
+  // (f) Mid-stream re-init that ALSO stalls -> bounded error, no loop/storm.
+  it("test_timeout_midStreamReinitAlsoStalls_boundedError_noLoop", async () => {
+    let initCount = 0;
+    const sess = {
+      sent: [], sessionId: "OLD", protocolVersion: null, idleMs: 60,
+      request(body, opts) {
+        if (opts && opts.isInitialize) {
+          initCount += 1;
+          if (initCount === 1) { // first handshake ok (clean JSON)
+            sess.sessionId = "SID-1";
+            return Promise.resolve({ status: 200, contentType: "application/json",
+              res: bodyStream(Buffer.from(JSON.stringify({ jsonrpc: "2.0", id: body.id, result: {} }))) });
+          }
+          return Promise.resolve(sseStall()); // re-init's read stalls mid-stream
+        }
+        return Promise.resolve(sseStall()); // call's read stalls mid-stream
+      },
+    };
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize" });
+    const out = await lc.handle({ jsonrpc: "2.0", id: 13, method: "tools/call", params: {} });
+    assert.strictEqual(out.id, 13);
+    assert.ok(out.error, "bounded error surfaced");
+    assert.notStrictEqual(out.error.code, -32098, "sentinel normalized, never leaked");
+    assert.strictEqual(initCount, 2, "exactly one re-init attempt; no loop/storm");
+  });
 });
 
 // ── identity across spawns/projects (R-17) ───────────────────────────────────

--- a/packages/unimatrix/test/hook-client/size-gate.test.js
+++ b/packages/unimatrix/test/hook-client/size-gate.test.js
@@ -259,11 +259,12 @@ describe("size-gate header", function () {
   });
 
   it("test_limits_are_decimal", function () {
-    // PRIMARY raised 100000→101000 (TEMP) for the #839 critical availability fix
-    // (transport/connect timeout + silent-eviction self-heal). Human-approved,
-    // recorded on #839; reclaim to 100000 tracked in #840. Keep this
-    // meta-assertion in lockstep with check-hook-client-size.js:34.
-    assert.strictEqual(PRIMARY_LIMIT, 101000);
+    // PRIMARY raised 100000→102000 (TEMP) for the COMPLETE #839 critical
+    // availability fix (transport/connect timeout + silent-eviction self-heal
+    // + F6 mid-stream idle-read deadline + SSE-timeout heal routing).
+    // Human-approved, recorded on #839; reclaim to 100000 tracked in #840.
+    // Keep this meta-assertion in lockstep with check-hook-client-size.js:34.
+    assert.strictEqual(PRIMARY_LIMIT, 102000);
     // BACKSTOP raised 160000→180000 for the vnc-039 stdio→HTTPS MCP bridge
     // (~24KB new pure-JS); human-approved, recorded on #775. Keep this
     // meta-assertion in lockstep with check-hook-client-size.js:35.

--- a/packages/unimatrix/test/hook-client/size-gate.test.js
+++ b/packages/unimatrix/test/hook-client/size-gate.test.js
@@ -259,7 +259,11 @@ describe("size-gate header", function () {
   });
 
   it("test_limits_are_decimal", function () {
-    assert.strictEqual(PRIMARY_LIMIT, 100000);
+    // PRIMARY raised 100000→101000 (TEMP) for the #839 critical availability fix
+    // (transport/connect timeout + silent-eviction self-heal). Human-approved,
+    // recorded on #839; reclaim to 100000 tracked in #840. Keep this
+    // meta-assertion in lockstep with check-hook-client-size.js:34.
+    assert.strictEqual(PRIMARY_LIMIT, 101000);
     // BACKSTOP raised 160000→180000 for the vnc-039 stdio→HTTPS MCP bridge
     // (~24KB new pure-JS); human-approved, recorded on #775. Keep this
     // meta-assertion in lockstep with check-hook-client-size.js:35.


### PR DESCRIPTION
## Summary
Fixes #839 — the first MCP call after long client dormancy hung **forever** on a half-open socket. The HTTPS mcp-bridge armed no transport timeout, so the request Promise never settled and #830's self-heal (gated only on a 404 `SESSION_NOT_FOUND`) was unreachable on a silently-evicted/hung socket. This delivers the **complete** fix (connect/idle/request timeout + self-heal routing + mid-stream idle-read).

## Root cause (3 aligned gaps)
1. `http-session.js:request()` built options with no `timeout` and wired only response/error handlers → half-open socket never settles the Promise → `lifecycle.js` await blocks forever (TLS `secureConnect` with `agent:false` also had no deadline).
2. Self-heal fired only on the 404 `SESSION_NOT_FOUND` sentinel → a hung socket returns nothing → re-init branch dead.
3. `lifecycle.js` already mapped `ETIMEDOUT` → "MCP endpoint timed out" but nothing armed a timeout.

## Fix
- Arm a **request + connect/TLS-handshake timeout** that destroys the socket with `ETIMEDOUT` (Node does not auto-destroy on the `timeout` option); deadlines configurable + generous (15s connect / 120s idle) so slow-but-healthy calls are never aborted.
- Emit a distinct **`TRANSPORT_TIMEOUT` (-32098)** sentinel and widen the self-heal predicate to `{404, transport-timeout}` **only**, routed through the existing **single-flight `_reinit`** (one attempt, normalize-on-exhaustion).
- **Double-settle guard** (vnc-039) — timeout reject gates on settled-state/error-code, not the `flushed` flag.
- **F6 — mid-stream idle-read deadline:** per-chunk-reset idle deadline in `readBounded` (`dispatch.js`) and `SseParser.collect` (`sse-parse.js`), destroying the stream with `ETIMEDOUT`. `_send` now reads the body **inside** its try/catch, so an SSE/JSON mid-stream timeout maps to `TRANSPORT_TIMEOUT` and routes into the same single self-heal (closes the connect-then-stall-mid-stream variant + the security N1 finding). **Supersedes follow-up #841.**

## Tests
- "transport timeout self-heal (#839)" block: **8 tests** — connect-stall fail-fast; timeout → exactly one transparent re-init then success; re-init that also stalls → bounded error, no loop; generic transport error does NOT heal; **+3 mid-stream**: `midStreamStall_boundedByIdleReadDeadline`, `midStreamStall_singleReinitThenSuccess`, `midStreamReinitAlsoStalls_boundedError_noLoop`.
- #830 clean-404 self-heal regression block (4) retained and green.
- Verified: full hook-client **762/0/1**, integration smoke **24/24**, HTTPS-UDS parity **12/12**, lifecycle/protocol green, `cargo build` OK. JS/TS-only diff (no Rust).

## Size cap (#840)
The complete fix is **101483** stripped bytes vs the 100,000-byte hook-client primary cap. Per the cap-change rule (human decision recorded on #839), `PRIMARY_LIMIT` was raised **100000→102000** to land the full fix in one issue. Reclaiming back to 100000 is tracked in **#840**. (Raw backstop now tight at 179818/180000.)

Closes #839. Supersedes #841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)