### PR TITLE
fix(size-gate): reground hook-client caps to 110000/200000 (#840)

### DIFF
--- a/packages/unimatrix/test/check-hook-client-size.js
+++ b/packages/unimatrix/test/check-hook-client-size.js
@@ -1,12 +1,13 @@
 "use strict";
 
 // ============================================================================
-// C-04 hook-client size gate (vnc-027, ADR-005). Human decision 2026-06-08.
+// C-04 hook-client size gate (vnc-027, ADR-005). Caps regrounded per ass-086
+// (#840, #861), human decision 2026-06-28 (prior baseline 2026-06-08).
 // ----------------------------------------------------------------------------
 // Two independent limits over lib/hook-client/**/*.js (decimal bytes):
 //
-//   PRIMARY  : comment-stripped total <= 100,000 bytes
-//   BACKSTOP : raw (on-disk) total    <= 180,000 bytes
+//   PRIMARY  : comment-stripped total <= 110,000 bytes
+//   BACKSTOP : raw (on-disk) total    <= 200,000 bytes
 //
 // The PRIMARY limit measures shipped logic only — line and block comments are
 // removed before counting so the oracle-citation comment style this client
@@ -17,9 +18,34 @@
 // Either limit exceeded -> non-zero exit (fails CI). Both totals are always
 // printed so each limit is independently auditable.
 //
+// WHAT THE CAP IS (ass-086): a SOFT maintainability / hand-auditability
+// discipline with NO hard downstream binder. Load/parse latency (~16us/KB),
+// install footprint, and any hard byte limit are all ruled out — the client is
+// always spawned from disk BY PATH; its bytes are never inlined or transmitted.
+// The cap's job is to keep the client small enough to hand-review and to force
+// a human checkpoint when it grows — not to protect a physical ceiling. Framing
+// it as a physical limit is what produced the inherited, ungrounded 100,000 and
+// the reactive ratchet (#4780). This regrounding replaced that vnc-026 raw cap.
+//
+// HEADROOM-BUDGET GROWTH POLICY (ass-086): cap = measured baseline + a fixed
+// review margin of ~two modules (~10 KB stripped / ~20 KB raw). The two-module
+// margin is a deliberate widening of ass-086's one-module illustration: with no
+// hard binder, a slightly larger runway trades a low-stakes byte number for
+// fewer forced human re-touches between logic additions — friction reduction,
+// not silent-growth permission. The margin is review runway, NOT a license to
+// grow. Concretely:
+//   1. A raise is granted ONLY for new shipped LOGIC. NEVER for documentation
+//      (the stripped PRIMARY already absorbs docs) and NEVER for temporary
+//      scaffolding (that gets reclaimed — the #839 pattern).
+//   2. Each approved raise RESETS the baseline to the new measured size and
+//      re-adds one standard margin — the cap tracks real growth plus constant
+//      runway, never ratcheting on round numbers.
+//   3. The cap is reviewed at every release that touches lib/hook-client/.
+//
 // CAP-CHANGE RULE: any change to either limit is a HUMAN decision recorded on
-// the feature's GitHub issue. It is NEVER an agent adjustment — raising a cap
-// to make a failing gate pass is a vacuous pass and is forbidden.
+// the feature's GitHub issue, made BEFORE merge. It is NEVER an agent
+// adjustment — raising a cap to turn a failing gate green is a vacuous pass and
+// is forbidden.
 //
 // The comment stripper below is a dependency-free, string-literal-safe
 // character state machine with an embedded self-test corpus that runs on EVERY
@@ -31,8 +57,8 @@
 const fs = require("fs");
 const path = require("path");
 
-const PRIMARY_LIMIT = 102000; // comment-stripped bytes (decimal) — TEMP raise 100000→102000 for the COMPLETE #839 critical availability fix (transport/connect timeout + silent-eviction self-heal + F6 mid-stream idle-read deadline + SSE-timeout heal routing): stripped 101483 after ~1420B in-bridge reclaim. Reclaim to 100000 tracked in #840. Human-approved, recorded on #839.
-const BACKSTOP_LIMIT = 180000; // raw bytes (decimal) — raised 160000→180000 for the vnc-039 stdio→HTTPS MCP bridge (~24KB new pure-JS); PRIMARY/stripped budget still passes. Human-approved, recorded on #775.
+const PRIMARY_LIMIT = 110000; // comment-stripped bytes (decimal) — regrounded 102000→110000 per ass-086 (#840, #861): baseline (as-measured stripped 101,445; reclaim was moot — the #839 ~1.4KB was already banked, the remainder is live availability logic) + ~two-module review margin. NOT a reclaim-to-100000 (that is the #4780 round-number failure mode). Human-approved, recorded on #840.
+const BACKSTOP_LIMIT = 200000; // raw bytes (decimal) — regrounded 180000→200000 per ass-086 (#840, #861): baseline (as-measured raw 179,944) + ~two-module review margin; clears the prior 56B latent reactive-bump headroom. Human-approved, recorded on #840.
 const ROOT = path.resolve(__dirname, "..", "lib", "hook-client");
 
 // Lexer states.

--- a/packages/unimatrix/test/hook-client/size-gate.test.js
+++ b/packages/unimatrix/test/hook-client/size-gate.test.js
@@ -274,7 +274,8 @@ describe("size-gate header", function () {
     // review margin. Reclaim was moot (the #839 ~1.4KB was already banked; the
     // remainder is live availability logic) — this is a reground, not the
     // #4780 round-number trim. Human-approved, recorded on #840. Keep these
-    // meta-assertions in lockstep with check-hook-client-size.js:34/35.
+    // meta-assertions in lockstep with the PRIMARY_LIMIT / BACKSTOP_LIMIT
+    // constants in check-hook-client-size.js.
     assert.strictEqual(PRIMARY_LIMIT, 110000);
     assert.strictEqual(BACKSTOP_LIMIT, 200000);
   });

--- a/packages/unimatrix/test/hook-client/size-gate.test.js
+++ b/packages/unimatrix/test/hook-client/size-gate.test.js
@@ -166,7 +166,7 @@ describe("size-gate behavior", function () {
     assert.ok(log.some((m) => m.startsWith("OK:")));
   });
 
-  it("test_gate_fails_on_stripped_over_100000", function () {
+  it("test_gate_fails_on_stripped_over_primary_limit", function () {
     // Pure code (a string literal) over the primary limit; raw stays < backstop.
     const big = 'const s = "' + "a".repeat(PRIMARY_LIMIT + 50) + '";\n';
     const dir = makeTree({ "big.js": big });
@@ -178,7 +178,7 @@ describe("size-gate behavior", function () {
     assert.ok(log.some((m) => m.includes("big.js")));
   });
 
-  it("test_gate_fails_on_raw_over_160000", function () {
+  it("test_gate_fails_on_raw_over_backstop_limit", function () {
     // Comment-heavy: raw > backstop but stripped collapses well under primary.
     const heavy = "/*" + "a".repeat(BACKSTOP_LIMIT + 50) + "*/\nconst x = 1;\n";
     const dir = makeTree({ "heavy.js": heavy });
@@ -252,22 +252,30 @@ describe("size-gate behavior", function () {
 describe("size-gate header", function () {
   it("test_header_documents_human_decision_rule", function () {
     const src = fs.readFileSync(path.join(__dirname, "..", "check-hook-client-size.js"), "utf8");
-    assert.ok(src.includes("100,000"), "primary limit documented");
-    assert.ok(src.includes("180,000"), "backstop limit documented");
+    // Drift-hardening (#5312, #840): the header prose literal is DERIVED from
+    // the live constant rather than a hardcoded substring — changing a constant
+    // without updating the prose fails this test. Pin "en-US" so comma-grouping
+    // is deterministic across CI locales (110000 -> "110,000").
+    assert.ok(
+      src.includes(PRIMARY_LIMIT.toLocaleString("en-US")),
+      "primary limit documented (derived from PRIMARY_LIMIT)"
+    );
+    assert.ok(
+      src.includes(BACKSTOP_LIMIT.toLocaleString("en-US")),
+      "backstop limit documented (derived from BACKSTOP_LIMIT)"
+    );
     assert.ok(/HUMAN decision/.test(src), "cap-change is a human decision");
     assert.ok(/GitHub issue/.test(src), "recorded on the feature issue");
   });
 
   it("test_limits_are_decimal", function () {
-    // PRIMARY raised 100000→102000 (TEMP) for the COMPLETE #839 critical
-    // availability fix (transport/connect timeout + silent-eviction self-heal
-    // + F6 mid-stream idle-read deadline + SSE-timeout heal routing).
-    // Human-approved, recorded on #839; reclaim to 100000 tracked in #840.
-    // Keep this meta-assertion in lockstep with check-hook-client-size.js:34.
-    assert.strictEqual(PRIMARY_LIMIT, 102000);
-    // BACKSTOP raised 160000→180000 for the vnc-039 stdio→HTTPS MCP bridge
-    // (~24KB new pure-JS); human-approved, recorded on #775. Keep this
-    // meta-assertion in lockstep with check-hook-client-size.js:35.
-    assert.strictEqual(BACKSTOP_LIMIT, 180000);
+    // Caps regrounded 102000/180000 → 110000/200000 per ass-086 (#840, #861):
+    // baseline (as-measured stripped 101,445 / raw 179,944) + ~two-module
+    // review margin. Reclaim was moot (the #839 ~1.4KB was already banked; the
+    // remainder is live availability logic) — this is a reground, not the
+    // #4780 round-number trim. Human-approved, recorded on #840. Keep these
+    // meta-assertions in lockstep with check-hook-client-size.js:34/35.
+    assert.strictEqual(PRIMARY_LIMIT, 110000);
+    assert.strictEqual(BACKSTOP_LIMIT, 200000);
   });
 });

--- a/product/research/ass-086/FINDINGS.md
+++ b/product/research/ass-086/FINDINGS.md
@@ -1,0 +1,136 @@
+# FINDINGS: Ground the hook-client size threshold (constraint + measure + number + growth policy)
+
+**Spike**: ass-086
+**Date**: 2026-06-28
+**Approach**: investigation + quick targeted measurement (latency probe)
+**Confidence**: directional
+
+---
+
+## Findings
+
+### Q1: "What real constraint should the cap encode?" — rule each candidate in/out
+
+**Answer**: The binding constraint is **(c) maintainability + zero-dep hand-auditability discipline**. It is a **soft discipline with no hard downstream binder**. (a), (b), and (d) are ruled **out** with evidence below.
+
+**(a) load/parse latency per hook invocation — RULED OUT.**
+Evidence (latency probe, Node v24.16.0, 8-10 runs each, medians; see Q-latency for full table):
+- Bare `node -e ""` startup: ~11.7 ms.
+- `node` + `require()` of the full `index.js` graph (19 modules, ~149 KB): ~22.5 ms, i.e. **~10.8 ms over bare startup**.
+- Pure parse cost is byte-insensitive: synthetic single files of 50->100 KB add **0.3 ms**; 150 KB adds 1.5 ms; 300 KB adds 3.6 ms. Roughly **~16 us per added KB**.
+- The ~10.8 ms require delta is dominated by *module count and top-level work* (resolving 19 modules, compiling regexes, building tool schemas), **not raw bytes** — a synthetic 150 KB single file costs only ~1.5 ms to parse vs the real graph's 10.8 ms.
+Implication: doubling the client (~150 KB -> ~300 KB) would add **~2 ms** of parse — noise against the ~12 ms Node startup the client already pays per event, and against the network round-trip a hook event performs. Bytes do not move per-event latency. Latency cannot ground the cap.
+
+**(b) npm package / install footprint — RULED OUT (real but non-binding).**
+Evidence: `npm pack --dry-run` -> published tarball is **373 KB unpacked / 115 KB packed, 48 files**. The hook-client tree is ~180 KB raw (~half the JS tarball). The heavy install weight — the platform Rust binary + onnxruntime — ships in the **separate** `optionalDependencies` packages (`@dug-21/unimatrix-linux-x64`), not this tarball. So hook-client bytes are <1% of a full local install and ~half of a tiny JS-only install. Doubling the client adds ~90 KB packed — immaterial for an npm package. Footprint is real but nowhere near a binding threshold.
+
+**(c) maintainability + zero-dep hand-auditability — RULED IN (binding).**
+Evidence: the de-facto purpose, confirmed by origin. Lesson #4780: the cap exists because verbose oracle-citation JSDoc (each JS module is a line-for-line Rust parity port) drifted the client over budget — a *documentation/readability* pressure, not a physical one. ADR-005 (#4806) split the measure precisely to protect hand-readability: strip comments so docs don't compete with the logic budget. The companion `check-zero-deps.js` enforces the structural half (no runtime deps, every `require()` resolves to a built-in or relative path). The size cap is the **review-trigger half** of the same hand-auditability invariant: keep the client small enough to read and reason about, and force a human checkpoint when it grows.
+
+**(d) a hard downstream byte limit — RULED OUT. There is no hard downstream limit. Stated plainly: the client bytes are never inlined or transmitted; the client is always spawned from disk by path.**
+Evidence across the entire load/packaging path:
+- `lib/merge-settings.js` `buildHookClientCommand()` writes `node <path> <event>` into `settings.json` — the **absolute path**, never the bytes.
+- `lib/init.js:456` resolves the client via `require.resolve("./hook-client/index.js")` and writes the **path** into the hook command; the credential/bundle goes to an out-of-tree store, not the command line.
+- `bin/unimatrix.js:54` invokes the bridge via `require("../lib/hook-client/mcp-bridge.js")` and `.mcp.json` runs `node <bridge> <projectHash>` — by **path**.
+- `lib/hook-client/bundle.js` is a connection-token *decoder* (`decodeBundle`), **not** a packaging bundle; there is no build/minify/inline step (confirmed per SCOPE prior-art note).
+No env var, argv, transport frame, or inlined payload ever carries the client bytes. No argv/env length bound applies. Raw size is a soft concern only.
+
+**Recommendation**: Treat the cap explicitly as a **soft maintainability/auditability discipline with no hard binder**. Stop framing it (in headers, issues, or reclaim tasks) as if a physical limit is being protected — that framing is what produced the inherited, ungrounded `100,000` and the reactive ratchet.
+
+---
+
+### Q2: "Is the current measure still correct?"
+
+**Answer**: **Yes — keep comment-stripped PRIMARY + raw BACKSTOP, measured over the whole tree.** The measure is correctly aligned to the binding constraint even though the *number* was not. Do not switch to loaded-subset or raw-only.
+
+**Evidence / rationale (tied to the binding constraint):**
+- **Stripped vs raw**: a maintainability constraint cares about *shipped logic readability*, and wants documentation to grow freely. Comment-stripped PRIMARY is exactly that metric — it is the mechanism that fixed #4780 (oracle-citation comments no longer compete with code for budget). A raw-only measure would resurrect the #4780 failure (byte pressure punishing documentation). So stripping **still serves a real purpose** under the binding constraint; it is aligned, not orthogonal. Keep it as PRIMARY.
+- **Keep the raw BACKSTOP**: its job is anti-gaming / anti-miscount — a stripper bug can't admit unbounded files, and minified-style code can't game the stripped budget unnoticed. That role is independent of which constraint binds. Keep it.
+- **Whole-tree vs loaded-subset**: the loaded-subset denominator (the `index.js` require-closure, ~19 of 26 modules) would only matter if **latency** bound — and it does not (Q1). For an auditability constraint, **every shipped byte must be auditable, including the `mcp-bridge/` subtree** that loads only on the bridge subcommand. Switching to the require-closure would (1) stop gating the bridge bytes entirely and (2) couple the gate to fragile require-graph analysis. **Keep whole-tree.**
+
+**Recommendation**: Retain the dual stripped-PRIMARY / raw-BACKSTOP measure over `lib/hook-client/**/*.js`. The measure is right; only the numbers need regrounding.
+
+---
+
+### Q3: "What is the right, grounded number(s) + growth policy?"
+
+**Answer**: Because the constraint is soft, the number **cannot be derived from a physical ceiling** — and chasing a round physical-looking number (`100,000`) is the #4780 failure mode reborn. Ground it instead as a **headroom-budget**: `cap = deliberate baseline + a fixed review margin of ~one module`, paired with a growth policy that makes the margin a *review-scheduling device*, not a silent-growth allowance.
+
+**Derivation (shown):**
+- Current measured (2026-06-28): stripped **101,445 / 102,000** (555 B headroom); raw **179,944 / 180,000** (56 B headroom).
+- Module unit (the natural budget grain): 26 modules, raw total 179,944 -> **avg ~6,921 B raw / ~3,902 B stripped per module**; typical real modules span ~3-11 KB raw (`session-id.js` 2,672 ... `transport-http.js` 11,009). Take **one module of review margin ~= ~5 KB stripped / ~10 KB raw** (generous-typical).
+- **PRIMARY**: baseline = post-#840 stripped size (~=100,000 if the #839 temp scaffolding is genuinely recovered; <=101,445 otherwise) **+ ~5 KB review margin** -> **PRIMARY ~= 105,000 stripped**.
+- **BACKSTOP**: baseline = post-#840 raw size (~178,500) **+ ~10 KB review margin** -> **BACKSTOP ~= 190,000 raw**. This also restores real headroom: the current 56 B is itself a latent reactive-bump trigger (any addition trips it), so BACKSTOP must be regrounded too, not just PRIMARY. (Cross-check: the measured raw/stripped ratio is 179,944/101,445 = **1.77**; 190,000/105,000 = 1.81 — consistent with the tree's actual comment density plus margin.)
+
+**Recommended numbers**: **PRIMARY 105,000 stripped, BACKSTOP 190,000 raw.**
+
+**Growth policy (ends reactive bumping) — "headroom-budget with mandatory pre-merge re-budget":**
+1. The cap is `measured baseline + one module of margin (~5 KB stripped / ~10 KB raw)`. The margin is **runway, not permission to grow silently**.
+2. A raise is granted **only for new shipped LOGIC** (new behavior). It is **never** granted to accommodate documentation (the stripped measure already absorbs docs) and **never** to accommodate temporary scaffolding (that gets reclaimed — the #839 pattern).
+3. When a planned change would consume the margin, the author must either fit under the current cap **or** open the ADR-005 CAP-CHANGE RULE human review on the issue **before merging** — never a post-hoc raise to turn a red gate green (that remains a forbidden vacuous pass).
+4. Each approved raise **resets the baseline to the new measured size and re-adds exactly one module of margin** — so the cap tracks real growth plus constant runway and never ratchets on round numbers.
+5. The cap is *reviewed* (not necessarily changed) at every release that touches `lib/hook-client/`, making it a living budget.
+This gives the cap a defensible "no": the default answer to "just bump it" is no, because the policy names exactly what qualifies (new logic, human review, baseline reset). (Open Question 4 — yes, the budget is tied to a measurable unit: the per-module average, not a hand-picked byte count. External practice agrees directionally: `size-limit`/`bundlesize`-style budgets are an absolute byte ceiling + fixed margin + explicit human bump — the same headroom-budget shape.)
+
+---
+
+### Q4: "What should #840 actually do?"
+
+**Answer**: Re-derive, don't reset to 100,000. `100,000` does **not** stand.
+
+- **Reclaim target**: recover only the **genuinely temporary #839 in-bridge scaffolding** (the ~1.4 KB the #839 comment flagged as TEMP) **if and only if it is real waste**. Do **not** trim live documentation or live logic to chase a round number — that is the #4780 failure mode. If the #839 bytes turn out to be permanent availability logic, keep them and set the baseline accordingly.
+- **Which cap(s) to move**: **both.** PRIMARY 102,000 -> **105,000** (replaces the TEMP 102,000 with a grounded baseline+margin). BACKSTOP 180,000 -> **190,000** (the 56 B current headroom is a latent reactive-bump trigger; reground it now in the same change).
+- **Does `100,000` stand?** **No — re-derived to 105,000 (PRIMARY).** Lowering to 100,000 would force a documentation/logic reclaim fight to hit an inherited number that has no defensible basis and would get bumped again on the next addition.
+- **Lockstep meta-assertion updates #840 must make (Pattern #5312) — all in one change, or the standalone gate goes green while `node --test` fails:**
+  1. `test/check-hook-client-size.js:34` — `PRIMARY_LIMIT` constant -> new value.
+  2. `test/check-hook-client-size.js:35` — `BACKSTOP_LIMIT` constant -> new value.
+  3. `test/check-hook-client-size.js` header doc block (lines ~8-9) — the literals `100,000` / `180,000` in the prose. The header-doc test greps the source with `src.includes("100,000")` and `src.includes("180,000")`, so the narrative literals must change **and** the grep targets in the test must change together.
+  4. `test/hook-client/size-gate.test.js:267` — `assert.strictEqual(PRIMARY_LIMIT, 102000)` -> new value.
+  5. `test/hook-client/size-gate.test.js:271` — `assert.strictEqual(BACKSTOP_LIMIT, 180000)` -> new value.
+  6. `test/hook-client/size-gate.test.js:255-256` — `assert.ok(src.includes("100,000"))` / `assert.ok(src.includes("180,000"))` header-doc greps -> new literals.
+  (Per ADR-005 / #4806 CAP-CHANGE RULE: this is a **human decision recorded on #840**, with the rationale "regrounded as baseline+one-module margin per ass-086," not an agent adjustment.)
+
+---
+
+## Latency-probe result (AC-07)
+
+**Rule-out.** Load/parse latency is **not** a binding constraint and does not change with client size in any meaningful range.
+
+Node v24.16.0, medians (8-10 runs each):
+
+| Measurement | Median | Delta over bare startup |
+|---|---|---|
+| bare `node -e ""` | 11.7 ms | — |
+| `node` + `require(index.js)` graph (19 mods, ~149 KB) | 22.5 ms | +10.8 ms |
+| parse synthetic 50 KB single file | 12.0 ms | +0.3 ms |
+| parse synthetic 100 KB | 12.0 ms | +0.3 ms |
+| parse synthetic 150 KB | 13.2 ms | +1.5 ms |
+| parse synthetic 200 KB | 14.7 ms | +2.9 ms |
+| parse synthetic 300 KB | 15.3 ms | +3.6 ms |
+
+Takeaways: (1) raw parse is ~16 us/KB — a 2x client growth adds ~2 ms; (2) the require graph's 10.8 ms is module-count/top-level-work, not bytes (a 150 KB single file parses in 1.5 ms vs the graph's 10.8 ms); (3) per-event cost is dominated by the ~12 ms Node process spawn, which size does not touch. Confirms and refines the preliminary ~10-14 ms figure. (Probe script: `scratchpad/probe.js`.)
+
+---
+
+## Unanswered Questions
+
+- **Is the specific ~1.4 KB of #839 genuinely reclaimable temp scaffolding, or live availability logic?** Requires reading the #839 bridge diff in detail — that is #840's implementation work, not this directional spike. The recommendation is robust to either answer (baseline shifts; PRIMARY still lands ~105,000), but the exact reclaim target is #840's to confirm.
+- **Depth of external benchmarking.** Per SCOPE the external scan was light and policy-only; the growth policy was derived from internal module structure plus the directional `size-limit`/`bundlesize` shape, not a deep survey. A deeper comparison is available if wanted but is not load-bearing for directional confidence.
+
+---
+
+## Out-of-Scope Discoveries
+
+- **BACKSTOP is already at 56 B headroom — a latent reactive-bump independent of #840's stripped reclaim.** The next pure-JS addition (even comment-only) trips the raw gate regardless of the stripped budget. Folded into the Q3/Q4 recommendation (move BACKSTOP to 190,000), but flagged because it would otherwise force a *second* reactive bump right after #840. Why it matters: regrounding only PRIMARY leaves the same ratchet alive on the raw axis.
+- **Header-doc test is a substring grep, so the header narrative can silently drift from the live constant** (already noted in #5312). A test that asserts the header literal *equals* the active constant (rather than merely containing some `"100,000"` string) would close the drift. Candidate test-hardening item — not pursued here.
+- **Per-event cost is dominated by fresh-process spawn (~12 ms), not bytes.** If per-event hook latency ever becomes a real concern, the lever is the spawn model (process reuse / a resident bridge), not byte trimming. Carry-forward for any future latency work — do not attack it by shrinking the client.
+
+---
+
+## Recommendations Summary
+
+- **Q1 (constraint)**: Binding constraint is **(c) maintainability/hand-auditability — a soft discipline with no hard binder**; (a) latency, (b) footprint, (d) hard downstream limit all ruled out. The client is always spawned from disk by path; its bytes are never inlined or transmitted.
+- **Q2 (measure)**: **Keep** comment-stripped PRIMARY + raw BACKSTOP over the **whole tree**. The measure is correctly aligned to the maintainability constraint; do not switch to loaded-subset or raw-only.
+- **Q3 (number + policy)**: Reground as **headroom-budget**: PRIMARY **105,000 stripped**, BACKSTOP **190,000 raw** (baseline + ~one-module margin: ~5 KB stripped / ~10 KB raw). Growth policy: raises only for new *logic*, only via ADR-005 human review *before* merge, each raise resets baseline + re-adds one module of margin — ending reactive bumping.
+- **Q4 (#840)**: `100,000` does **not** stand — re-derive to **105,000**. Recover only genuine #839 temp waste (never trim live docs/logic to hit a number); move **both** caps; update all **six** lockstep sites (#5312) in one human-recorded change on #840.
+- **Latency probe**: **Ruled OUT** — ~16 us/KB parse; a 2x client adds ~2 ms; per-event cost is the ~12 ms Node spawn, size-independent.

--- a/product/research/ass-086/SCOPE.md
+++ b/product/research/ass-086/SCOPE.md
@@ -1,0 +1,232 @@
+# ass-086 — Ground the hook-client size threshold: what constraint should it encode, what is the right measure, and what is the right number(s) + growth policy (input to #840)
+
+## Problem Statement
+
+The hook-client size cap (`packages/unimatrix/test/check-hook-client-size.js`) is
+**ungrounded**. The measurement *mechanism* — comment-stripped PRIMARY + raw BACKSTOP via a
+dependency-free state-machine stripper (ADR-005, Unimatrix #4806) — is sound and well-audited:
+an embedded self-test corpus runs before every measurement and fails the gate closed on a
+stripper bug. But the *number* `100,000` was inherited verbatim from vnc-026's old raw cap
+(lesson #4780) and was **never tied to a real downstream constraint**.
+
+It has since been bumped reactively under release pressure:
+- PRIMARY: `100,000` → `101,000` (#839) → `102,000` (current file, `check-hook-client-size.js:34`)
+- BACKSTOP: `160,000` → `180,000` (#775, the vnc-039 stdio→HTTPS MCP bridge, ~24KB new pure-JS)
+
+The client is now pinned against **both** caps simultaneously (measured 2026-06-28):
+**stripped 101,445 / 102,000** (555 B headroom) and **raw 179,944 / 180,000** (56 B headroom).
+#840 wants to reclaim ~1.5 KB and lower PRIMARY back to `100,000` — but that just resets an
+ungrounded number that will get bumped again the next time the client grows. The pattern is a
+ratchet: a cap with no derivation has no defensible "no," so every increment wins.
+
+This spike grounds the cap in whatever it actually protects **before** #840 re-sets it, so the
+number #840 lands on is *derived*, not inherited, and arrives with a growth policy that ends the
+reactive bumping.
+
+## Goal
+
+Answer four questions:
+
+1. **What real constraint should the cap encode?** Rule each candidate in or out with evidence:
+   - (a) **load/parse latency per hook invocation** — the client is spawned as a fresh
+     `node .../lib/hook-client/index.js <EVENT>` process on every Claude Code hook event
+     (`lib/merge-settings.js` builds this command form; `lib/init.js:456` wires the path), so
+     parse cost is paid per event, not amortized.
+   - (b) **npm package / install footprint** — `lib/` ships in `package.json` `files`; the
+     hook-client is part of the published `@dug-21/unimatrix` tarball.
+   - (c) **maintainability + zero-dep hand-auditability discipline** — the current de-facto
+     purpose; the client must stay hand-readable and is separately gated zero-dependency
+     (`check-zero-deps.js`).
+   - (d) **an actual hard downstream limit** — something that inlines or transmits the client
+     where bytes genuinely bite (an env/argv length bound, an inlined payload, a transport
+     frame). If no hard downstream limit exists, **state that plainly** — a "soft discipline"
+     answer is a valid and likely outcome.
+2. **Is the current measure still correct?** Given the binding constraint, is comment-stripped
+   PRIMARY + raw BACKSTOP the right metric, or does the constraint call for a different one
+   (parse/load time, raw bytes only, per-file vs total, or the *loaded-subset* bytes rather than
+   the whole tree — note a hook event loads ~19 of 26 modules; the `mcp-bridge/` subtree loads
+   only for the bridge subcommand)?
+3. **What is the right, grounded number(s) + growth policy?** Derive the number from the binding
+   constraint rather than inheriting it, and define a growth policy so the cap stops getting
+   bumped reactively. Account for the current near-zero headroom on **both** caps.
+4. **What should #840 actually do?** In light of 1–3: the reclaim target, which cap(s) it should
+   move, and whether "lower PRIMARY to 100,000" is still the right move or the number should be
+   re-derived.
+
+## Breadth
+
+`code+ecosystem` — **code-dominant**. The primary surface is internal: our hook-client tree
+(`lib/hook-client/`), the size gate, the zero-dep gate, the `package.json` `files`/`bin`, and
+how the client is loaded (`bin/unimatrix.js`, `lib/init.js`, `lib/merge-settings.js`,
+`postinstall.js`) and packaged. A **light** external scan of how comparable
+zero-dependency / injected JS clients budget size is in scope only insofar as it informs the
+growth policy — **not** industry-depth.
+
+## Approach
+
+`investigation` + a **quick targeted** `measurement` (latency probe).
+
+- **Investigate** the load/packaging path to identify the binding constraint: what loads the
+  client, what subset is loaded per event, what (if anything) imposes a hard byte ceiling
+  downstream.
+- **Probe** actual `require()`/parse cost across a few representative byte sizes **only** to rule
+  load latency in or out — not a full empirical sweep. A preliminary measurement already exists
+  (see Prior art): cold `require()` of the full index.js graph (~149 KB, 19 modules) is ~10–14 ms
+  and is dwarfed by Node process startup; the spike should confirm/refine this with a small
+  size-varied probe, not an exhaustive characterization.
+
+## Confidence required
+
+`directional`. A grounded recommendation (constraint + measure + number + policy) with **enough**
+measurement to rule load latency in or out. A data-backed empirical sweep is **explicitly NOT
+required** — a small probe sufficient to settle the latency question is the bar.
+
+## Target outputs
+
+FINDINGS.md containing:
+- The **identified binding constraint** with evidence (which of a/b/c/d, and an explicit "no hard
+  downstream limit" statement if that is the finding).
+- The **recommended measure** — keep the current dual-limit or change it — with rationale.
+- The **recommended grounded number(s)** + a **growth policy** that ends reactive bumping.
+- An **explicit #840 recommendation**: reclaim target, which cap(s), whether `100,000` stands or
+  is re-derived.
+- The **latency-probe result** (rule-in / rule-out, with the few data points behind it).
+- **Unanswered Questions** and **Out-of-Scope Discoveries**.
+
+## Constraints
+
+**Hard** (fixed; changing one means changing shipped code or breaking the gate's integrity):
+- The client stays **zero-dependency and hand-auditable**. `check-zero-deps.js` enforces this:
+  no runtime `dependencies` in `package.json` (the `optionalDependencies` platform binaries are
+  the LOCAL Rust path, not consumed by the pure-JS remote client) and every `require()` reachable
+  from `lib/hook-client/` resolves to a Node built-in or a relative path. Any recommendation must
+  preserve this.
+- **CAP-CHANGE RULE (ADR-005, #4806):** any change to either limit is a **human decision recorded
+  on the GH issue** — never an agent adjustment. Raising a cap to make a failing gate pass is a
+  **vacuous pass and is forbidden**. This spike *recommends*; it does not change the cap.
+- The **stripper self-test must stay green** — the gate measures only after the embedded
+  `SELF_TEST_CORPUS` passes and **fails closed** on a stripper bug. No recommendation may weaken
+  this fail-closed property.
+- **Lockstep meta-assertions (#5312):** the cap constants are duplicated in
+  `test/hook-client/size-gate.test.js` (`test_limits_are_decimal` hard-codes the PRIMARY value)
+  and the header-doc test greps the source for the literal `"100,000"`. Any number the spike
+  recommends must note that #840 has to move these in lockstep, or the standalone gate goes green
+  while the full `node --test` run fails.
+- **Read-only in Unimatrix.** No code committed, no PR. This is a research spike feeding #840.
+
+**Hypothesis** (challengeable positions to test, NOT assumptions to carry):
+- "**100,000 is a meaningful threshold**" — it is inherited from vnc-026's raw cap, not derived.
+  Challenge it.
+- "**Comment-stripped is the right primary measure**" — challenge whether the binding constraint
+  actually cares about stripped bytes (a latency or install-footprint constraint would care about
+  *raw* or *loaded* bytes; comment-stripping serves a documentation-fairness goal that may be
+  orthogonal to the real constraint).
+- "**The client must keep shrinking**" — the right answer may be a grounded *higher* cap plus a
+  policy, not endless reclaim. Endless reclaim that fights documentation is the #4780 failure mode
+  in a new guise.
+
+## Background Research / Prior art
+
+Read directly for this scope:
+- **Gate file** `packages/unimatrix/test/check-hook-client-size.js` — dual limit, decimal bytes,
+  current `PRIMARY_LIMIT = 102000` / `BACKSTOP_LIMIT = 180000`, the inline raise-rationale
+  comments citing #839 and #775, the state-machine stripper, the embedded self-test, and the
+  DI seams (`runGate`/`measureTree`/`stripFn`).
+- **Zero-dep gate** `packages/unimatrix/test/check-zero-deps.js` — static require-scan; the
+  hard zero-dependency invariant the size recommendation must not disturb.
+- **Packaging** `package.json` — `files: [bin/, lib/, skills/, postinstall.js, protocols/]`,
+  `bin.unimatrix = bin/unimatrix.js`, `optionalDependencies` are the platform Rust binaries.
+- **Load path** — the client is spawned per hook event as a fresh `node .../hook-client/index.js
+  <EVENT>` process (`lib/merge-settings.js` builds the command; `lib/init.js:456` resolves the
+  path; `bin/unimatrix.js:54` lazy-loads `mcp-bridge.js` only for the `mcp-bridge` subcommand).
+- **NOTE — do not mistake the decoder for a bundle:** `lib/hook-client/bundle.js` is a
+  connection-token **decoder** (`decodeBundle`, used by `lib/init.js`), **not** a packaging
+  bundle / minified artifact. There is no build/minify step; every byte gating against the cap is
+  hand-written source. This rules out a "shrink the bundle" framing.
+
+Current measured state (2026-06-28):
+- Tree: **26** `.js` files under `lib/hook-client/`, raw total **179,944 B**, stripped total
+  **101,445 B**. Largest: `index.js` (17,066 raw), `build-request-tools.js` (12,483),
+  `state.js` (11,382), `config.js` (11,097), `transport-http.js` (11,009).
+- **Per-event load subset:** requiring `index.js` pulls in **19** of the 26 modules (~149 KB
+  raw); the `mcp-bridge/` subtree (~17 KB) and a few others load only for the bridge subcommand,
+  not for hook events. The cap measures the **whole tree**; a hook event parses only a **subset**
+  — a relevant input to Goal 2 (is "total tree" even the right denominator for a latency
+  constraint?).
+- **Preliminary latency probe:** cold `require()` of the full `index.js` graph measures
+  ~10–14 ms (5 runs), and is small relative to Node's own process-startup cost. Directionally this
+  points toward latency **not** being the binding constraint, but the spike should confirm with a
+  small size-varied probe before ruling it out.
+
+Unimatrix knowledge:
+- **ADR-005 (#4806)** — the dual-limit design and rationale: comment-stripped 100,000 PRIMARY
+  measures *shipped logic only* (so oracle-citation comments don't compete with code — the #4780
+  driver); raw BACKSTOP caps total growth so a stripper miscount can't admit unbounded files;
+  decimal interpretation; cap changes are human decisions on the issue. **Note ADR-005's own
+  numbers (100,000 / 160,000) are the *inherited* baseline this spike interrogates.**
+- **Lesson #4780** — vnc-026 origin: the client shipped at 104,240 B against a single 100,000 B
+  **raw** cap; root cause was verbose parity-port JSDoc, not logic bloat. Takeaway: "trim comment
+  prose only, never minify or inflate the limit." This is where the decimal 100,000 came from —
+  and it was a *raw* cap, repurposed as a *stripped* cap by ADR-005, so the number never matched
+  the new measure's semantics.
+- **Pattern #4820** — the dual-limit pattern statement; how to budget hook-client additions
+  against the stripped budget.
+- **Pattern #5312** — the lockstep meta-assertion trap (see Constraints): `test_limits_are_decimal`
+  hard-codes PRIMARY, and the header-doc test greps for `"100,000"`; the #839 bump tripped exactly
+  this (cap moved to 101000 but the meta-assertion stayed at 100000).
+
+Issues:
+- **#839** — the COMPLETE critical-availability fix (transport/connect timeout + silent-eviction
+  self-heal + F6 mid-stream idle-read deadline + SSE-timeout heal routing) that drove PRIMARY
+  100000 → 101000 → 102000 after ~1420 B in-bridge reclaim.
+- **#775** — the BACKSTOP 160000 → 180000 raise for the vnc-039 stdio→HTTPS MCP bridge (~24 KB).
+- **#840** — the reclaim task this spike feeds: reclaim ~1.5 KB and (currently) lower PRIMARY back
+  to 100,000.
+
+## Proposed Approach
+
+Settled with the human and research leader (do not re-litigate): a code-dominant investigation of
+the load and packaging path to identify the binding constraint, plus a quick latency probe to rule
+load-latency in or out, producing a directional recommendation — constraint + measure + grounded
+number(s) + growth policy + explicit #840 guidance. Light external scan only to inform policy.
+
+## Acceptance Criteria
+
+- **AC-01:** Each constraint candidate (a) load/parse latency, (b) install footprint,
+  (c) maintainability/zero-dep discipline, (d) a hard downstream byte limit — is explicitly ruled
+  **in** or **out** with evidence; if no hard downstream limit exists, that is stated plainly.
+- **AC-02:** The single **binding** constraint (or the explicit finding that the cap is a soft
+  discipline with no hard binder) is named.
+- **AC-03:** A recommendation on the **measure** — keep comment-stripped PRIMARY + raw BACKSTOP, or
+  change it — is given with rationale tied to the binding constraint, addressing whole-tree vs
+  loaded-subset and stripped vs raw.
+- **AC-04:** A **grounded number (or numbers)** is recommended, *derived* from the binding
+  constraint, with the derivation shown — not inherited from vnc-026.
+- **AC-05:** A **growth policy** is defined that gives the cap a defensible basis for future
+  raise/hold decisions, so increments stop being reactive.
+- **AC-06:** An **explicit #840 recommendation**: reclaim target, which cap(s) to move, and whether
+  `100,000` stands or is re-derived — including the lockstep meta-assertion (#5312) update #840
+  must make.
+- **AC-07:** The **latency-probe result** is reported as an explicit rule-in / rule-out, with the
+  handful of data points behind it.
+- **AC-08:** FINDINGS.md includes **Unanswered Questions** and **Out-of-Scope Discoveries**.
+
+## Open Questions
+
+- Is there any consumer that **inlines or transmits** the client bytes (an env var, an argv, a
+  transport frame, a future bundling step) where a hard byte ceiling genuinely exists — or is the
+  client only ever spawned from disk by path, making raw size a soft concern?
+- If the binding constraint is latency, the right denominator is the **loaded subset per event**,
+  not the whole tree — should the gate then measure the `index.js` require-closure rather than all
+  `*.js`? (And how would that interact with the `mcp-bridge/` subtree that loads on a different
+  path?)
+- Does comment-stripping still serve a purpose if the binding constraint cares about raw/loaded
+  bytes rather than shipped logic, or is the PRIMARY/BACKSTOP split solving the #4780 documentation
+  problem at the cost of obscuring the real constraint?
+- Can the growth policy be tied to a measurable budget (e.g. a latency ceiling per event, or a
+  fraction of the install footprint) rather than a hand-picked byte count?
+
+## Tracking
+
+GH research issue **#861** (ass-086). Single spike → executed via `uni-spike-researcher` once
+scope is confirmed complete. Findings feed **#840** (the reclaim + cap-reset task).


### PR DESCRIPTION
## What & why

The hook-client size cap was **ungrounded**: the number `100,000` was inherited verbatim from vnc-026's old *raw* cap (#4780), never tied to a real constraint, and bumped reactively under pressure (PRIMARY 100,000→101,000→102,000 #839; BACKSTOP 160,000→180,000 #775). The client was pinned against **both** caps — stripped 101,445/102,000 (555 B) and raw 179,944/180,000 (**56 B**) — so every change became a cap fight.

Research spike **ass-086** (#861) grounded it: the cap is a **soft maintainability / hand-auditability discipline with no hard downstream binder** (load latency, install footprint, and any hard byte limit all ruled out — the client is always spawned from disk by path, never inlined or transmitted; latency probe: ~16 µs/KB, dwarfed by the ~12 ms Node spawn). The *measure* (comment-stripped PRIMARY + raw BACKSTOP) is right; only the *numbers* were wrong.

## Change

- **Reground, not reclaim.** Investigator confirmed the ~1.4 KB #839 called "TEMP" was already banked during #839; the remainder is live availability logic. Trimming further would be the #4780 doc-vs-bytes failure mode.
- **PRIMARY 102,000 → 110,000** stripped, **BACKSTOP 180,000 → 200,000** raw — baseline (101,445 / 179,944) + ~two-module review margin (~8.5 KB / ~20 KB runway). Also clears the 56 B raw ratchet.
- **Headroom-budget growth policy** written into the gate header: raises only for new *logic* (never docs or temp scaffolding), via the ADR-005 CAP-CHANGE RULE human review *before* merge, baseline reset on each raise. The two-module margin is stated and justified.
- **Drift-hardening (closes the recurring #5312 lockstep tax):** the header-doc test now derives its expected literals from the live constants (`PRIMARY_LIMIT.toLocaleString("en-US")` / `BACKSTOP_LIMIT.toLocaleString("en-US")`) instead of hardcoded substrings — a constant change without the prose update now fails CI.
- All 8 lockstep sites moved together (`check-hook-client-size.js` + `size-gate.test.js`).

## Verification

- `node --test` (full package): **1019/1020 pass**, 1 skip, 0 fail — the lockstep proof (standalone gate green AND package meta-assertions green).
- Size gate: PASS — `stripped=101445/110000  raw=179944/200000`.
- `size-gate.test.js` 21/21; `run-hook-client.js` 764/765 (1 skip); `check-zero-deps.js` PASS; embedded stripper self-test PASS.
- Scope: only the two JS test-tooling files; no Rust/server/shipped-client surface (cargo/clippy/python smoke N/A). `delta.test.js`'s unrelated `200000` fixture and `CLAUDE.md` untouched.

Gate: Bugfix Validation **PASS (8/8)**.

## Follow-up (tracked, not in this diff)

A superseding ADR for #4806's numeric + CAP-CHANGE clauses via `context_correct` (preserves provenance) — the growth policy needs a durable home beyond gate prose. Being handled in this session per the architect's recommendation.

Closes #840. Research: `product/research/ass-086/` (#861).

🤖 Generated with [Claude Code](https://claude.com/claude-code)