### PR TITLE
fix: provision UDS-leg binary for nan-021 parity gate (#851)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,12 @@ env:
   ORT_VERSION: "1.20.1"
 
 jobs:
+  # NOTE: runs on BOTH tag-push and workflow_dispatch. The dispatch path is
+  # load-bearing for the nan-021-https-uds-parity gate, whose UDS leg spawns a
+  # live LOCAL daemon and needs this host-built `unimatrix-linux-x64` artifact
+  # (#851). The only other consumer, package-npm, stays dispatch-guarded, so
+  # producing the artifact on dispatch causes no extra publish.
   build-linux-x64:
-    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -571,10 +575,34 @@ jobs:
   # by release-gate-cloud-cycle-logic-test.sh (R-12) so this is not the first
   # place the gate logic runs.
   nan-021-https-uds-parity:
-    needs: [build-container-x64]
+    needs: [build-container-x64, build-linux-x64]
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+
+      # The UDS leg spawns a live LOCAL daemon (daemon_server fixture), which
+      # needs a HOST-compatible binary. Use the ubuntu-22.04-built artifact
+      # (glibc-compatible with this runner) — NOT a binary extracted from the
+      # bookworm/distroless image. Download to an absolute, working-directory-
+      # independent path (download-artifact's `path:` is repo-root relative and
+      # ignores the job-level working-directory) (#851, F2).
+      - name: Download host-built UDS-leg binary
+        uses: actions/download-artifact@v4
+        with:
+          name: unimatrix-linux-x64
+          path: ${{ github.workspace }}/bin
+
+      # chmod (upload-artifact drops the exec bit) + export UNIMATRIX_BINARY via
+      # $GITHUB_ENV so the pytest step's daemon_server/binary_version_preflight
+      # resolve it. Warm the embedding model up front (model-download) so the
+      # cold first-boot HF fetch does not blow the 15s daemon socket-bind
+      # deadline; ORT resolves via the co-located lib (RUNPATH $ORIGIN) (#851, F1).
+      - name: Provision UDS-leg binary and warm embedding model
+        run: |
+          set -euo pipefail
+          chmod +x "${{ github.workspace }}/bin/unimatrix"
+          echo "UNIMATRIX_BINARY=${{ github.workspace }}/bin/unimatrix" >> "$GITHUB_ENV"
+          "${{ github.workspace }}/bin/unimatrix" model-download
 
       - name: Provision pinned Node for the shipped mcp-bridge.js leg
         uses: actions/setup-node@v4

--- a/product/test/infra-001/scripts/release-gate-cloud-cycle-logic-test.sh
+++ b/product/test/infra-001/scripts/release-gate-cloud-cycle-logic-test.sh
@@ -491,6 +491,43 @@ test_c5_lane_resolves_image_via_shipped_lib() {
 }
 test_c5_lane_resolves_image_via_shipped_lib
 
+test_c5_lane_provisions_uds_leg_binary() {
+  # The parity gate is CROSS-TRANSPORT: the UDS leg spawns a live LOCAL daemon
+  # (daemon_server) that needs a HOST-compatible binary (#851). Assert the lane
+  # provisions it: (a) downloads the unimatrix-linux-x64 artifact, (b) exports
+  # UNIMATRIX_BINARY, (c) has build-linux-x64 in `needs:`, (f1) warms the model
+  # so the daemon binds within the 15s socket deadline. (d) below asserts the
+  # build job actually produces the artifact on dispatch — a `needs:` edge on a
+  # guarded-skipped job would SILENTLY SKIP the parity lane on workflow_dispatch.
+  local blk
+  blk="$(job_block nan-021-https-uds-parity)"
+  if printf '%s\n' "$blk" | grep -q 'download-artifact' \
+     && printf '%s\n' "$blk" | grep -q 'name: unimatrix-linux-x64' \
+     && printf '%s\n' "$blk" | grep -q 'UNIMATRIX_BINARY' \
+     && printf '%s\n' "$blk" | grep -q 'model-download' \
+     && printf '%s\n' "$blk" | grep -qE 'needs:.*build-linux-x64'; then
+    pass "test_c5_lane_provisions_uds_leg_binary (UDS-leg binary downloaded + UNIMATRIX_BINARY exported + model warmed + needs: build-linux-x64)"
+  else
+    oops "test_c5_lane_provisions_uds_leg_binary" "parity lane does not provision the UDS-leg binary (download unimatrix-linux-x64 + export UNIMATRIX_BINARY + model-download + needs: build-linux-x64)"
+  fi
+}
+test_c5_lane_provisions_uds_leg_binary
+
+test_c5_build_linux_x64_runs_on_dispatch() {
+  # (d) The artifact must EXIST on workflow_dispatch, not just tag-push. A job
+  # whose `needs:` dependency is guard-SKIPPED is itself skipped (not failed),
+  # so a dispatch-excluding `if:` on build-linux-x64 would silently dark the
+  # parity gate on dispatch (#851 / F3).
+  local blk
+  blk="$(job_block build-linux-x64)"
+  if printf '%s\n' "$blk" | grep -q "if: github.event_name != 'workflow_dispatch'"; then
+    oops "test_c5_build_linux_x64_runs_on_dispatch" "build-linux-x64 is dispatch-guarded -> parity lane silently skipped on workflow_dispatch"
+  else
+    pass "test_c5_build_linux_x64_runs_on_dispatch (build-linux-x64 produces the artifact on workflow_dispatch too)"
+  fi
+}
+test_c5_build_linux_x64_runs_on_dispatch
+
 echo
 echo "release-gate-cloud-cycle-logic-test: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
Fixes #851 — the `nan-021-https-uds-parity` gate in the Release workflow errored at pytest collection on every release run (`RuntimeError: Cannot find unimatrix binary`).

## Root cause
The gate is **cross-transport**, not pure-IMAGE. The HTTPS leg runs against the container image, but the **UDS leg spawns a live local daemon** via the `daemon_server` fixture, so a host-compatible local binary is a genuine requirement. The parity job's `needs:` only guaranteed the container image; the host-built `unimatrix-linux-x64` artifact (from `build-linux-x64`) was neither in `needs:` nor produced on `workflow_dispatch`, so `conftest._resolve_binary()` aborted at setup.

## Fix (full — both tag-push and workflow_dispatch)
- **`.github/workflows/release.yml`**
  - `nan-021-https-uds-parity`: add `build-linux-x64` to `needs:`; download `unimatrix-linux-x64` to `${{ github.workspace }}/bin`; `chmod +x`; export `UNIMATRIX_BINARY` via `$GITHUB_ENV`; `model-download` warm-up before pytest so the UDS daemon binds within the 15s deadline. ORT resolves via co-located lib (`RUNPATH $ORIGIN`).
  - `build-linux-x64`: relax the `workflow_dispatch`-excluding `if:` so the host artifact is produced on dispatch too. Manifest/npm/release/arm64 guards untouched.
- **`product/test/infra-001/scripts/release-gate-cloud-cycle-logic-test.sh`**: two new static assertions — `test_c5_lane_provisions_uds_leg_binary` and `test_c5_build_linux_x64_runs_on_dispatch`.

## Verification
- New static assertions: pre-fix FAIL (21/2) → post-fix PASS (23/0) — reproduces the gap, verifies the fix.
- `cargo test --workspace` rc=0; clippy clean; integration smoke 24 passed / 0 failed; release.yml parses.
- The live parity job cannot run locally (needs container image + runner artifact); the static gate test is the design-intended proxy.

## Scope / notes
Gate is non-blocking by design; this fix cannot break a real release (all manifest/publish edges untouched). Clears the binary-provisioning blocker — coordinate with the #849/#844 first-green sweep for any next sequenced failure.

Diagnosis, design review, product review, fix, test, and gate reports are on #851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
