### PR TITLE
fix: cap concurrent-link RSS to stop workspace test-link OOM (#878)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,18 @@
 # Override via environment variables for other setups:
 #   export ORT_LIB_LOCATION=/path/to/ort
 #   export ORT_PREFER_DYNAMIC_LINK=1
+# Bound concurrent-link RSS to keep the full-workspace build off the memory ceiling (#878).
+# The BFD `ld` OOM-killed at the `cargo test --workspace` link step: N-parallel-link RSS
+# summed past available RAM (swap exhausted). After the [profile.dev] debug-info reduction
+# in root Cargo.toml, measured peak `ld` RSS is ~1112 MB per heavy server-integration link
+# (was ~1842 MB). Empirically at default -j=nproc(10) min MemAvailable bottomed at ~1134 MB;
+# at jobs=7 it was ~1652 MB (under the 20% headroom line); at jobs=6 it was ~2463 MB — the
+# highest cap that holds comfortable margin (swap=0). jobs=6 keeps 6-way compile parallelism
+# on a 10-core box; local/agent/devcontainer only (GH CI is JS-client-only). Override for a
+# faster build on a larger box via `cargo --jobs N` or CARGO_BUILD_JOBS.
+[build]
+jobs = 6
+
 [env]
 ORT_LIB_LOCATION = { value = "/usr/local/lib", force = false }
 ORT_PREFER_DYNAMIC_LINK = { value = "1", force = false }

--- a/.claude/agents/uni/uni-tester.md
+++ b/.claude/agents/uni/uni-tester.md
@@ -101,11 +101,12 @@ test-plan/
 ### What You Do
 
 1. Execute unit tests via the hardened convention (see "Cargo Output Truncation" below): `log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_SECS:-600}" cargo test --workspace > "$log" 2>&1; rc=$?; tail -30 "$log"; rm -f "$log"; exit $rc`
-2. Execute integration smoke tests (MANDATORY gate): `cd product/test/infra-001 && python -m pytest suites/ -v -m smoke --timeout=60`
-3. Execute relevant integration suites based on what the feature touches (see suite selection table below)
-4. Execute feature-level tests mapped to the Risk Strategy
-5. Verify every identified risk has test coverage
-6. Triage any integration test failures per the failure triage rules below
+2. Execute the full-workspace LINK smoke (#878 regression guard — MANDATORY for any Rust change): `bash product/test/infra-002/check-workspace-link-smoke.sh` — links all workspace test binaries at the configured parallelism, no test execution. Exit 0 = link holds; 1 = link failed (OOM signature reported = the #878 link-OOM is back — do NOT salvage with `--lib`/`-j1`, re-derive the profile/jobs settings); 3 = self-skipped (no cargo). This exists because `--lib` salvage SKIPS integration links and hid #878 three times.
+3. Execute integration smoke tests (MANDATORY gate): `cd product/test/infra-001 && python -m pytest suites/ -v -m smoke --timeout=60`
+4. Execute relevant integration suites based on what the feature touches (see suite selection table below)
+5. Execute feature-level tests mapped to the Risk Strategy
+6. Verify every identified risk has test coverage
+7. Triage any integration test failures per the failure triage rules below
 
 ### What You Produce
 

--- a/.claude/rules/rust-workspace.md
+++ b/.claude/rules/rust-workspace.md
@@ -22,7 +22,29 @@ log="$(mktemp -t uni-test.XXXXXX.log)"; setsid -w timeout "${CARGO_TEST_TIMEOUT_
 
 # Clippy: first warnings only
 cargo clippy --workspace -- -D warnings 2>&1 | head -30
+
+# Full-workspace LINK smoke (#878 regression guard) — run for any Rust change / pre-PR gate.
+# Links every workspace test binary (--no-run) at the configured `jobs` cap; NO test run.
+# Exit 0 = link holds; 1 = link failed (an OOM signature = the #878 link-step OOM is BACK —
+# do NOT salvage with `--lib` or `-j1`; re-derive [profile.dev] debug + .cargo jobs cap);
+# 3 = self-skipped (no cargo). `--lib` salvage skips integration links and masked #878 thrice.
+bash product/test/infra-002/check-workspace-link-smoke.sh
 ```
+
+## Build-memory guardrails (#878)
+
+`cargo test --workspace` OOM-killed `ld` at the LINK step: cumulative N-parallel-link RSS
+summed past the memory ceiling (swap exhausted). Two config-only levers keep it off the wall
+(release profile UNTOUCHED — the shipped `--release` binary is unchanged):
+
+- Root `Cargo.toml` `[profile.dev]`: `debug = "line-tables-only"` (keeps file:line panic
+  backtraces, drops variable DWARF) + `split-debuginfo = "unpacked"` (keeps DWARF out of the
+  linker's relocation path). Set on `dev`, not `test` — `cargo test` builds deps under `dev`.
+- `.cargo/config.toml` `[build] jobs`: an empirically-derived cap bounding concurrent-link
+  RSS. Default `-j nproc` still OOMs post-profile (measured); the cap is what delivers safety.
+
+Do NOT restore `debug = 2` on dev, remove `split-debuginfo`, or raise `jobs` toward `nproc`
+without re-measuring peak `ld` RSS. The link smoke above trips if any of these regress.
 
 ## Hardened cargo test convention (canonical — copy byte-identical)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,25 @@
 members = ["crates/*"]
 resolver = "3"
 
+# Build-profile tuning for the full-workspace link (#878).
+# The linker (BFD `ld`) OOM-killed (SIGKILL) at the `cargo test --workspace` link
+# step: cumulative N-parallel-link RSS summed past the memory ceiling. `debug = 2`
+# (the default) produced 350-477 MB test binaries; peak `ld` RSS was ~1,842 MB per
+# heavy server integration link, and up to `-j nproc` such links overlap.
+#
+# Two independent levers reduce per-link `ld` RSS (release profile is UNTOUCHED —
+# the shipped `--release` binary is unchanged):
+#   - debug = "line-tables-only": keeps file:line panic backtraces (what CI/agents
+#     read); drops variable-level DWARF. Cuts debug-info volume.
+#   - split-debuginfo = "unpacked": keeps DWARF in .o/.dwo files instead of relocating
+#     it into the linked image — attacks `ld` RSS most directly, at full fidelity.
+# Set on [profile.dev] (NOT [profile.test]): `cargo test` builds its dependency graph
+# under `dev`, and `test` inherits `dev`, so this one stanza covers the fat dep objects
+# that a [profile.test]-only override would miss.
+[profile.dev]
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
+
 [workspace.package]
 version = "0.8.9"
 edition = "2024"

--- a/product/test/infra-002/README.md
+++ b/product/test/infra-002/README.md
@@ -74,6 +74,19 @@ The #878 fix is config-only: `[profile.dev]` debug-info reduction in root `Cargo
 execution) at the repo's **configured parallelism** and FAILS if the link does not complete,
 distinguishing an OOM (the #878 mode) from an ordinary compile/link error.
 
+It ALSO runs a cheap, environment-independent **profile-presence assertion** first: root
+`Cargo.toml`'s `[profile.dev]` must carry BOTH `debug = "line-tables-only"` AND
+`split-debuginfo = "unpacked"` (section-scoped — the keys in another table such as
+`[profile.release]` do not count; tolerant of whitespace and quote style; no TOML parser).
+This is needed because the link-based removal detection is **memory-ceiling-dependent** — on
+a higher-RAM box, dropping `[profile.dev]` could still link clean and leave the guard falsely
+GREEN. The grep-assert makes stanza detection hold regardless of RAM and reports as a distinct
+`profile-presence` failure, legibly separate from a link OOM.
+
+**Failure modes (all exit 1):** `profile-presence` — required `[profile.dev]` lever(s)
+missing; linker `OOM` — the #878 link-step OOM is back; ordinary compile/link error — a
+non-OOM build break unrelated to #878.
+
 **Why the configured `jobs` cap and not default `-j nproc`:** MEASURED post-fix, peak `ld`
 RSS is ~1112 MB per heavy server link and default `-j nproc(10)` STILL OOMs (≈11 GB demand
 vs ~9.4 GB avail, swap=0). Safety comes from the jobs cap, not from making 10-way links fit,

--- a/product/test/infra-002/README.md
+++ b/product/test/infra-002/README.md
@@ -55,3 +55,44 @@ Exit codes: `0` clean, `1` violation(s) found, `2` usage/self-test failure.
 
 Tier A only. Tier B (hook-based reaping in `unimatrix-observe`) and Tier C (per-crate
 routine testing default) are deferred to follow-up issues — see #122 discussion.
+
+---
+
+# infra-002 full-workspace LINK smoke — regression guard for bug #878 (link-step OOM)
+
+Bug #878: `cargo test --workspace` OOM-killed `ld` at the **link** step — cumulative
+N-parallel-link RSS summed past the memory ceiling (swap exhausted). It was salvaged three
+times without exercising the real thing: `-j1` (#750), then `--lib` (#873/#877, which
+**skips integration-test links entirely**), then the #878 fix. Nothing exercised the
+full-workspace link, so a re-regression stayed invisible until a human ran the full suite.
+
+The #878 fix is config-only: `[profile.dev]` debug-info reduction in root `Cargo.toml`
+(`debug = "line-tables-only"` + `split-debuginfo = "unpacked"`) plus an empirically-derived
+`[build] jobs` cap in `.cargo/config.toml`.
+
+`check-workspace-link-smoke.sh` runs `cargo test --workspace --no-run` (link only, no test
+execution) at the repo's **configured parallelism** and FAILS if the link does not complete,
+distinguishing an OOM (the #878 mode) from an ordinary compile/link error.
+
+**Why the configured `jobs` cap and not default `-j nproc`:** MEASURED post-fix, peak `ld`
+RSS is ~1112 MB per heavy server link and default `-j nproc(10)` STILL OOMs (≈11 GB demand
+vs ~9.4 GB avail, swap=0). Safety comes from the jobs cap, not from making 10-way links fit,
+so a default-`-j` smoke is guaranteed-RED and un-gateable. It is also **not** `-j1` (a single
+link always fits and would neuter the guard). At the cap it sums the real operational load
+(e.g. 6 × 1112 ≈ 6.7 GB), and still TRIPS when (a) cumulative growth pushes cap × per-link
+past the ceiling, or (b) the `[profile.dev]` levers are removed (per-link reverts to
+~1842 MB → cap × 1842 ≈ 11 GB → OOM). So it also guards the fix's *presence* without a
+separate profile-presence assertion, and gates unsafe `jobs`-cap raises.
+
+## Run
+
+```bash
+# link-only smoke at configured parallelism (pre-PR / Rust protocol test gate)
+bash product/test/infra-002/check-workspace-link-smoke.sh
+
+# prove the OOM-detection logic without provoking a real OOM
+bash product/test/infra-002/check-workspace-link-smoke.sh --self-test
+```
+
+Exit codes: `0` link holds · `1` link failed (OOM or other) · `2` usage/self-test failure ·
+`3` self-skipped (no cargo). Tunable: `LINK_SMOKE_TIMEOUT_SECS` (default 1200).

--- a/product/test/infra-002/check-workspace-link-smoke.sh
+++ b/product/test/infra-002/check-workspace-link-smoke.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# infra-002 full-workspace LINK smoke — durable guard for bug #878 (link-step OOM).
+#
+# Bug recap: `cargo test --workspace` OOM-killed (SIGKILL) at the LINK step — the BFD
+# `ld` process was killed because cumulative N-parallel-link RSS summed past the memory
+# ceiling (swap exhausted). The failure was salvaged THREE times without ever exercising
+# the real thing: `-j1` (#750), then `--lib` (#873/#877, which SKIPS the integration-test
+# links entirely), then this fix (#878). Nothing exercised the full-workspace link, so a
+# re-regression stayed invisible until a human ran the full suite locally.
+#
+# This guard runs `cargo test --workspace --no-run` — link only, no test execution — at
+# the repo's CONFIGURED build parallelism (the `jobs` cap in .cargo/config.toml) and FAILS
+# if the link does not complete.
+#
+# Why the configured cap and NOT default `-j nproc`: MEASURED on the #878 box, after the
+# [profile.dev] debug-info reduction, peak `ld` RSS is ~1112 MB per heavy server link and
+# default `-j nproc(10)` STILL OOMs (10 x 1112 ~= 11 GB > ~9.4 GB avail, swap exhausted).
+# The fix delivers link safety through the jobs cap, not by making 10-way links fit — so a
+# default-`-j` smoke is guaranteed-RED post-fix and could never be a green gate check.
+# It is also NOT `-j1`: a single link always fits (~1.1-1.8 GB) and would neuter the guard.
+# Running at the configured cap sums the real operational load (e.g. 6 x 1112 ~= 6.7 GB of
+# concurrent link RSS) — a genuine memory stress that still TRIPS on:
+#   - cumulative growth: when per-link RSS grows enough that cap x per-link crosses the
+#     ceiling (the exact recurrence this cycle-breaks), AND
+#   - profile-stanza removal: without [profile.dev]'s levers per-link reverts to ~1842 MB,
+#     so cap x 1842 (e.g. 6 x 1842 ~= 11 GB) OOMs -> RED. The guard therefore also covers
+#     the fix's *presence* without a separate profile-presence assertion.
+# If the cap is later raised in config, this guard runs at the raised value and goes RED if
+# that raise is unsafe — correctly gating cap changes too.
+#
+# Why a standalone shell guard (not a `cargo test` target): the invariant it protects is
+# "the workspace still LINKS under its real build parallelism". This trips on the actual
+# outcome, BEFORE a `--lib` salvage (which skips the integration-test links entirely) can
+# hide a re-regression — the salvage that masked #878 three times (#750, #873/#877).
+#
+# Run:
+#   bash product/test/infra-002/check-workspace-link-smoke.sh
+#   bash product/test/infra-002/check-workspace-link-smoke.sh --self-test
+#
+# Exit codes:
+#   0 = full-workspace link completed (invariant holds)
+#   1 = link failed — OOM (SIGKILL/signal 9) or any other link/compile error
+#   2 = usage / self-test failure
+#   3 = self-skipped (cargo unavailable) — non-blocking in environments without a toolchain
+#
+# Tunable: LINK_SMOKE_TIMEOUT_SECS (default 1200) — hard ceiling for the link-only build.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+# Signatures of a linker OOM (the #878 failure mode). Any of these in the build output
+# means the linker was killed by the OOM killer rather than exiting on a normal error.
+OOM_REGEX='signal:? 9|SIGKILL|terminated with signal 9|\[Killed\]|Killed\b|out of memory|Cannot allocate memory'
+
+# classify_link_output RC LOGFILE
+#   Emits a human verdict and returns: 0 = passed, 1 = failed. On failure, distinguishes
+#   an OOM (the bug this guard exists for) from an ordinary compile/link error.
+classify_link_output() {
+  local rc="$1" log="$2"
+  if [ "${rc}" -eq 0 ]; then
+    echo "PASS: full-workspace --no-run link completed at configured parallelism (#878 invariant holds)."
+    return 0
+  fi
+  if grep -qiE "${OOM_REGEX}" "${log}" 2>/dev/null; then
+    echo "FAIL: linker OOM at the workspace link step (rc=${rc}) — the #878 regression is BACK."
+    echo "      Cumulative parallel-link RSS crossed the memory ceiling. Do NOT salvage with"
+    echo "      --lib or -j1; re-derive the [profile.dev] debug settings / .cargo jobs cap."
+    grep -iE "${OOM_REGEX}" "${log}" 2>/dev/null | head -5 | sed 's/^/      > /'
+    return 1
+  fi
+  echo "FAIL: workspace --no-run link did not complete (rc=${rc}), no OOM signature found —"
+  echo "      likely an ordinary compile/link error unrelated to #878. Tail:"
+  tail -8 "${log}" 2>/dev/null | sed 's/^/      > /'
+  return 1
+}
+
+run_link_smoke() {
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "SKIP: cargo not found — link smoke self-skipped (exit 3)."
+    return 3
+  fi
+  local log rc
+  log="$(mktemp -t uni-linksmoke.XXXXXX.log)"
+  # NO --jobs flag: inherit .cargo/config.toml's `jobs` cap (the repo's real parallelism).
+  echo "[878-link-smoke] cargo test --workspace --no-run at configured parallelism (ceiling ${LINK_SMOKE_TIMEOUT_SECS:-1200}s)"
+  # Own session/process group + hard ceiling + file-not-pipe — same orphan-safety contract
+  # as the hardened cargo-test convention (infra-002 / #122 / GH#709). setsid -w propagates
+  # the child's real exit code (bare setsid returns the fork's 0 -> false green).
+  setsid -w timeout "${LINK_SMOKE_TIMEOUT_SECS:-1200}" \
+    cargo test --workspace --no-run \
+    > "${log}" 2>&1
+  rc=$?
+  if [ "${rc}" -eq 124 ]; then
+    echo "FAIL: link smoke killed at the ${LINK_SMOKE_TIMEOUT_SECS:-1200}s ceiling (rc=124) — investigate a hang or a swap-thrash stall (a near-OOM box thrashes before it kills)."
+    rm -f "${log}"
+    return 1
+  fi
+  classify_link_output "${rc}" "${log}"
+  local verdict=$?
+  rm -f "${log}"
+  return "${verdict}"
+}
+
+# --self-test proves the OOM-detection logic without provoking a real OOM: feed a captured
+# linker-OOM log and a clean log through classify_link_output and assert the verdicts.
+# capture VERDICT_OUT (stdout) and VERDICT_RC (return code) of classify_link_output
+# without a pipe — `set -o pipefail` would otherwise surface the function's non-zero
+# return through a `classify | grep` pipeline and mask grep's real match result.
+_classify_capture() {
+  VERDICT_OUT="$(classify_link_output "$1" "$2")"; VERDICT_RC=$?
+}
+
+self_test() {
+  local tmp fails=0
+  echo "[self-test] classify_link_output OOM detection"
+
+  tmp="$(mktemp)"
+  printf '%s\n' \
+    'error: linking with `cc` failed: exit status: 1' \
+    'collect2: fatal error: ld terminated with signal 9 [Killed]' > "${tmp}"
+  _classify_capture 1 "${tmp}"
+  if [ "${VERDICT_RC}" -eq 0 ]; then
+    echo "  FAIL: an OOM log (signal 9 [Killed]) was NOT flagged as failure"; fails=1
+  elif ! printf '%s' "${VERDICT_OUT}" | grep -q 'linker OOM'; then
+    echo "  FAIL: OOM log flagged, but not classified as an OOM"; fails=1
+  else
+    echo "  ok: OOM log -> FAIL + OOM classification"
+  fi
+  rm -f "${tmp}"
+
+  tmp="$(mktemp)"
+  printf '%s\n' '    Finished `test` profile [unoptimized + debuginfo] target(s) in 42s' > "${tmp}"
+  _classify_capture 0 "${tmp}"
+  if [ "${VERDICT_RC}" -eq 0 ]; then
+    echo "  ok: clean 'Finished' log (rc=0) -> PASS"
+  else
+    echo "  FAIL: a clean rc=0 link was flagged as failure"; fails=1
+  fi
+  rm -f "${tmp}"
+
+  tmp="$(mktemp)"
+  printf '%s\n' 'error[E0432]: unresolved import `foo::bar`' > "${tmp}"
+  _classify_capture 1 "${tmp}"
+  if [ "${VERDICT_RC}" -ne 0 ] && printf '%s' "${VERDICT_OUT}" | grep -q 'ordinary compile/link error'; then
+    echo "  ok: non-OOM error (rc=1) -> FAIL, classified as ordinary error (not #878)"
+  else
+    echo "  FAIL: a non-OOM error was misclassified"; fails=1
+  fi
+  rm -f "${tmp}"
+
+  if [ "${fails}" -eq 0 ]; then echo "[self-test] PASS"; return 0; fi
+  echo "[self-test] FAIL"; return 2
+}
+
+main() {
+  case "${1:-}" in
+    --self-test) self_test; exit $? ;;
+    "") : ;;
+    *) echo "usage: $0 [--self-test]" >&2; exit 2 ;;
+  esac
+  cd "${REPO_ROOT}" || { echo "cannot cd to repo root ${REPO_ROOT}" >&2; exit 2; }
+  run_link_smoke
+  exit $?
+}
+
+main "$@"

