### PR TITLE
fix(infra-001/nan-022): D1/D4 parity flip — corpus under-population 5→25 (#844)

### DIFF
--- a/product/test/infra-001/harness/parity_seed_corpus.py
+++ b/product/test/infra-001/harness/parity_seed_corpus.py
@@ -46,7 +46,21 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 # entries on the shared retrieval topic — comfortably above the floor (head-room so HNSW tail
 # churn below the prefix does not starve the prefix). The exact size is the OQ-C/Stage-3a
 # test-design call fixed HERE; the SHAPE (size > STABLE_PREFIX_FLOOR > 1) is ADR-fixed.
-SEED_CORPUS_SIZE: int = 5
+#
+# #844 (ass-085 #852): raised 5 -> 25. At N=k=5 hnsw_rs short-returns (<5 results) in
+# ~14% of builds, starving the stable prefix below the floor -> D1/D4 PARITY_FAIL. ass-085
+# measured N~=25 with a >=0.20 head/tail "moat" cuts the flip ~30x and eliminates the
+# short-return mode. N is the dominant lever; exact-zero is unreachable (~0.2-0.6% intrinsic
+# hnsw_rs build-RNG residual remains, owned by ADR-004 stable-prefix policy + the C0 #5304
+# documented exception). The corpus complements that policy; it does not replace it.
+SEED_CORPUS_SIZE: int = 25
+
+# Requested retrieval breadth (top-k) for the D1 context_search query, DECOUPLED from
+# SEED_CORPUS_SIZE (#844). Must be >= STABLE_PREFIX_FLOOR (3, the asserted stable prefix
+# depth, single-sourced in ranking_tolerance.py) and <= the head size (5). We seed 25 entries
+# for graph stability but query a small stable HEAD: querying k=25 would return the whole
+# corpus and re-introduce the boundary noise the deep corpus exists to suppress (ass-085 Q2).
+RETRIEVAL_QUERY_K: int = 5
 
 # The single shared topic the corpus is seeded under and the query set retrieves over, so the
 # ranking is non-degenerate (>= STABLE_PREFIX_FLOOR hits). Content-only — never an output.
@@ -54,38 +68,86 @@ SEED_TOPIC: str = "nan-022-parity-corpus"
 SEED_CATEGORY: str = "pattern"
 
 
-# Per-entry distinct subjects (Stage-3c first-live-run fix — Stage-3c fix; see product/features/nan-022/testing/RISK-COVERAGE-REPORT.md / R-06 / OQ-3).
-# The corpus MUST survive the server's near-duplicate collapse: the previous boilerplate
-# entries differed only by a 2-digit index and the server deduped ALL of them into a single
-# entry (`similarity: 1.00 | duplicate: true`), so retrieval returned a single hit (< the
-# STABLE_PREFIX_FLOOR of 3) — a degenerate, vacuous ranking (R-06). Each entry now carries a
-# semantically DISTINCT subject so the embeddings differ enough to land as separate entries
-# while all sharing the SEED_TOPIC keyword (so a topic query still returns >= the floor).
+# Per-entry distinct subjects (Stage-3c R-06 fix; expanded for #844 / ass-085 #852).
+#
+# Two invariants this pool must hold (verified once at authoring against the REAL MiniLM
+# model — sentence-transformers/all-MiniLM-L6-v2 — via scripts/docker-embed-readiness-smoke.sh
+# DESIGN-VERIFY mode; ass-085's model was synthetic, so the geometry the fix rests on was
+# unverified until #844 measured it):
+#
+#  1. DISTINCTNESS / no near-duplicate collapse (R-06). The previous boilerplate entries
+#     differed only by a 2-digit index and the server deduped ALL of them
+#     (`similarity: 1.00 | duplicate: true`), collapsing the ranking to one hit (< the
+#     STABLE_PREFIX_FLOOR of 3) — a vacuous parity pass (#5177). Each entry carries a
+#     semantically DISTINCT subject; measured MAX pairwise cosine ~0.74, comfortably below
+#     the server DUPLICATE_THRESHOLD (0.92, store_ops.rs). The pool size is also >=
+#     SEED_CORPUS_SIZE so the `i % len` modulo in `_seed_entry_content` never wraps and
+#     re-collapses distinctness (locked by a unit test).
+#
+#  2. GEOMETRY: a coherent HEAD (the first RETRIEVAL_QUERY_K subjects — all "cross-transport
+#     parity" aspects) ranks above a TAIL (distinct subsystems / off-domain) by a >=0.20
+#     cosine "moat" against the primary retrieval query, with the head internally graded so
+#     the asserted top-3 prefix has no boundary tie. Measured against the primary D1 query:
+#     moat ~0.225, top-3 intra-head gaps ~0.10 / ~0.04, residual projection ~0.3% (within the
+#     ~0.4% envelope the C0 exception is signed for). The retrieval-flavored SECONDARY queries
+#     reorder the (intrinsically clustered) head more tightly — that residual is the intrinsic
+#     hnsw_rs flip the stable-prefix policy + C0 exception own; it cannot be designed to zero
+#     (ass-085 Q2 geometric cap, confirmed on real embeddings in #844).
+#
+# Content geometry note: the stored embed text is f"{title}: {content}" (embed/text.rs,
+# separator ": "). seed_corpus_calls sets title == content == subject so the embed text is
+# SUBJECT-DOMINANT. The MCP default title is f"{topic}: {category}" — a UNIFORM string across
+# all 25 entries — which (measured) compresses the head/tail moat to ~0.03 and destroys the
+# geometry; hence the explicit per-entry title.
+#
 # CONTENT ONLY — never a compared output (no topic_signal / edge / briefing id; R-15).
 _SEED_SUBJECTS: tuple[str, ...] = (
-    "transport-layer socket framing and unix-domain stream handshakes",
-    "embedding-vector similarity scoring and approximate nearest-neighbour recall",
-    "write-ahead-log checkpoint durability and per-slug store isolation",
-    "proactive briefing index ranking and injection-set selection heuristics",
-    "behavioral observation attribution from declared cycle topic signals",
-    "JSON-RPC tool-call envelope routing over the pinned HTTPS bridge surface",
-    "contradiction detection across incompatible stored directive entries",
-    "confidence Wilson-score re-ranking under sparse vote evidence",
+    # HEAD (first RETRIEVAL_QUERY_K) — graded cross-transport-parity ladder, mutually distinct
+    # aspects. Order here is the intended descending relevance to the primary retrieval query.
+    "cross-transport parity of identical ranked results on each transport",
+    "cross-transport parity of byte-identical stored-entry rankings on both legs",
+    "cross-transport parity for ranked search output on both request legs",
+    "cross-transport parity of HTTPS and unix-domain search responses",
+    "cross-transport parity between the HTTPS bridge and the unix-domain socket",
+    # TAIL — distinct subsystems / off-domain subjects, each >=0.20 cosine below the head
+    # against the retrieval query (the "moat"), and pairwise-distinct from each other.
+    "write-ahead-log checkpoint durability and crash recovery",
+    "contradiction detection across incompatible stored directives",
+    "quarterly payroll tax withholding schedules",
+    "per-slug database isolation and multi-tenant project configuration",
+    "dashboard panel layout and time-series visualization widgets",
+    "kitchen pantry inventory and grocery restocking lists",
+    "open-source license compliance and dependency vulnerability auditing",
+    "markdown documentation generation and changelog formatting",
+    "knowledge graph edge traversal and provenance lineage",
+    "agent role orchestration and swarm coordination",
+    "secret management and environment-variable credential handling",
+    "garbage collection of expired ephemeral session records",
+    "JPEG chroma subsampling and color-space conversion",
+    "cron scheduling of recurring background maintenance jobs",
+    "geospatial tile rendering and map projection mathematics",
+    "houseplant watering frequency by season",
+    "thermal sensor calibration drift over temperature cycles",
+    "audio waveform resampling and loudness normalization",
+    "spreadsheet pivot-table aggregation and cell formatting",
+    "container image layer caching and registry digest pinning",
 )
 
 
 def _seed_entry_content(i: int) -> str:
-    """Deterministic, DISTINCT content for corpus entry i. Each entry carries a unique
-    subject (`_SEED_SUBJECTS`) so it survives the server's near-duplicate collapse and the
-    corpus ranks to depth >= STABLE_PREFIX_FLOOR; the shared SEED_TOPIC keyword keeps a topic
-    query returning the whole corpus (related enough to rank together, distinct enough not to
-    dedup). Index `i` is taken modulo the subject pool so any SEED_CORPUS_SIZE stays distinct."""
-    subject = _SEED_SUBJECTS[i % len(_SEED_SUBJECTS)]
-    return (
-        f"{SEED_TOPIC} corpus entry {i:02d}: {subject}. This entry documents {subject} "
-        f"as cross-transport parity reference material number {i:02d} for retrieval and "
-        f"briefing ranking over the HTTPS-vs-UDS canonical workload."
-    )
+    """Deterministic, DISTINCT content for corpus entry i: the bare subject string.
+
+    The content is the SUBJECT alone (no shared boilerplate). #844/ass-085 measured that the
+    previous template's shared "{SEED_TOPIC} ... cross-transport parity ... HTTPS-vs-UDS"
+    filler appeared in EVERY entry and pulled all 25 embeddings toward the query, compressing
+    the head/tail moat to ~0.02 and destroying the geometry the fix depends on. A subject-only
+    content lets the distinct subject dominate, realizing the >=0.20 moat (see _SEED_SUBJECTS).
+
+    Index `i` is taken modulo the subject pool. With len(_SEED_SUBJECTS) >= SEED_CORPUS_SIZE
+    the modulo never wraps, so every seeded entry stays distinct (no R-06 dedup collapse).
+    Topic-scoped recall does NOT rely on a content keyword: context_lookup matches the
+    structured `topic` field, and seed_corpus_calls sets topic=SEED_TOPIC on every write."""
+    return _SEED_SUBJECTS[i % len(_SEED_SUBJECTS)]
 
 
 def seed_corpus_calls() -> list["ToolCall"]:
@@ -96,6 +158,12 @@ def seed_corpus_calls() -> list["ToolCall"]:
     `observe=False`: the seed writes are MCP-bridge store calls, not `/observe`-hooked tool
     uses, so they do NOT inflate `expected_observe_count` (the barrier predicate). They are
     the corpus the QUERY phase ranks over, identical on both legs.
+
+    `title` is set EXPLICITLY per entry (to the subject) — NOT left to the MCP default. The
+    default title is f"{topic}: {category}", a UNIFORM string across all 25 entries; since the
+    stored embed text is f"{title}: {content}" (embed/text.rs), that uniform prefix (measured,
+    #844) compresses the head/tail moat to ~0.03 and destroys the retrieval geometry. With
+    title == content == subject the embed text is subject-dominant and the moat is realized.
     """
     from harness.parity_workload import ToolCall  # local import — avoid circular import
 
@@ -103,6 +171,7 @@ def seed_corpus_calls() -> list["ToolCall"]:
         ToolCall(
             name="context_store",
             args={
+                "title": _seed_entry_content(i),
                 "content": _seed_entry_content(i),
                 "topic": SEED_TOPIC,
                 "category": SEED_CATEGORY,
@@ -125,7 +194,7 @@ def retrieval_query_calls() -> list["ToolCall"]:
     return [
         ToolCall(
             name="context_search",
-            args={"query": f"{SEED_TOPIC} cross-transport parity", "k": SEED_CORPUS_SIZE},
+            args={"query": f"{SEED_TOPIC} cross-transport parity", "k": RETRIEVAL_QUERY_K},
             observe=False,
             response_snippet=f"search {SEED_TOPIC}",
         ),
@@ -137,7 +206,7 @@ def retrieval_query_calls() -> list["ToolCall"]:
         ),
         ToolCall(
             name="context_search",
-            args={"query": f"{SEED_TOPIC} retrieval ranking seed", "k": SEED_CORPUS_SIZE},
+            args={"query": f"{SEED_TOPIC} retrieval ranking seed", "k": RETRIEVAL_QUERY_K},
             observe=False,
             response_snippet=f"search {SEED_TOPIC} ranking",
         ),

--- a/product/test/infra-001/scripts/docker-embed-readiness-smoke.sh
+++ b/product/test/infra-001/scripts/docker-embed-readiness-smoke.sh
@@ -37,6 +37,13 @@
 # Env:     IMAGE   pre-built image tag to test instead of building (optional)
 #          KEEP    set to 1 to keep the container/volumes for inspection
 #          READY_TIMEOUT_SECS  override the embed-readiness deadline (default 180)
+#          DESIGN_VERIFY  set to 1 to ALSO run the #844 parity-corpus GEOMETRY check:
+#                  embed the 25 real seed subjects with the SAME shipped ONNX model and
+#                  print the pairwise-cosine matrix + the head/tail moat + the intra-head
+#                  top-3 gaps. This is a ONE-TIME AUTHORING/SIGN-OFF measurement (ass-085
+#                  #852 / #844), NOT a per-parity-run gate — wiring corpus geometry into
+#                  every parity build would recouple the suite to ONNX/model drift and
+#                  reintroduce the flakiness the corpus fix removes. Default OFF.
 #
 # Exit contract (identical shape to docker-http-posture-smoke.sh so the SAME
 # release-gate-lib.sh run_smoke_gate spine consumes it):
@@ -238,5 +245,73 @@ done
 MODEL_OK="$(shared sh -c 'f=$(find /shared/models -name model.onnx 2>/dev/null | head -1); t=$(find /shared/models -name tokenizer.json 2>/dev/null | head -1); [ -s "$f" ] && [ -s "$t" ] && echo OK || echo MISSING')"
 [ "$MODEL_OK" = "OK" ] || fail "model.onnx and/or tokenizer.json missing or empty under /shared/models after boot"
 log "model.onnx + tokenizer.json present and non-empty under /shared/models. PASS model-file check"
+
+# -- #844 PARITY-CORPUS GEOMETRY CHECK (opt-in, DESIGN_VERIFY=1) --------------
+# One-time AUTHORING/sign-off measurement (NOT a per-parity-run gate). Embeds the 25 real
+# seed subjects with the SAME shipped ONNX model that just landed in /shared, in the exact
+# stored embed form f"{title}: {content}" (the corpus ships title == content == subject), and
+# prints the pairwise-cosine matrix + the head/tail moat + the intra-head top-3 gaps so the
+# human sign-off can confirm the geometry the #844 fix rests on is REAL (ass-085 measured it
+# only on synthetic vectors). A separate python sidecar (the runtime image is distroless) reads
+# /shared:ro and imports the live parity_seed_corpus.py — no second copy of the corpus.
+if [ "${DESIGN_VERIFY:-0}" = "1" ]; then
+  log "DESIGN_VERIFY=1 -> running the #844 parity-corpus geometry measurement (authoring check, not a per-run gate)"
+  HARNESS_DIR="$REPO_ROOT/product/test/infra-001/harness"
+  [ -f "$HARNESS_DIR/parity_seed_corpus.py" ] || fail "parity_seed_corpus.py not found at $HARNESS_DIR"
+  docker run --rm -i \
+    -v "$SVOL:/shared:ro" \
+    -v "$HARNESS_DIR:/harness:ro" \
+    python:3.11-slim bash -s <<'SIDECAR' || fail "DESIGN_VERIFY geometry check FAILED (moat < 0.20 or sidecar error) — do NOT sign off the corpus geometry"
+set -e
+pip install -q onnxruntime tokenizers numpy >/dev/null 2>&1
+python - <<'PY'
+import glob, importlib.util, sys, numpy as np, onnxruntime as ort
+from tokenizers import Tokenizer
+onnx=glob.glob("/shared/models/**/model.onnx", recursive=True)
+toks=glob.glob("/shared/models/**/tokenizer.json", recursive=True)
+assert onnx and toks, "model.onnx / tokenizer.json not found under /shared/models"
+tok=Tokenizer.from_file(toks[0]); tok.enable_truncation(max_length=256)
+sess=ort.InferenceSession(onnx[0], providers=["CPUExecutionProvider"])
+def emb(t):
+    e=tok.encode(t)
+    f={"input_ids":np.array([e.ids],dtype=np.int64),"attention_mask":np.array([e.attention_mask],dtype=np.int64),"token_type_ids":np.array([e.type_ids],dtype=np.int64)}
+    w={i.name for i in sess.get_inputs()}; f={k:v for k,v in f.items() if k in w}
+    h=sess.run(None,f)[0][0]; m=f["attention_mask"][0].astype(np.float32)
+    p=(h*m[:,None]).sum(0)/max(m.sum(),1e-9); return p/(np.linalg.norm(p) or 1e-9)
+spec=importlib.util.spec_from_file_location("psc","/harness/parity_seed_corpus.py")
+psc=importlib.util.module_from_spec(spec); spec.loader.exec_module(psc)
+N=psc.SEED_CORPUS_SIZE; HEAD=psc.RETRIEVAL_QUERY_K; FLOOR=3; T=psc.SEED_TOPIC
+SUBJ=[psc._seed_entry_content(i) for i in range(N)]          # bare subject == content
+EV=np.array([emb(f"{s}: {s}") for s in SUBJ])                # stored embed text "title: content"
+q=emb(f"{T} cross-transport parity")                         # primary D1 retrieval query
+print(f"[844-geom] N={N} head(RETRIEVAL_QUERY_K)={HEAD} distinct={len(set(SUBJ))}")
+print("[844-geom] pairwise cosine matrix (stored embed text 'subject: subject'):")
+print("      "+"".join(f"{j:>5}" for j in range(N)))
+mx=0.0
+for i in range(N):
+    print(f"{i:>4} "+"".join(f"{float(np.dot(EV[i],EV[j])):>5.2f}" for j in range(N)))
+    mx=max(mx, max(float(np.dot(EV[i],EV[j])) for j in range(N) if j!=i))
+sc=sorted(((float(np.dot(EV[i],q)),i) for i in range(N)), reverse=True)
+head, tail = sc[:HEAD], sc[HEAD:]
+moat=head[-1][0]-tail[0][0]
+gaps=[head[r-1][0]-head[r][0] for r in range(1,FLOOR)]
+b23=head[FLOOR-1][0]-head[FLOOR][0]
+worst=min(min(gaps), b23)
+print("[844-geom] primary-query top ranking:")
+for r,(s,i) in enumerate(sc[:HEAD+2]):
+    print(f"   {r:>2} {'HEAD' if r<HEAD else 'tail'} {s:+.4f}  {SUBJ[i][:55]}")
+print(f"[844-geom] MOAT (lowest-head {head[-1][0]:+.4f} - highest-tail {tail[0][0]:+.4f}) = {moat:+.4f}  [need >= 0.20]")
+print(f"[844-geom] intra-head top-3 gaps={['%.4f'%g for g in gaps]} rank2/3-boundary={b23:.4f} worst={worst:.4f} (ass-085 synthetic ref ~0.03)")
+print(f"[844-geom] projected intra-prefix residual ~ {0.4*0.03/worst:.2f}% (C0 envelope ~0.4%)")
+print(f"[844-geom] MAX off-diagonal pairwise={mx:.3f} [DUPLICATE_THRESHOLD=0.92]")
+moat_ok = moat>=0.20; dedup_ok = mx<0.92
+print(f"[844-geom] VERDICT moat={'GREEN' if moat_ok else 'RED'} dedup={'GREEN' if dedup_ok else 'RED'} worst-prefix-gap={'GREEN' if worst>=0.03 else ('AMBER' if worst>=0.02 else 'RED')}")
+if worst < 0.02:
+    print("[844-geom] STOP-WARNING: real top-3 gap materially tighter than the synthetic ~0.03 ref — intra-prefix residual may EXCEED the ~0.4% C0 envelope; re-confirm the exception with the human before sign-off.")
+sys.exit(0 if (moat_ok and dedup_ok) else 1)
+PY
+SIDECAR
+  log "DESIGN_VERIFY geometry check complete (see [844-geom] lines above). This is an authoring/sign-off measurement, not a per-run gate."
+fi
 
 log "ALL GATES PASSED — first boot downloaded the model into /shared and the embed path is live (context_store/context_search round trip succeeded)."

--- a/product/test/infra-001/suites/test_parity_workload.py
+++ b/product/test/infra-001/suites/test_parity_workload.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from harness import parity_seed_corpus as psc
 from harness import parity_workload as pw
 from harness.parity_workload import (
     AT_RISK_FIELDS,
@@ -573,6 +574,42 @@ def test_seed_corpus_size_yields_prefix_floor_gt_one():
     assert STABLE_PREFIX_FLOOR > 1
     assert len(wl.seed_calls) >= STABLE_PREFIX_FLOOR
     assert len(wl.seed_calls) > 1
+
+
+def test_seed_corpus_deep_enough_for_844():
+    # #844 (ass-085 #852): N=k=5 sits in the hnsw_rs short-return regime (<5 results ~14% of
+    # builds) that starves the stable prefix -> D1/D4 PARITY_FAIL. The fix raises the corpus
+    # well above the floor so a leg's tail churn can never shorten the asserted prefix. Lock the
+    # corpus deep (>= 8 escapes the short-return band; ass-085 reaches the floor at ~25).
+    wl = default_workload()
+    assert len(wl.seed_calls) >= 25
+    assert psc.SEED_CORPUS_SIZE >= 25
+
+
+def test_seed_subject_pool_distinct_and_no_modulo_collapse():
+    # R-06 / #844 modulo-collapse trap: `_seed_entry_content` indexes `_SEED_SUBJECTS` with
+    # `i % len(_SEED_SUBJECTS)`. If the subject POOL is smaller than SEED_CORPUS_SIZE the modulo
+    # wraps and re-creates near-duplicate entries the server dedups into one (`duplicate: true`),
+    # collapsing the ranking below the floor. Lock the pool >= corpus size AND fully distinct.
+    assert len(set(psc._SEED_SUBJECTS)) == len(psc._SEED_SUBJECTS), "subject pool has duplicates"
+    assert len(set(psc._SEED_SUBJECTS)) >= psc.SEED_CORPUS_SIZE
+    # Therefore every seeded entry's content is distinct (no wrap, no dedup collapse).
+    contents = [psc._seed_entry_content(i) for i in range(psc.SEED_CORPUS_SIZE)]
+    assert len(set(contents)) == psc.SEED_CORPUS_SIZE
+
+
+def test_retrieval_query_k_decoupled_from_corpus_size():
+    # #844: the requested retrieval breadth (top-k) is DECOUPLED from corpus size. Querying
+    # k == N returns the whole corpus and re-introduces boundary noise (ass-085 Q2). k must be a
+    # small stable head: >= STABLE_PREFIX_FLOOR (asserted prefix depth) and < SEED_CORPUS_SIZE.
+    assert psc.RETRIEVAL_QUERY_K >= STABLE_PREFIX_FLOOR
+    assert psc.RETRIEVAL_QUERY_K < psc.SEED_CORPUS_SIZE
+    # The live context_search calls request exactly RETRIEVAL_QUERY_K, never SEED_CORPUS_SIZE.
+    searches = [tc for tc in default_workload().retrieval_calls if tc.name == "context_search"]
+    assert searches
+    for tc in searches:
+        assert tc.args["k"] == psc.RETRIEVAL_QUERY_K
+        assert tc.args["k"] != psc.SEED_CORPUS_SIZE
 
 
 def test_seed_corpus_query_set_non_trivial():


### PR DESCRIPTION
## Summary

Fixes the nan-022 cross-transport **D1 (retrieval) / D4 (briefing) parity flip** (#844). Root cause is **corpus under-population**: `SEED_CORPUS_SIZE = 5` with retrieval querying top-5, so `hnsw_rs` short-returns (<5 results) in ~6.6% of builds — the literal #844 signature (`[3,1,5,4]`) — dropping the stable prefix below `STABLE_PREFIX_FLOOR` and reding parity.

Test-only. No production / `hnsw_rs` / comparator / tolerance edits.

## Changes

- `harness/parity_seed_corpus.py` — `SEED_CORPUS_SIZE` 5→25; `_SEED_SUBJECTS` 8→25 distinct (5 graded head + 20 separated tail); new `RETRIEVAL_QUERY_K=5` decoupling query-k from corpus size; removed shared boilerplate that was collapsing the head/tail moat.
- `suites/test_parity_workload.py` — 3 cumulative regression tests (corpus depth ≥ floor, subject-pool distinctness / no modulo collapse, query-k decoupling).
- `scripts/docker-embed-readiness-smoke.sh` — opt-in `DESIGN_VERIFY=1` real-embedding geometry measurement seam (authoring/sign-off only, **not** wired as a per-run gate — avoids recoupling parity to model drift).

## Proof (measured, not projected)

ass-085 seam instrument, **real** all-MiniLM-L6-v2 embeddings, **5000 fresh HNSW builds**, old-vs-new:

| Corpus / query | top-3 (asserted) | naive top-5 | short-return |
|---|---|---|---|
| OLD N=5 D1-primary | 0.36% | 6.64% | **6.64%** |
| NEW N=25 D1-primary | 0.56% | 0.62% | **0.00%** |
| NEW N=25 D1-secondary | 0.40% | 1.10% | 0.04% |
| NEW N=25 D4-briefing-1 | 0.42% | 0.46% | **0.00%** |
| NEW N=25 D4-briefing-2 | 0.30% | 6.22% | **0.00%** |

- **Short-return (the #844 signature) eliminated: 6.64% → ~0.00%.**
- Stable-prefix policy validated on real embeddings: heavy top-5 *tail* churn (up to 6.22%) is correctly tolerated because the asserted **top-3 holds at 0.30–0.56%**.
- Verification: 164 unit + 3 new regression + 24 integration smoke, **0 failures**.

## Residual & documented exception

The measured worst-case top-3 residual is **~0.56% (95% CI upper ~0.85%)** — non-zero and intrinsic to `hnsw_rs` build-RNG (no seed API; #746/#4990). This is owned by the ADR-004 stable-prefix policy + the **C0 (#5304) documented exception**, to be human-signed post-merge against the *measured* ~0.56% (not the earlier ~0.4% projection). Per **ADR #5381**, we do not add production HNSW determinism solely for testability.

## Follow-ups

- **#864** — companion single-transport golden ranking-precision test (recovers boundary-precision sensitivity that a wide corpus no longer detects; fast-follow, non-blocking).
- Human: sign/narrow the live C0 (#5304) successor against measured ~0.56%, referencing ADR #5381.

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)