### PR TITLE
fix(nan-021): provision sqlite3 on parity lane for D2 host-side read (#849)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -589,6 +589,12 @@ jobs:
       - name: Install pytest harness deps
         run: pip install pytest pytest-timeout pytest-json-report
 
+      - name: Provision sqlite3 (D2 behavioral host-side read; #849)
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y sqlite3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary
The release-gate parity lane `nan-021-https-uds-parity` runs `pytest -m parity`, which drives the nan-022 D2 behavioral capture. That capture reads the per-slug DB host-side via `sqlite3` (distroless image → DB copied out and queried on host) in `cloud-bundle-lib.sh:capture_behavioral_topic_signals`. The lane provisioned `node`+`python` but never `sqlite3`, so the deliberate HARD-INFRA guard fired before any parity verdict on a clean tag round.

This adds one `sqlite3` provisioning step to the parity lane, **byte-identical** to the precedent in the same workflow's `multi-tenant-isolation-amd64` job, which ADR-003 (#5351) prescribed and explicitly tagged "coordinate #849." The HARD-INFRA-on-missing-`sqlite3` guard in `cloud-bundle-lib.sh` is left untouched (working as designed).

## Change
- `.github/workflows/release.yml` — add `Provision sqlite3` step to `nan-021-https-uds-parity`, before the `pytest -m parity` gate (6 insertions, one step).

## Verification
- Diff scope: `release.yml` only (6 insertions).
- YAML parses clean (`yaml.safe_load`).
- Step `run:` block byte-identical to the isolation-lane precedent; placed before the D2 host-side read.
- cargo/clippy/smoke N/A — zero Rust/JS/harness-source changes; release.yml executes only on the GitHub release lane.
- Gate: Bug Fix Validation — PASS (7/7).
- Post-merge confirmation (out of local scope): the parity lane reaching a per-dimension verdict instead of INFRA-ERROR can only be confirmed on an actual tag round / workflow_dispatch.

## Risk
Low — one ephemeral runner; lane is NOT in `create-container-manifest.needs`, so a failure does not block releases. Transient apt failure fails closed (intended loud signal).

## Follow-up (not in this PR)
Reviewers suggested a cross-lane sqlite3 workflow lint to guard the recurring class (any `cloud-cycle-lib` lane needs sqlite3). Worth a separate issue.

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)