--- a/product/test/infra-002/check-workspace-link-smoke.sh
+++ b/product/test/infra-002/check-workspace-link-smoke.sh
@@ -24,10 +24,16 @@
 #   - cumulative growth: when per-link RSS grows enough that cap x per-link crosses the
 #     ceiling (the exact recurrence this cycle-breaks), AND
 #   - profile-stanza removal: without [profile.dev]'s levers per-link reverts to ~1842 MB,
-#     so cap x 1842 (e.g. 6 x 1842 ~= 11 GB) OOMs -> RED. The guard therefore also covers
-#     the fix's *presence* without a separate profile-presence assertion.
+#     so cap x 1842 (e.g. 6 x 1842 ~= 11 GB) OOMs -> RED — ON THIS BOX.
 # If the cap is later raised in config, this guard runs at the raised value and goes RED if
 # that raise is unsafe — correctly gating cap changes too.
+#
+# The link run's profile-removal detection is MEMORY-CEILING-DEPENDENT: on a higher-RAM box
+# dropping [profile.dev] could still link clean and leave the guard falsely GREEN. So this
+# script ALSO runs a cheap, environment-independent grep-assert (assert_profile_present) that
+# fails if root Cargo.toml's [profile.dev] does not carry BOTH debug = "line-tables-only" AND
+# split-debuginfo = "unpacked". That makes stanza-presence detection hold regardless of RAM,
+# and reports as a distinct "profile-presence" failure (legibly separate from a link OOM).
 #
 # Why a standalone shell guard (not a `cargo test` target): the invariant it protects is
 # "the workspace still LINKS under its real build parallelism". This trips on the actual
