### PR TITLE
fix: client-side dormancy reconnect + session-id restore + errors-only observability (#872)

### DIFF
--- a/packages/unimatrix/lib/hook-client/mcp-bridge.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge.js
@@ -61,7 +61,9 @@ function run(session, deps) {
   const exit = (deps && deps.exit) || ((c) => process.exit(c));
 
   const framer = new StdioFramer(stdin, stdout);
-  const lifecycle = new Lifecycle(session);
+  // Forward deps so the lifecycle's errOut floor + injectable clock are wired
+  // (N3: run() previously built Lifecycle with no deps → stderr-only, untestable).
+  const lifecycle = new Lifecycle(session, deps);
 
   framer.onMessage(async (msg) => {
     let response = null;

--- a/packages/unimatrix/lib/hook-client/mcp-bridge/http-session.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/http-session.js
@@ -130,8 +130,10 @@ class HttpSession {
       // Connect/TLS-handshake deadline (F4): armed before connect, cleared in
       // secureConnect (clearCt) — covers the half-open-socket stall the socket
       // `timeout` option does NOT. Idle (post-connect): Node emits "timeout".
+      // REF'd on purpose (not unref'd): #872 recovery runs on an idle/dormant
+      // loop where an unref'd deadline never fires (#847/#848). Every terminal
+      // path routes through settle() -> clearCt(), so it never leaks a handle.
       const ct = setTimeout(() => kill("connect"), this.connectMs);
-      ct.unref();
       const clearCt = () => clearTimeout(ct);
       const settle = (fn, v) => { if (settled) return; settled = true; clearCt(); fn(v); };
       req.on("timeout", () => kill("idle"));

--- a/packages/unimatrix/lib/hook-client/mcp-bridge/http-session.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/http-session.js
@@ -37,6 +37,10 @@ class HttpSession {
     this.requester = (o) => https.request(o); // injectable for tests
     this.connectMs = connectMs || 15000;
     this.idleMs = idleMs || 120000;
+    // Last successful round-trip wall-clock; mirrored by the lifecycle so a
+    // transport timeout can report idle_ms (dormancy vs server-down). Seeded to
+    // now so an early failure reports a small, sane idle span (#872).
+    this.lastActivityMs = Date.now();
   }
 
   _headers(body, opts) {
@@ -104,16 +108,33 @@ class HttpSession {
       const req = this.requester(this._options("POST", this._headers(body, opts)));
       let flushed = false;
       let settled = false; // single settle-guard (F3, vnc-039 C2 double-settle)
+      let killed = false; // one-shot: emit the timeout event + destroy at most once
+      const startMs = Date.now();
+      // Errors-only observability (#872, ALWAYS-ON, stderr seam only). connect vs
+      // idle is ONLY distinguishable here. idle_ms distinguishes dormancy timeout
+      // from server-down. NO token, NO session id (redaction). B1: try/catch no-op.
+      const emitTimeout = (phase) => {
+        try {
+          this.errOut("mcp-bridge: transport_timeout phase=" + phase +
+            " elapsed_ms=" + (Date.now() - startMs) +
+            " idle_ms=" + (Date.now() - this.lastActivityMs) + "\n");
+        } catch (_e) {}
+      };
       // ETIMEDOUT-coded so lifecycle.js maps it to "MCP endpoint timed out".
-      const kill = () => { try { req.destroy(Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })); } catch (_e) {} };
+      const kill = (phase) => {
+        if (killed) return;
+        killed = true;
+        emitTimeout(phase);
+        try { req.destroy(Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })); } catch (_e) {}
+      };
       // Connect/TLS-handshake deadline (F4): armed before connect, cleared in
       // secureConnect (clearCt) — covers the half-open-socket stall the socket
       // `timeout` option does NOT. Idle (post-connect): Node emits "timeout".
-      const ct = setTimeout(kill, this.connectMs);
+      const ct = setTimeout(() => kill("connect"), this.connectMs);
       ct.unref();
       const clearCt = () => clearTimeout(ct);
       const settle = (fn, v) => { if (settled) return; settled = true; clearCt(); fn(v); };
-      req.on("timeout", kill);
+      req.on("timeout", () => kill("idle"));
       this._pinThenFlush(
         req,
         () => { flushed = true; req.end(body); }, // pin OK — flush Bearer body

--- a/packages/unimatrix/lib/hook-client/mcp-bridge/lifecycle.js
+++ b/packages/unimatrix/lib/hook-client/mcp-bridge/lifecycle.js
@@ -20,12 +20,36 @@ const CLIENT_INFO_NAME = "unimatrix-mcp-bridge"; // STABLE, fixed (FR-03a/AC-12)
 // Exhausted-heal normalization: an internal sentinel never reaches the client.
 const SENTINEL_TEXT = { [SESSION_NOT_FOUND]: "MCP session lost, re-init failed", [TRANSPORT_TIMEOUT]: "MCP endpoint timed out" };
 
+// Proactive dormancy reconnect (#872 Gap 1). After the client sleeps past the
+// server's rmcp keep_alive (4h), the pre-sleep socket is silently dead; the next
+// call would eat a full connect/idle deadline before healing. If we have been
+// idle beyond STALE_MS, re-init BEFORE dispatch. Default ~2.5h (62.5% of the 4h
+// server TTL) so we preempt eviction with margin; overridable for tuning/tests.
+const DEFAULT_STALE_MS = 9000000; // 2.5h in ms
+function resolveStaleMs() {
+  const n = parseInt(process.env.UNIMATRIX_HOOK_MCP_STALE_MS, 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_STALE_MS;
+}
+
 class Lifecycle {
   constructor(session, deps) {
     this.session = session;
     this.initMessage = null; // captured client initialize, replayed on re-init (B3)
     this.reinitInFlight = null; // single-flight guard for concurrent 404s (C2)
     this.errOut = (deps && deps.errOut) || ((s) => process.stderr.write(s));
+    this.now = (deps && deps.now) || (() => Date.now()); // injectable clock (#872)
+    this.staleMs = (deps && deps.staleMs) || resolveStaleMs();
+    // F1: seed to NOW (not 0/epoch) so the first healthy cold-start call does not
+    // see now-0 and fire a spurious proactive re-init on the hot path.
+    this.lastActivityMs = this.now();
+    this.session.lastActivityMs = this.lastActivityMs; // mirror for idle_ms observability
+  }
+
+  // Refresh the dormancy clock after any successful server round-trip and mirror
+  // it onto the session so http-session can emit idle_ms on a transport timeout.
+  _touch() {
+    this.lastActivityMs = this.now();
+    this.session.lastActivityMs = this.lastActivityMs;
   }
 
   // handle(msg) -> Promise<jsonRpcMessage | null>  (null for notifications)
@@ -37,6 +61,15 @@ class Lifecycle {
       if (!msg.params.clientInfo || typeof msg.params.clientInfo !== "object") msg.params.clientInfo = {};
       msg.params.clientInfo.name = CLIENT_INFO_NAME;
       this.initMessage = msg; // already-stamped; replayed verbatim on re-init (B3)
+    }
+
+    // Gap 1: proactive dormancy reconnect on any post-init message (gate on
+    // "non-init", not "has id", so a leading notification also refreshes — F6).
+    // FAIL-OPEN (F2): a false proactive re-init falls through to normal dispatch
+    // — the restored session then still gets its reactive 404/timeout heal; a
+    // failed preemptive probe must never convert a would-succeed call into a fail.
+    if (!isInit && this.initMessage && this.now() - this.lastActivityMs > this.staleMs) {
+      try { await this._reinit(); } catch (_e) {}
     }
 
     let out = await this._send(msg, isInit);
@@ -69,6 +102,7 @@ class Lifecycle {
       // timeout routes into the SAME TRANSPORT_TIMEOUT self-heal as the connect
       // path — the SSE branch reaches parity with the connect/request branch.
       out = await dispatchResponse(resp, this.session.idleMs);
+      this._touch(); // successful server round-trip → reset the dormancy clock (#872)
     } catch (err) {
       const id = msg && msg.id != null ? msg.id : null;
       // A transport TIMEOUT gets a distinct sentinel so handle() can self-heal it
@@ -101,11 +135,24 @@ class Lifecycle {
     const init = this.initMessage;
     if (!init) return false; // never saw initialize — cannot heal
     const prevId = this.session.sessionId;
-    this.errOut("mcp-bridge: session evicted (404); re-init\n");
+    // B1: wrap EVERY errOut on the heal path — this precedes the re-init POST and
+    // handle():_reinit swallows throws, so an unwrapped logging throw would
+    // silently ABORT the heal (the observability causing the failure it observes).
+    try { this.errOut("mcp-bridge: session evicted (404); re-init\n"); } catch (_e) {}
     this.session.sessionId = null; // discard the dead id before re-init
     await this._send(init, true); // protocolVersion re-captured inside
     const newId = this.session.sessionId;
-    return !(newId == null || newId === prevId); // fresh session id minted?
+    const ok = !(newId == null || newId === prevId); // fresh session id minted?
+    if (!ok) {
+      // Gap 2 (#872): a failed re-init must NEVER leave sessionId null. A null
+      // session dispatches session-less → server returns HTTP 422 (verified),
+      // which is NOT a heal signal → permanent wedge. Restore the previous
+      // (evicted) id so the next call carries it → server 404 → #830 heal re-fires.
+      this.session.sessionId = prevId;
+      const tag = this.session.sessionId != null ? "restored" : "null";
+      try { this.errOut("mcp-bridge: reinit_fail session=" + tag + "\n"); } catch (_e) {}
+    }
+    return ok;
   }
 }
 

--- a/packages/unimatrix/test/hook-client/mcp-bridge.test.js
+++ b/packages/unimatrix/test/hook-client/mcp-bridge.test.js
@@ -542,7 +542,7 @@ describe("transport timeout self-heal (#839)", () => {
       const s = HttpSession.create({
         mcpUrl: "https://127.0.0.1:" + silent.port + "/v1/slug",
         token: "TKN", pinnedFp: "sha256:" + "a".repeat(64),
-        connectMs: 80, idleMs: 5000,
+        connectMs: 80, idleMs: 5000, errOut: () => {},
       });
       // Real socket to the silent listener; secureConnect never fires.
       s.requester = (opts) => http.request({ host: "127.0.0.1", port: silent.port, method: opts.method });
@@ -770,6 +770,188 @@ describe("transport timeout self-heal (#839)", () => {
       "readBounded's ref'd idle deadline must reject, not hang the idle loop"
     );
     assert.ok(Date.now() - t0 < 4000, "settled at the ~30ms idle deadline, not forever");
+  });
+
+  // ── #872: proactive dormancy reconnect + session-id restore + observability ──
+  function jsonRes872(obj) {
+    return { status: 200, contentType: "application/json", res: bodyStream(Buffer.from(JSON.stringify(obj))) };
+  }
+  function sessionNotFoundRes872(id) {
+    return { status: 404, contentType: "application/json",
+      res: bodyStream(Buffer.from(JSON.stringify({ id, error: "Session not found" }))) };
+  }
+
+  // (1) Dormancy → a proactive re-init fires BEFORE any slow-failure deadline is
+  // paid. The tools/call responder returns success (no 404/timeout signal), yet
+  // initCount goes 1→2 — only possible via the proactive dormancy path.
+  it("test_dormancy_proactiveReconnectFiresBeforeAnyTimeout (#872 Gap1)", async () => {
+    const t = { v: 1000 };
+    const now = () => t.v;
+    const sess = {
+      sent: [], sessionId: null, protocolVersion: null, initCount: 0, idCounter: 0,
+      request(body, opts) {
+        sess.sent.push({ opts, sessionAtSend: sess.sessionId });
+        if (opts && opts.isInitialize) {
+          sess.initCount += 1; sess.sessionId = "SID-" + ++sess.idCounter;
+          return Promise.resolve(jsonRes872({ jsonrpc: "2.0", id: body.id, result: { protocolVersion: "2025-06-18" } }));
+        }
+        return Promise.resolve(jsonRes872({ jsonrpc: "2.0", id: body.id, result: { ok: true } }));
+      },
+    };
+    const lc = new Lifecycle(sess, { errOut: () => {}, now, staleMs: 100000 });
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize" });
+    assert.strictEqual(sess.initCount, 1);
+    const initId = sess.sessionId;
+    t.v += 100001; // long dormancy: advance the injected clock past STALE_MS
+    const out = await lc.handle({ jsonrpc: "2.0", id: 9, method: "tools/call", params: {} });
+    assert.deepStrictEqual(out.result, { ok: true }, "call succeeded on the fresh session");
+    assert.strictEqual(sess.initCount, 2, "a proactive re-init fired before dispatch");
+    assert.notStrictEqual(sess.sessionId, initId, "dispatched under a fresh session id");
+  });
+
+  // Healthy short gaps must NOT trigger a proactive re-init (F1: no spurious churn).
+  it("test_dormancy_freshSessionNoProactiveReinit (#872 Gap1/F1)", async () => {
+    const t = { v: 1000 };
+    const now = () => t.v;
+    const sess = {
+      sent: [], sessionId: null, protocolVersion: null, initCount: 0, idCounter: 0,
+      request(body, opts) {
+        if (opts && opts.isInitialize) {
+          sess.initCount += 1; sess.sessionId = "SID-" + ++sess.idCounter;
+          return Promise.resolve(jsonRes872({ jsonrpc: "2.0", id: body.id, result: {} }));
+        }
+        return Promise.resolve(jsonRes872({ jsonrpc: "2.0", id: body.id, result: { ok: true } }));
+      },
+    };
+    const lc = new Lifecycle(sess, { errOut: () => {}, now, staleMs: 100000 });
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize" });
+    t.v += 10; // small gap, well under STALE_MS
+    await lc.handle({ jsonrpc: "2.0", id: 9, method: "tools/call", params: {} });
+    assert.strictEqual(sess.initCount, 1, "no spurious proactive re-init on a healthy gap");
+  });
+
+  // (2) Heal-exhaustion preserves sessionId: a failed re-init restores the evicted
+  // id — the bridge is never left dispatching session-less (→ server 422 wedge).
+  it("test_healExhaustion_preservesSessionId_notWedgedSessionless (#872 Gap2)", async () => {
+    let initCount = 0;
+    const sess = {
+      sent: [], sessionId: "OLD", protocolVersion: null,
+      request(body, opts) {
+        sess.sent.push({ opts, sessionAtSend: sess.sessionId });
+        if (opts && opts.isInitialize) {
+          initCount += 1;
+          if (initCount === 1) { sess.sessionId = "SID-1"; return Promise.resolve(jsonRes872({ jsonrpc: "2.0", id: body.id, result: {} })); }
+          return Promise.reject(Object.assign(new Error("stall"), { code: "ETIMEDOUT" })); // re-init stalls
+        }
+        return Promise.reject(Object.assign(new Error("stall"), { code: "ETIMEDOUT" })); // call stalls
+      },
+    };
+    const lc = new Lifecycle(sess, { errOut: () => {} });
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize" });
+    assert.strictEqual(sess.sessionId, "SID-1");
+    const out = await lc.handle({ jsonrpc: "2.0", id: 13, method: "tools/call", params: {} });
+    assert.ok(out.error, "bounded error surfaced");
+    assert.strictEqual(sess.sessionId, "SID-1", "session id restored, not left null/session-less");
+    // The next dispatch still carries the (evicted) id → server 404 → #830 heal.
+    const lastSend = sess.sent[sess.sent.length - 1];
+    assert.ok(lastSend, "a request was dispatched");
+  });
+
+  // (3) Recovery is bounded to the SHORT connect budget, never the idle budget.
+  // Real socket to a silent listener: connect never completes; proactive re-init
+  // + reactive heal each settle at the 80ms connect deadline (not the 5000ms idle
+  // budget) → total worst case stays well inside human/harness tolerance.
+  it("test_proactiveReconnect_boundedToConnectBudget (#872 Gap3)", async () => {
+    const silent = await startSilentTcpServer();
+    try {
+      const s = HttpSession.create({
+        mcpUrl: "https://127.0.0.1:" + silent.port + "/v1/slug",
+        token: "TKN", pinnedFp: "sha256:" + "a".repeat(64),
+        connectMs: 80, idleMs: 5000, errOut: () => {},
+      });
+      s.requester = (opts) => http.request({ host: "127.0.0.1", port: silent.port, method: opts.method });
+      s.sessionId = "OLD"; // an initialized-but-stale session
+      const t = { v: 1000 };
+      const lc = new Lifecycle(s, { errOut: () => {}, now: () => t.v, staleMs: 100 });
+      lc.initMessage = { jsonrpc: "2.0", id: 0, method: "initialize", params: { clientInfo: { name: "claude-code" } } };
+      t.v += 1000; // past STALE_MS → proactive path engages on the next call
+      const t0 = Date.now();
+      const out = await lc.handle({ jsonrpc: "2.0", id: 9, method: "tools/call", params: {} });
+      assert.ok(Date.now() - t0 < 4000, "settled on connect budgets, not the 5000ms idle budget");
+      assert.ok(out.error, "bounded error surfaced against a still-dead socket");
+      assert.strictEqual(s.sessionId, "OLD", "Gap 2 holds: evicted id restored, not null");
+    } finally {
+      await silent.close();
+    }
+  });
+
+  // (4) B1: a throwing errOut on the heal path must be a TRUE no-op — the heal
+  // still completes. Without the try/catch wrap the logging throw is swallowed by
+  // handle():_reinit and silently ABORTS the heal (regression guard for #869).
+  it("test_b1_errOutThrows_healStillCompletes (#872 B1)", async () => {
+    let firstCall = true, initCount = 0;
+    const sess = {
+      sent: [], sessionId: "OLD", protocolVersion: null,
+      request(body, opts) {
+        if (opts && opts.isInitialize) { initCount += 1; sess.sessionId = "SID-" + initCount; return Promise.resolve(jsonRes872({ jsonrpc: "2.0", id: body.id, result: {} })); }
+        if (firstCall) { firstCall = false; return Promise.resolve(sessionNotFoundRes872(body.id)); } // evicted
+        return Promise.resolve(jsonRes872({ jsonrpc: "2.0", id: body.id, result: { ok: true } })); // retry on new id
+      },
+    };
+    const throwingErrOut = () => { throw new Error("stderr is closed"); };
+    const lc = new Lifecycle(sess, { errOut: throwingErrOut });
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize" });
+    const out = await lc.handle({ jsonrpc: "2.0", id: 9, method: "tools/call", params: {} });
+    assert.deepStrictEqual(out.result, { ok: true }, "heal completed despite a throwing errOut");
+    assert.strictEqual(initCount, 2, "exactly one re-init; the logging throw did not abort the heal");
+  });
+
+  // (5a) transport_timeout carries idle_ms and leaks no token / no full session id.
+  it("test_observability_transportTimeout_hasIdleMs_noSecrets (#872 obs)", async () => {
+    const errs = [];
+    const s = HttpSession.create({
+      mcpUrl: "https://h.example/v1/slug", token: "TKN-SECRET",
+      pinnedFp: "sha256:" + "a".repeat(64), connectMs: 20, idleMs: 5000,
+      errOut: (x) => errs.push(x),
+    });
+    s.sessionId = "SESSIONID-abcdef123456";
+    s.lastActivityMs = Date.now() - 500;
+    s.requester = () => {
+      const req = makeFakeReq();
+      req.destroy = (e) => { req.destroyed = e || true; process.nextTick(() => req.emit("error", e || new Error("x"))); };
+      return req; // never connects → the connect deadline fires
+    };
+    await assert.rejects(s.request({ method: "tools/call", id: 1 }, {}), (e) => e && e.code === "ETIMEDOUT");
+    const line = errs.join("");
+    assert.match(line, /mcp-bridge: transport_timeout /);
+    assert.match(line, /phase=connect/);
+    assert.match(line, /elapsed_ms=\d+/);
+    assert.match(line, /idle_ms=\d+/);
+    assert.ok(!line.includes("TKN-SECRET"), "bearer token never emitted");
+    assert.ok(!line.includes("SESSIONID-abcdef123456"), "full session id never emitted");
+  });
+
+  // (5b) reinit_fail emits session=restored and leaks no raw id / token.
+  it("test_observability_reinitFail_sessionRestored_noSecrets (#872 obs)", async () => {
+    const errs = [];
+    let initCount = 0;
+    const sess = {
+      sent: [], sessionId: "SID-SECRET-9999", protocolVersion: null,
+      request(body, opts) {
+        if (opts && opts.isInitialize) {
+          initCount += 1;
+          if (initCount === 1) return Promise.resolve(jsonRes872({ jsonrpc: "2.0", id: body.id, result: {} }));
+          return Promise.reject(Object.assign(new Error("stall"), { code: "ETIMEDOUT" }));
+        }
+        return Promise.reject(Object.assign(new Error("stall"), { code: "ETIMEDOUT" }));
+      },
+    };
+    const lc = new Lifecycle(sess, { errOut: (x) => errs.push(x) });
+    await lc.handle({ jsonrpc: "2.0", id: 0, method: "initialize" });
+    await lc.handle({ jsonrpc: "2.0", id: 13, method: "tools/call", params: {} });
+    const line = errs.join("");
+    assert.match(line, /mcp-bridge: reinit_fail session=restored/);
+    assert.ok(!line.includes("SID-SECRET-9999"), "raw session id never emitted");
   });
 });
 


### PR DESCRIPTION
Fixes #872.

## Problem
The Personal Cloud edge client hangs on the first call after a long idle period and never recovers. The reporter expects the **client** to recover on resume by reconnecting — no server action.

## Why prior fixes didn't close it
The #831 / #842 / #848 lineage armed reactive timeouts, routed `ETIMEDOUT` into self-heal, and ref'd the F6 idle-read timers. That machinery is **reactive and single-shot with no notion of elapsed idle time** — every recovery path only fires *after* a live call has already burned a connect (15s) or idle (120s) deadline, and one path could wedge the session.

## Root cause (two gaps)
- **Gap 1 — no proactive dormancy reconnect.** Recovery never fires until a deadline is paid, so it reads as a hang. This was #839's explicitly-deferred item 4; never built.
- **Gap 2 — session-id null-poisoning wedge.** `_doReinit` nulled `sessionId` before the re-init POST; if that POST also timed out, `sessionId` stayed `null`, and the bridge then dispatched every later call session-less. rmcp 1.7.0 answers a session-less non-init POST with **HTTP 422** (not a heal-triggering 404) — a permanent wedge.

## Fix (client-side, JS/TS mcp-bridge only)
1. **Gap 1** — track `lastActivityMs` (seeded to `now`); in `handle()`, run the existing single-flight `_reinit()` proactively when `now - lastActivityMs > STALE_MS`, **fail-open** (fall through to normal dispatch if it fails), on the short connect budget. `STALE_MS` default **2.5h** (62.5% of the 4h server keep-alive), override `UNIMATRIX_HOOK_MCP_STALE_MS`.
2. **Gap 2** — restore `prevId` on a failed re-init; never leave `sessionId === null`.
3. **Observability (errors-only, always-on)** — via the existing `errOut`→stderr seam, one dialect (`mcp-bridge: <event> key=value`):
   - `transport_timeout phase=connect|idle elapsed_ms=<int> idle_ms=<int>` — `idle_ms` distinguishes dormancy timeout from server-down.
   - `reinit_fail session=restored`.
   - Redacted (no Bearer token, no full session id); every emit wrapped in a true no-op try/catch so a logging throw can never abort the heal — enforced by a test.

## Tests (DoD)
7 new tests in `mcp-bridge.test.js`:
- `test_dormancy_proactiveReconnectFiresBeforeAnyTimeout` — proactive reconnect fires before a slow failure is paid.
- `test_healExhaustion_preservesSessionId_notWedgedSessionless` — session preserved after heal-exhaustion.
- `test_proactiveReconnect_boundedToConnectBudget` — recovery bounded to the connect budget.
- `test_b1_errOutThrows_healStillCompletes` — a throwing `errOut` never aborts the heal.
- `test_dormancy_freshSessionNoProactiveReinit`, `test_observability_transportTimeout_hasIdleMs_noSecrets`, `test_observability_reinitFail_sessionRestored_noSecrets`.

Results: bridge 61/0 (7 new), hook-client 771 pass/1 platform-skip, integration smoke 26/0, cross-transport parity (layer2 HTTPS-vs-UDS) 24/0, `cargo build --workspace` clean (0 Rust files changed).

## Convergence (on the record)
This session believes #872 is the **terminal fix for the reported dormancy/wake hang mode**: it builds the proactive reconnect the whole lineage deferred and closes the non-recovery wedge that made prior reactive patches fail to recover. It does **not** claim closure of the entire half-open-transport class — the errors-only observability (`idle_ms` / `transport_timeout` / `reinit_fail`) is shipped deliberately so any future instance arrives with evidence instead of guesswork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
