### PR TITLE
fix: ref F6 idle-read deadline timers so they fire in an idle loop (#847)

### DIFF
--- a/packages/unimatrix/lib/hook-client/mcp-bridge/dispatch.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/dispatch.js
@@ -53,7 +53,8 @@ function readBounded(res, limit, readMs) {
     let received = 0;
     let t;
     const stop = () => { if (t) { clearTimeout(t); t = null; } };
-    const arm = () => { stop(); t = setTimeout(() => { try { res.destroy(); } catch (_e) {} reject(readTimedOut()); }, readMs || DEFAULT_READ_MS); if (t.unref) t.unref(); };
+    // Kept REF'd (#847): load-bearing idle deadline; cleared on every settle via stop().
+    const arm = () => { stop(); t = setTimeout(() => { try { res.destroy(); } catch (_e) {} reject(readTimedOut()); }, readMs || DEFAULT_READ_MS); };
     const ok = () => { stop(); resolve(Buffer.concat(chunks)); };
     arm();
     res.on("data", (c) => {

--- a/packages/unimatrix/lib/hook-client/mcp-bridge/sse-parse.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/sse-parse.js
@@ -20,7 +20,8 @@ class SseParser {
     let buffer = "";
     let total = 0;
     let t;
-    const arm = () => { if (t) clearTimeout(t); t = setTimeout(() => { try { res.destroy(Object.assign(new Error("MCP endpoint timed out"), { code: "ETIMEDOUT" })); } catch (_e) {} }, readMs || DEFAULT_READ_MS); if (t.unref) t.unref(); };
+    // Kept REF'd (#847): load-bearing idle deadline; cleared in the finally below.
+    const arm = () => { if (t) clearTimeout(t); t = setTimeout(() => { try { res.destroy(Object.assign(new Error("MCP endpoint timed out"), { code: "ETIMEDOUT" })); } catch (_e) {} }, readMs || DEFAULT_READ_MS); };
     arm();
     try {
       for await (const chunk of res) {

--- a/packages/unimatrix/test/hook-client/mcp-bridge.test.js
+++ b/packages/unimatrix/test/hook-client/mcp-bridge.test.js
@@ -17,7 +17,7 @@ const http = require("http");
 const { startSilentTcpServer } = require("../helpers/stub-server.js");
 const { StdioFramer } = require("../../lib/hook-client/mcp-bridge/stdio-frame.js");
 const { SseParser } = require("../../lib/hook-client/mcp-bridge/sse-parse.js");
-const { dispatchResponse, correlateById, isSessionNotFound, SESSION_NOT_FOUND } = require("../../lib/hook-client/mcp-bridge/dispatch.js");
+const { dispatchResponse, correlateById, isSessionNotFound, SESSION_NOT_FOUND, readBounded } = require("../../lib/hook-client/mcp-bridge/dispatch.js");
 const { Lifecycle, CLIENT_INFO_NAME } = require("../../lib/hook-client/mcp-bridge/lifecycle.js");
 const { HttpSession, SESSION_HEADER_LC } = require("../../lib/hook-client/mcp-bridge/http-session.js");
 const bridge = require("../../lib/hook-client/mcp-bridge.js");
@@ -738,6 +738,38 @@ describe("transport timeout self-heal (#839)", () => {
     assert.ok(out.error, "bounded error surfaced");
     assert.notStrictEqual(out.error.code, -32098, "sentinel normalized, never leaked");
     assert.strictEqual(initCount, 2, "exactly one re-init attempt; no loop/storm");
+  });
+
+  // ── F6 unref regression (#847): the idle-read deadline must be REF'd ─────────
+  // Exercise SseParser.collect AND readBounded DIRECTLY against a handle-free
+  // stall (stallingSse: a bare EventEmitter, no socket/timer/libuv handle) with
+  // NO other ref'd handle armed in the test — the F6 deadline is the sole liveness
+  // source. We must NOT add a competing keepalive timer here: a ref'd race timer
+  // would itself hold the loop open and mask an unref'd deadline. We bound the
+  // wall-clock with Date.now() instead. If either setTimeout is .unref()'d, the
+  // loop drains before the deadline on Node 18/20/22 and the awaited promise never
+  // settles -> the runner reports it unresolved (deterministic failure). REF'd, it
+  // fires and rejects within the tiny idle budget.
+  it("test_f6_sseCollect_idleDeadline_refd_settlesWithNoOtherHandle", async () => {
+    const t0 = Date.now();
+    await assert.rejects(
+      SseParser.collect(stallingSse(": keep-alive\n\n"), 1 << 20, 30),
+      /timed out/,
+      "collect's ref'd idle deadline must reject, not hang the idle loop"
+    );
+    assert.ok(Date.now() - t0 < 4000, "settled at the ~30ms idle deadline, not forever");
+  });
+
+  it("test_f6_readBounded_idleDeadline_refd_settlesWithNoOtherHandle", async () => {
+    // stallingSse never emits data/end/error/close, so readBounded's only settle
+    // path is its arm() deadline -> res.destroy() + reject(ETIMEDOUT).
+    const t0 = Date.now();
+    await assert.rejects(
+      readBounded(stallingSse(""), 1 << 20, 30),
+      (e) => e && e.code === "ETIMEDOUT",
+      "readBounded's ref'd idle deadline must reject, not hang the idle loop"
+    );
+    assert.ok(Date.now() - t0 < 4000, "settled at the ~30ms idle deadline, not forever");
   });
 });
 


### PR DESCRIPTION
Fixes #847.

## Root cause
The two F6 mid-stream idle-read deadline timers were `.unref()`'d:
- `dispatch.js` `readBounded` (line 56)
- `sse-parse.js` `SseParser.collect` (line 23)

An unref'd timer doesn't keep the libuv loop alive on its own. With a handle-free mock stream as the sole loop participant, the loop drains before the deadline, so the F6 deadline never fires on Node 18/20/22 (Node 24's test runner masks it) — the awaited timeout promise never settles, cascading `cancelledByParent` into sibling suites (R-17, R-13). This was red CI on PR #842 and blocks the v0.8.8 re-release.

## Fix
Remove `.unref()` from both load-bearing deadlines and mark them intentionally ref'd (Note A comments). Both timers are already cleared on every settle path (`readBounded` via `stop()`, `collect` via its `finally`), so a ref'd timer is only pending during an active read and never delays clean process exit. The connect deadline (`ct`) and teardown timer stay unref'd — a documented two-tier convention (load-bearing read deadlines ref'd, cleanup-grade timers unref'd).

**Runtime impact: test-only.** In production the stalled stream keeps a ref'd socket handle (so the unref'd timer still fired), and `http-session.js` independently bounds a mid-stream stall via its req timeout. The fix hardens the F6 guard to be self-sufficient rather than relying on those coincidences.

## Tests
- 2 new direct regression tests drive a handle-free stall with no competing ref'd handle and assert bounded settle — they fail deterministically if `.unref()` is re-added.
- Full Node suite: 1019 pass / 0 fail / 0 cancelled; the 3 previously-failing F6 mid-stream tests pass; no `cancelledByParent` cascade.
- Hook-client size cap green: stripped 101445/102000, raw 179944/180000.

## Merge gate
Local validation is Node 24 only, which **masks** this bug. The cross-platform `ci.yml` Node 18/20/22/24 × ubuntu/macos/windows matrix is the real gate — **do not merge on local single-Node green.** `release.yml` runs only Rust tests, so `ci.yml` is the sole gate for this class of failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