@@ -39,8 +45,8 @@
 #   bash product/test/infra-002/check-workspace-link-smoke.sh --self-test
 #
 # Exit codes:
-#   0 = full-workspace link completed (invariant holds)
-#   1 = link failed — OOM (SIGKILL/signal 9) or any other link/compile error
+#   0 = full-workspace link completed (invariant holds) AND [profile.dev] levers present
+#   1 = FAIL — link failed (OOM/other) OR required [profile.dev] levers missing (profile-presence)
 #   2 = usage / self-test failure
 #   3 = self-skipped (cargo unavailable) — non-blocking in environments without a toolchain
 #
@@ -54,6 +60,50 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 # Signatures of a linker OOM (the #878 failure mode). Any of these in the build output
 # means the linker was killed by the OOM killer rather than exiting on a normal error.
 OOM_REGEX='signal:? 9|SIGKILL|terminated with signal 9|\[Killed\]|Killed\b|out of memory|Cannot allocate memory'
+
+# _extract_profile_dev_block FILE
+#   Prints the body lines of the [profile.dev] table only (from the `[profile.dev]` header
+#   to the next `[...]` table header). Section-scoped so a `debug`/`split-debuginfo` in any
+#   OTHER table (e.g. [profile.release]) cannot satisfy the assertion. awk reads the file as
+#   a data arg — no eval, injection-safe.
+_extract_profile_dev_block() {
+  awk '
+    /^[[:space:]]*\[profile\.dev\][[:space:]]*$/ { inblk=1; next }
+    /^[[:space:]]*\[/                            { inblk=0 }
+    inblk                                        { print }
+  ' "$1"
+}
+
+# assert_profile_present CARGO_TOML
+#   Environment-independent presence check for the #878 fix: [profile.dev] must carry BOTH
+#   debug = "line-tables-only" AND split-debuginfo = "unpacked". Tolerant of surrounding
+#   whitespace and single/double quotes; NOT a TOML parser. Emits a distinct "profile-presence"
+#   verdict. Returns: 0 = both levers present, 1 = stanza/lever missing.
+assert_profile_present() {
+  local cargo="$1" body missing=""
+  if [ ! -f "${cargo}" ]; then
+    echo "FAIL: profile-presence — root Cargo.toml not found at ${cargo} (#878)."
+    return 1
+  fi
+  body="$(_extract_profile_dev_block "${cargo}")"
+  if [ -z "${body}" ]; then
+    echo "FAIL: profile-presence — [profile.dev] stanza missing from root Cargo.toml (#878)."
+    echo "      Restore it with debug = \"line-tables-only\" and split-debuginfo = \"unpacked\"."
+    return 1
+  fi
+  printf '%s\n' "${body}" | grep -Eq "^[[:space:]]*debug[[:space:]]*=[[:space:]]*[\"']line-tables-only[\"']" \
+    || missing="${missing} debug=\"line-tables-only\""
+  printf '%s\n' "${body}" | grep -Eq "^[[:space:]]*split-debuginfo[[:space:]]*=[[:space:]]*[\"']unpacked[\"']" \
+    || missing="${missing} split-debuginfo=\"unpacked\""
+  if [ -n "${missing}" ]; then
+    echo "FAIL: profile-presence — [profile.dev] is missing required #878 lever(s):${missing}."
+    echo "      On a higher-RAM box the link smoke can stay GREEN without these levers; this"
+    echo "      grep-assert keeps stanza detection environment-independent. Restore both keys."
+    return 1
+  fi
+  echo "OK: profile-presence — [profile.dev] carries debug=\"line-tables-only\" + split-debuginfo=\"unpacked\" (#878)."
+  return 0
+}
 
 # classify_link_output RC LOGFILE
 #   Emits a human verdict and returns: 0 = passed, 1 = failed. On failure, distinguishes
@@ -114,7 +164,41 @@ _classify_capture() {
 }
 
 self_test() {
-  local tmp fails=0
+  local tmp fails=0 out rc
+  echo "[self-test] assert_profile_present detection"
+
+  tmp="$(mktemp)"
+  printf '%s\n' '[profile.dev]' 'debug = "line-tables-only"' 'split-debuginfo = "unpacked"' \
+    '' '[workspace.package]' 'version = "0.1.0"' > "${tmp}"
+  out="$(assert_profile_present "${tmp}")"; rc=$?
+  if [ "${rc}" -eq 0 ]; then
+    echo "  ok: complete [profile.dev] (both levers) -> PASS"
+  else
+    echo "  FAIL: a complete [profile.dev] stanza was rejected"; fails=1
+  fi
+  rm -f "${tmp}"
+
+  tmp="$(mktemp)"
+  printf '%s\n' '[profile.dev]' 'debug = "line-tables-only"' '' '[profile.release]' 'lto = true' > "${tmp}"
+  out="$(assert_profile_present "${tmp}")"; rc=$?
+  if [ "${rc}" -ne 0 ] && printf '%s' "${out}" | grep -q 'profile-presence'; then
+    echo "  ok: incomplete stanza (split-debuginfo missing) -> FAIL + profile-presence classification"
+  else
+    echo "  FAIL: an incomplete [profile.dev] was not flagged as a profile-presence failure"; fails=1
+  fi
+  rm -f "${tmp}"
+
+  tmp="$(mktemp)"
+  printf '%s\n' '[profile.release]' 'debug = "line-tables-only"' 'split-debuginfo = "unpacked"' \
+    '' '[profile.dev]' 'opt-level = 0' > "${tmp}"
+  out="$(assert_profile_present "${tmp}")"; rc=$?
+  if [ "${rc}" -ne 0 ]; then
+    echo "  ok: levers present only OUTSIDE [profile.dev] do NOT satisfy -> FAIL (section-scoped)"
+  else
+    echo "  FAIL: levers in [profile.release] wrongly satisfied the [profile.dev] assertion"; fails=1
+  fi
+  rm -f "${tmp}"
+
   echo "[self-test] classify_link_output OOM detection"
 
   tmp="$(mktemp)"
@@ -162,6 +246,11 @@ main() {
     *) echo "usage: $0 [--self-test]" >&2; exit 2 ;;
   esac
   cd "${REPO_ROOT}" || { echo "cannot cd to repo root ${REPO_ROOT}" >&2; exit 2; }
+  # Environment-independent presence check FIRST — cheap, RAM-independent, and legible on its
+  # own before the heavy link run. Reuses the FAIL path (exit 1).
+  if ! assert_profile_present "${REPO_ROOT}/Cargo.toml"; then
+    exit 1
+  fi
   run_link_smoke
   exit $?
 }


### PR DESCRIPTION
Closes #878.

## Root cause
Full `cargo test --workspace` SIGKILLed `ld` (OOM) at the **link step** — not one fat binary, but **N parallel links summing**. ~41 integration binaries link concurrently at default `-j=nproc(10)`; per-link peak `ld` RSS ≈ **1842 MB** (`debug=2`) × up to 10 ≈ 18 GB against a **~9.4 GB ceiling with swap exhausted**. As test surface grew it crossed a fixed ceiling — a footprint regression, salvaged-via-`--lib` three times (#750, #873, #877) so the full-workspace integration link was verified nowhere.

## Fix — two levers, empirically sized (ships on measured numbers, not estimates)
1. **`[profile.dev]`** in root `Cargo.toml`: `debug = "line-tables-only"` + `split-debuginfo = "unpacked"` — cuts per-link RSS **1842 → 1112 MB**, keeps `file:line` backtraces. `[profile.release]` untouched (shipped binary unchanged).
2. **`[build] jobs = 6`** in `.cargo/config.toml` — bounds concurrent links. Derived as `floor(0.8 × avail / per-link)`; confirmed by a full `cargo test --workspace --no-run` link holding **~2.5 GB headroom** (jobs=7 dipped under the 20% headroom line, swap=0).

## Regression guard
`product/test/infra-002/check-workspace-link-smoke.sh` exercises the **full-workspace link** at the configured cap — trips on cumulative growth *and* on removal of the `[profile.dev]` stanza (per-link → 1842 → 6× ≈ 11 GB OOM). Wired as a mandatory uni-tester gate step. Defeats the `--lib` salvage that hid this bug thrice.

**Guard altitude:** runs at the configured cap, **not default `-j`**. Measured: default `-j`(10) *still* OOMs post-fix (10 × 1112 ≈ 11 GB > ceiling) — safety comes from the cap, not from making 10-way links fit, so a default-`-j` guard would be guaranteed-RED / un-gateable. Deviation from the reviewers' original spec is measured, documented, and ruled ACCEPTABLE at the validation gate.

## Verification
- `cargo test --workspace`: **link CLEAN (no OOM)** — the load-bearing invariant — **6734 passed / 0 failed**
- Clippy: clean · Integration smoke: 28/28 · Guard self-test + real run: PASS
- Named bug-area binaries all build+link+run green (import/export/project_routing/graph_subgraph integration)

## Deferred (separate `nan` infra)
mold/lld linker — not installed here; a devcontainer+CI system dependency, not a one-liner. Would give true default-`-j` headroom but is out of scope for this fix.

Gate: Bugfix Validation — **PASS** (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)