### PR TITLE
fix: default-resolve context_graph supersessions across read surfaces (#881)

### DIFF
--- a/crates/unimatrix-server/src/mcp/get_edges.rs
+++ b/crates/unimatrix-server/src/mcp/get_edges.rs
@@ -41,7 +41,23 @@ use super::response::edges::{
 ///
 /// Returns `Result<EdgesView, StoreError>` so the handler maps the whole assembly once
 /// with the identical primary-read mapping (FR-19). No `.unwrap()`/`.expect()`.
-pub(crate) async fn build_edges_view(store: &Store, id: u64) -> Result<EdgesView, StoreError> {
+///
+/// NG-1 (bugfix-881 / ass-088 F5): when `resolve_targets` is true (the default — mirrors
+/// `follow_supersessions`, so the `follow_supersessions=false` escape hatch keeps raw
+/// targets), each of the ≤`GET_EDGE_DISPLAY_LIMIT` displayed edge TARGETS is resolved to its
+/// active terminal via `follow_to_current`. Substitution happens ONLY when a target is
+/// actually deprecated (`terminal != raw`); an all-active response is therefore byte-identical
+/// to the pre-resolution shape, preserving the `test_none_json_byte_identical_to_base_object`
+/// canary. Dead-end / cycle / 50-hop-cap targets keep their raw id (same `None -> raw`
+/// fallback as context_get and the BFS handlers). N5: `totals`/`authored_total` stay computed
+/// from the uncapped STORED edge set (unresolved) — they may exceed the distinct displayed
+/// targets after resolve+dedup; this is the intended honest-stored-totals design (vnc-037),
+/// NOT a counting bug.
+pub(crate) async fn build_edges_view(
+    store: &Store,
+    id: u64,
+    resolve_targets: bool,
+) -> Result<EdgesView, StoreError> {
     let pool = store.read_pool_server();
 
     // 1. ranked ≤cap displayed rows (canonicalized, LEFT JOIN confidence, LIMIT cap).
@@ -50,11 +66,30 @@ pub(crate) async fn build_edges_view(store: &Store, id: u64) -> Result<EdgesView
     // 2. honest uncapped split totals — three buckets + digest-only `authored`.
     let split: EdgeCountSplit = count_neighbors_split(pool, id).await?;
 
-    // 3. batched title join over the ≤cap displayed targets ONLY (never the uncapped set).
+    // 3. NG-1 resolve the ≤cap displayed edge-target labels to their active terminal. Bounded
+    //    to the ≤GET_EDGE_DISPLAY_LIMIT displayed targets (≤3 chain walks — N1 fine as-is).
+    //    resolution maps raw_target -> effective_target; entries only differ when a target is
+    //    actually deprecated (terminal != raw), so all-active responses stay byte-identical.
+    let mut resolution: HashMap<u64, u64> = HashMap::new();
+    if resolve_targets {
+        for edge in &rows {
+            let raw = edge.row.target_id;
+            if let std::collections::hash_map::Entry::Vacant(slot) = resolution.entry(raw) {
+                let terminal = crate::mcp::graph_read::follow_to_current(store, raw)
+                    .await
+                    .unwrap_or(raw);
+                slot.insert(terminal);
+            }
+        }
+    }
+    let effective = |raw: u64| resolution.get(&raw).copied().unwrap_or(raw);
+
+    // 4. batched title join over the ≤cap displayed (effective) targets ONLY.
     let mut target_ids: Vec<u64> = Vec::with_capacity(rows.len());
     for edge in &rows {
-        if !target_ids.contains(&edge.row.target_id) {
-            target_ids.push(edge.row.target_id);
+        let t = effective(edge.row.target_id);
+        if !target_ids.contains(&t) {
+            target_ids.push(t);
         }
     }
     let title_map = if target_ids.is_empty() {
@@ -63,13 +98,13 @@ pub(crate) async fn build_edges_view(store: &Store, id: u64) -> Result<EdgesView
         fetch_titles_batch(pool, &target_ids).await?
     };
 
-    // 4. project ranked rows → GetEdge.
+    // 5. project ranked rows → GetEdge (target_id substituted to the effective terminal).
     let edges: Vec<GetEdge> = rows
         .iter()
-        .map(|edge| project_edge(edge, &title_map))
+        .map(|edge| project_edge(edge, effective(edge.row.target_id), &title_map))
         .collect();
 
-    // 5. assemble (edges already ≤cap from SQL; totals uncapped, three buckets;
+    // 6. assemble (edges already ≤cap from SQL; totals uncapped, three buckets;
     //    authored_total threaded for the digest from the FULL uncapped set).
     Ok(EdgesView {
         edges,
@@ -84,13 +119,13 @@ pub(crate) async fn build_edges_view(store: &Store, id: u64) -> Result<EdgesView
 
 /// Project one ranked row into the discovery-list [`GetEdge`].
 ///
-/// `target_id` is the OTHER endpoint (`RankedEdge.row.target_id`); `target_title` is the
-/// title-map lookup (`None` ⇒ dangling, retained — DNB-1); `authored` is derived in
-/// [`GetEdge::new`] from the raw `source` string (`== "agent"`). The SQL-computed
+/// `target_id` is the effective OTHER endpoint (the resolved terminal when the stored target
+/// is deprecated — NG-1; otherwise the raw `RankedEdge.row.target_id`); `target_title` is the
+/// title-map lookup for that effective id (`None` ⇒ dangling, retained — DNB-1); `authored` is
+/// derived in [`GetEdge::new`] from the raw `source` string (`== "agent"`). The SQL-computed
 /// direction string is mapped to the canonical `&'static str` constant — a `↔` row is
 /// never re-derived as `→`/`←` in Rust.
-fn project_edge(edge: &RankedEdge, title_map: &HashMap<u64, String>) -> GetEdge {
-    let target_id = edge.row.target_id;
+fn project_edge(edge: &RankedEdge, target_id: u64, title_map: &HashMap<u64, String>) -> GetEdge {
     GetEdge::new(
         edge.row.relation_type.clone(),
         map_direction(&edge.direction),

--- a/crates/unimatrix-server/src/mcp/get_edges_tests.rs
+++ b/crates/unimatrix-server/src/mcp/get_edges_tests.rs
@@ -120,7 +120,7 @@ async fn test_edge_query_failure_fails_loud() {
         .await
         .expect("drop confidence column");
 
-    let result = build_edges_view(&store as &Store, anchor).await;
+    let result = build_edges_view(&store as &Store, anchor, true).await;
     assert!(
         result.is_err(),
         "a ranked-query failure must surface as Err (fail-loud), not a success with omitted edges"
@@ -152,7 +152,7 @@ async fn test_count_query_failure_fails_loud() {
         "count_neighbors_split must error when its graph_edges source is gone"
     );
 
-    let result = build_edges_view(&store as &Store, anchor).await;
+    let result = build_edges_view(&store as &Store, anchor, true).await;
     assert!(
         result.is_err(),
         "a count-query failure must surface as Err (fail-loud), not a success"
@@ -178,7 +178,7 @@ async fn test_title_join_failure_fails_loud() {
         .await
         .expect("drop title column");
 
-    let result = build_edges_view(&store as &Store, anchor).await;
+    let result = build_edges_view(&store as &Store, anchor, true).await;
     assert!(
         result.is_err(),
         "a title-join failure must surface as Err — never a silent null fill or omitted edges"
@@ -195,7 +195,7 @@ async fn test_zero_edges_is_success_distinct_from_failure() {
 
     let anchor = insert_entry_conf(pool, "lonely", 0.5).await;
 
-    let view = build_edges_view(&store as &Store, anchor)
+    let view = build_edges_view(&store as &Store, anchor, true)
         .await
         .expect("zero-edge entry must succeed (not fail)");
 
@@ -227,7 +227,7 @@ async fn test_projection_outbound_inbound_far_endpoint() {
     // Inbound: anchor is the target.
     insert_edge(pool, in_source, anchor, "Prerequisite", "agent").await;
 
-    let view = build_edges_view(&store as &Store, anchor)
+    let view = build_edges_view(&store as &Store, anchor, true)
         .await
         .expect("build");
 
@@ -267,7 +267,7 @@ async fn test_projection_symmetric_both_no_arrow() {
     insert_edge(pool, anchor, other, "Informs", "co_access").await;
     insert_edge(pool, other, anchor, "Informs", "co_access").await;
 
-    let view = build_edges_view(&store as &Store, anchor)
+    let view = build_edges_view(&store as &Store, anchor, true)
         .await
         .expect("build");
 
@@ -309,7 +309,7 @@ async fn test_totals_projection_three_buckets() {
     let split = unimatrix_store::count_neighbors_split(store.read_pool_server(), anchor)
         .await
         .expect("split");
-    let view = build_edges_view(&store as &Store, anchor)
+    let view = build_edges_view(&store as &Store, anchor, true)
         .await
         .expect("build");
 
@@ -340,7 +340,7 @@ async fn test_authored_total_threaded_from_full_set() {
         insert_edge(pool, anchor, t, "Supports", "agent").await;
     }
 
-    let view = build_edges_view(&store as &Store, anchor)
+    let view = build_edges_view(&store as &Store, anchor, true)
         .await
         .expect("build");
 
@@ -372,7 +372,7 @@ async fn test_dangling_title_null_retained_no_panic() {
     let anchor = insert_entry_conf(pool, "anchor", 0.5).await;
     insert_dangling_edge(pool, anchor, 999_999, "Supports").await;
 
-    let view = build_edges_view(&store as &Store, anchor)
+    let view = build_edges_view(&store as &Store, anchor, true)
         .await
         .expect("dangling target must not error");
 
@@ -397,7 +397,7 @@ async fn test_mixed_resolved_and_dangling() {
     insert_edge(pool, anchor, resolved, "Supports", "agent").await;
     insert_dangling_edge(pool, anchor, 888_888, "Prerequisite").await;
 
-    let view = build_edges_view(&store as &Store, anchor)
+    let view = build_edges_view(&store as &Store, anchor, true)
         .await
         .expect("build");
 
@@ -420,6 +420,87 @@ async fn test_mixed_resolved_and_dangling() {
 }
 
 // ---------------------------------------------------------------------------
+// NG-1 (bugfix-881 / ass-088 F5) — displayed edge-TARGET label resolution
+// ---------------------------------------------------------------------------
+
+/// Deprecate `id`, pointing it at `superseded_by` (its active successor).
+async fn deprecate_toward(pool: &SqlitePool, id: u64, superseded_by: u64) {
+    sqlx::query("UPDATE entries SET status = 1, superseded_by = ?2 WHERE id = ?1")
+        .bind(id as i64)
+        .bind(superseded_by as i64)
+        .execute(pool)
+        .await
+        .expect("deprecate entry");
+}
+
+/// NG-1: a displayed edge whose TARGET is deprecated resolves to the terminal id + title by
+/// default (`resolve_targets = true`). Anchor → X, X superseded by X′ ⇒ the displayed edge
+/// carries X′'s id and title, not X's stale label.
+#[tokio::test]
+async fn test_ng1_deprecated_target_resolves_to_terminal() {
+    let (store, _dir) = open_test_store().await;
+    let pool = store.write_pool_server();
+
+    let anchor = insert_entry_conf(pool, "anchor", 0.5).await;
+    let x = insert_entry_conf(pool, "x-stale", 0.9).await;
+    let x_prime = insert_entry_conf(pool, "x-prime-current", 0.9).await;
+    insert_edge(pool, anchor, x, "Supports", "agent").await;
+    deprecate_toward(pool, x, x_prime).await;
+
+    let view = build_edges_view(&store as &Store, anchor, true)
+        .await
+        .expect("build");
+
+    let edge = view
+        .edges
+        .iter()
+        .find(|e| e.edge_type == "Supports")
+        .expect("Supports edge present");
+    assert_eq!(
+        edge.target_id, x_prime,
+        "deprecated target resolves to its active terminal id"
+    );
+    assert_eq!(
+        edge.target_title.as_deref(),
+        Some("x-prime-current"),
+        "displayed title is the terminal's, not the stale X label"
+    );
+}
+
+/// NG-1 escape hatch: `resolve_targets = false` (follow_supersessions=false) keeps the raw
+/// as-stored target — the audit/lookback surface is preserved.
+#[tokio::test]
+async fn test_ng1_escape_hatch_keeps_raw_target() {
+    let (store, _dir) = open_test_store().await;
+    let pool = store.write_pool_server();
+
+    let anchor = insert_entry_conf(pool, "anchor", 0.5).await;
+    let x = insert_entry_conf(pool, "x-stale", 0.9).await;
+    let x_prime = insert_entry_conf(pool, "x-prime-current", 0.9).await;
+    insert_edge(pool, anchor, x, "Supports", "agent").await;
+    deprecate_toward(pool, x, x_prime).await;
+
+    let view = build_edges_view(&store as &Store, anchor, false)
+        .await
+        .expect("build");
+
+    let edge = view
+        .edges
+        .iter()
+        .find(|e| e.edge_type == "Supports")
+        .expect("Supports edge present");
+    assert_eq!(
+        edge.target_id, x,
+        "escape hatch keeps the raw as-stored deprecated target"
+    );
+    assert_eq!(
+        edge.target_title.as_deref(),
+        Some("x-stale"),
+        "raw target keeps its stored title"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // authored projection (R-05 / FR-17) — carried-forward / context_edge authored
 // ---------------------------------------------------------------------------
 
@@ -437,7 +518,7 @@ async fn test_authored_flag_from_source() {
     insert_edge(pool, anchor, authored_t, "Supports", "agent").await;
     insert_edge(pool, anchor, inferred_t, "Supports", "co_access").await;
 
-    let view = build_edges_view(&store as &Store, anchor)
+    let view = build_edges_view(&store as &Store, anchor, true)
         .await
         .expect("build");
 

--- a/crates/unimatrix-server/src/mcp/graph_read.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read.rs
@@ -85,8 +85,9 @@ pub struct GraphParams {
     pub edge_types: Option<Vec<String>>,
     /// neighbors only: hop depth 1..=10 (default 1).
     pub depth: Option<u8>,
-    /// neighbors only: resolve deprecated endpoints to active terminal (default false).
-    /// Rejected on chain mode (ADR-003).
+    /// neighbors / subgraph / path: resolve deprecated endpoints to their active terminal.
+    /// Default TRUE (bugfix-881, aligning with context_get) — pass `false` for raw as-stored
+    /// topology (audit). Rejected on chain/current/inverse/filter modes (ADR-003, #616A).
     pub resolve_supersessions: Option<bool>,
     // -- Forward-compat fields — error on misuse in incompatible modes (ADR-003) --
     /// subgraph mode: one or more entry IDs to use as BFS seeds.

--- a/crates/unimatrix-server/src/mcp/graph_read_cross_surface_tests.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_cross_surface_tests.rs
@@ -1,0 +1,193 @@
+//! bugfix-881 — cross-surface supersession-resolution consistency.
+//!
+//! Regression guard for the divergence that shipped invisibly: `context_get` resolved
+//! supersessions BY DEFAULT (vnc-042) while `context_graph`'s traversal modes did not. Each
+//! surface was previously tested only in isolation with an EXPLICIT flag, so the default-path
+//! divergence never showed up in CI. This test supersedes X → X′ once and asserts that ALL
+//! read surfaces surface X′ by DEFAULT (no `resolve_supersessions` flag): context_get
+//! (resolve_effective_id anchor resolution), neighbors at DEFAULT depth 1 (the arm G1 fixed —
+//! previously ignored the flag entirely), subgraph, and path.
+//!
+//! It also asserts the escape hatch: an explicit `resolve_supersessions:false` neighbors call
+//! still returns the raw as-stored X.
+
+use std::sync::{Arc, RwLock};
+
+use unimatrix_core::Store;
+use unimatrix_store::{NewEntry, PoolConfig, SqlxStore, Status};
+
+use crate::mcp::graph_read::GraphParams;
+use crate::mcp::graph_read::graph_read_neighbors::handle_neighbors;
+use crate::mcp::graph_read::graph_read_path::handle_path;
+use crate::mcp::graph_read::graph_read_subgraph::handle_subgraph;
+use crate::mcp::tools::resolve_effective_id;
+use crate::services::typed_graph::TypedGraphState;
+
+async fn open_test_store() -> (SqlxStore, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("test.db");
+    let store = SqlxStore::open(&path, PoolConfig::test_default())
+        .await
+        .expect("open test store");
+    (store, dir)
+}
+
+async fn insert_active(store: &SqlxStore, title: &str) -> u64 {
+    store
+        .insert(NewEntry {
+            title: title.to_string(),
+            content: format!("content-{title}"),
+            topic: "test".to_string(),
+            category: "pattern".to_string(),
+            tags: vec![],
+            source: "test".to_string(),
+            status: Status::Active,
+            created_by: "test".to_string(),
+            feature_cycle: "bugfix-881".to_string(),
+            trust_source: "agent".to_string(),
+        })
+        .await
+        .unwrap_or_else(|e| panic!("insert {title}: {e:?}"))
+}
+
+async fn insert_supports_edge(store: &SqlxStore, source_id: u64, target_id: u64) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    sqlx::query(
+        "INSERT OR IGNORE INTO graph_edges
+             (source_id, target_id, relation_type, weight, created_at,
+              created_by, source, bootstrap_only)
+         VALUES (?1, ?2, 'Supports', 1.0, ?3, 'test', 'agent', 0)",
+    )
+    .bind(source_id as i64)
+    .bind(target_id as i64)
+    .bind(now as i64)
+    .execute(store.write_pool_server())
+    .await
+    .expect("insert Supports edge");
+}
+
+async fn deprecate_toward(store: &SqlxStore, id: u64, superseded_by: u64) {
+    sqlx::query("UPDATE entries SET status = 1, superseded_by = ?2 WHERE id = ?1")
+        .bind(id as i64)
+        .bind(superseded_by as i64)
+        .execute(store.write_pool_server())
+        .await
+        .expect("deprecate entry");
+}
+
+/// Cold-start handle (`use_fallback = true`) so subgraph/path take the live-SQL DB-fallback
+/// path (no tick rebuild needed); neighbors depth=1 always uses live SQL.
+fn cold_start_handle() -> Arc<RwLock<TypedGraphState>> {
+    Arc::new(RwLock::new(TypedGraphState::new()))
+}
+
+/// Supersede X → X′ once; assert every read surface resolves to X′ BY DEFAULT.
+#[tokio::test]
+async fn test_cross_surface_default_resolves_to_terminal() {
+    let (store, _dir) = open_test_store().await;
+    let handle = cold_start_handle();
+
+    let a = insert_active(&store, "A").await;
+    let x = insert_active(&store, "X-stale").await;
+    let x_prime = insert_active(&store, "X-prime").await;
+    insert_supports_edge(&store, a, x).await;
+    deprecate_toward(&store, x, x_prime).await;
+
+    // --- context_get: anchor resolves X → X′ by default (None). ---
+    let (eff, _note) = resolve_effective_id(&store as &Store, x, None).await;
+    assert_eq!(eff, x_prime, "context_get default must resolve X → X′");
+
+    // --- neighbors at DEFAULT depth 1 (depth omitted) — this is the arm G1 fixed. ---
+    let neighbors_params = GraphParams {
+        mode: "neighbors".to_string(),
+        id: Some(a),
+        ..Default::default()
+    };
+    let neighbors = handle_neighbors(&store, &handle, &neighbors_params, a)
+        .await
+        .expect("neighbors ok");
+    let edge = neighbors
+        .edges
+        .iter()
+        .find(|e| e.relation_type == "Supports")
+        .expect("A→ Supports edge present");
+    assert_eq!(
+        edge.target_id, x_prime,
+        "neighbors (default depth 1) must surface X′, not deprecated X (G1 regression guard)"
+    );
+
+    // --- subgraph seeded on A. ---
+    let subgraph_params = GraphParams {
+        mode: "subgraph".to_string(),
+        seed_ids: Some(vec![a]),
+        ..Default::default()
+    };
+    let subgraph = handle_subgraph(&store, &handle, &subgraph_params)
+        .await
+        .expect("subgraph ok");
+    assert!(
+        subgraph.edges.iter().any(|e| e.target_id == x_prime),
+        "subgraph must surface an edge to X′ by default"
+    );
+    assert!(
+        !subgraph.edges.iter().any(|e| e.target_id == x),
+        "subgraph must NOT surface the deprecated X target by default"
+    );
+    assert!(
+        subgraph.nodes.iter().any(|n| n.id == x_prime),
+        "subgraph node set must include the terminal X′"
+    );
+
+    // --- path A → X (to_id given as the deprecated id). ---
+    let path_params = GraphParams {
+        mode: "path".to_string(),
+        from_id: Some(a),
+        to_id: Some(x),
+        ..Default::default()
+    };
+    let path = handle_path(&store, &handle, &path_params)
+        .await
+        .expect("path ok");
+    assert!(path.found, "path A→X must be found (to_id resolves to X′)");
+    assert_eq!(path.to_id, x_prime, "path to_id must be resolved to X′");
+    assert!(
+        path.hops.iter().any(|h| h.entry_id == x_prime),
+        "path hops must terminate at X′, not deprecated X"
+    );
+}
+
+/// The explicit `resolve_supersessions:false` opt-out still returns the raw as-stored X —
+/// the audit surface is preserved after the default flip.
+#[tokio::test]
+async fn test_neighbors_explicit_false_returns_raw() {
+    let (store, _dir) = open_test_store().await;
+    let handle = cold_start_handle();
+
+    let a = insert_active(&store, "A").await;
+    let x = insert_active(&store, "X-stale").await;
+    let x_prime = insert_active(&store, "X-prime").await;
+    insert_supports_edge(&store, a, x).await;
+    deprecate_toward(&store, x, x_prime).await;
+
+    let params = GraphParams {
+        mode: "neighbors".to_string(),
+        id: Some(a),
+        resolve_supersessions: Some(false),
+        ..Default::default()
+    };
+    let neighbors = handle_neighbors(&store, &handle, &params, a)
+        .await
+        .expect("neighbors ok");
+    let edge = neighbors
+        .edges
+        .iter()
+        .find(|e| e.relation_type == "Supports")
+        .expect("A→ Supports edge present");
+    assert_eq!(
+        edge.target_id, x,
+        "explicit resolve_supersessions:false must return the raw as-stored X (audit opt-out)"
+    );
+}

--- a/crates/unimatrix-server/src/mcp/graph_read_neighbors.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_neighbors.rs
@@ -7,7 +7,7 @@
 //!
 //! Declared as a sub-module of `graph_read.rs` via `#[path]`.
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, RwLock};
 
 use petgraph::stable_graph::NodeIndex;
@@ -52,6 +52,25 @@ pub(crate) async fn follow_to_current(store: &Store, id: u64) -> Option<u64> {
         }
     }
     None
+}
+
+/// Resolve `raw_id` to its terminal Active successor, memoizing the result per request.
+///
+/// N1 (bugfix-881): the memo (raw_id -> terminal) resolves each DISTINCT endpoint at most once
+/// per request — `neighbors_sql` has no fan-out cap (hot nodes reach in-degree ~110), so this
+/// avoids an unbounded per-row `store.get`. `None -> raw` fallback matches context_get / the
+/// depth>1 BFS handlers (vnc-042): dead-end/cycle/50-hop-cap endpoints stay as-stored.
+pub(crate) async fn resolve_memoized(
+    store: &Store,
+    memo: &mut HashMap<u64, u64>,
+    raw_id: u64,
+) -> u64 {
+    if let Some(&terminal) = memo.get(&raw_id) {
+        return terminal;
+    }
+    let terminal = follow_to_current(store, raw_id).await.unwrap_or(raw_id);
+    memo.insert(raw_id, terminal);
+    terminal
 }
 
 // ---------------------------------------------------------------------------
@@ -158,10 +177,14 @@ pub(super) async fn handle_neighbors(
     };
 
     // Step 4: Dispatch to SQL (depth=1) or BFS (depth>1) per ADR-005.
+    // resolve_supersessions defaults TRUE (bugfix-881, overrides vnc-042 ADR-001 for
+    // context_graph per issue #881) — aligns with context_get; `false` = raw/audit opt-out.
+    // G1 (bugfix-881): the depth-1 arm now honors the flag — previously neighbors_sql ignored
+    // it entirely, so even an explicit `true` was a no-op on the default-depth neighbors call.
+    let resolve = params.resolve_supersessions.unwrap_or(true);
     let edges = if depth == 1 {
-        neighbors_sql(store, id, &requested_types, direction).await?
+        neighbors_sql(store, id, &requested_types, direction, resolve).await?
     } else {
-        let resolve = params.resolve_supersessions.unwrap_or(false);
         neighbors_bfs(
             store,
             typed_graph_state,
@@ -184,11 +207,17 @@ pub(super) async fn handle_neighbors(
 // ---------------------------------------------------------------------------
 
 /// depth=1 live SQL path (ADR-005).
+///
+/// When `resolve` is true (the default — bugfix-881 G1) each row's NEIGHBOR endpoint (the
+/// non-anchor side) is resolved to its active terminal via the per-request memo; the anchor
+/// `id` is left as-stored, matching the depth>1 BFS handler. Per-row on the stored edge set
+/// (no dedup) — one displayed row per stored edge, endpoint pointed at current truth.
 async fn neighbors_sql(
     store: &Store,
     id: u64,
     types: &[RelationType],
     direction: NeighborDirection,
+    resolve: bool,
 ) -> Result<Vec<EdgeRecord>, ErrorData> {
     let type_strs: Vec<&str> = types.iter().map(|t| t.as_str()).collect();
 
@@ -199,24 +228,27 @@ async fn neighbors_sql(
             ErrorData::new(ERROR_INTERNAL, format!("graph query failed: {e}"), None)
         })?;
 
-    let edges = raw_rows
-        .into_iter()
-        .map(|row| {
-            let dir_str = if row.source_id == id {
-                "outgoing"
+    let mut memo: HashMap<u64, u64> = HashMap::new(); // per-request resolution memo (N1)
+    let mut edges = Vec::with_capacity(raw_rows.len());
+    for row in raw_rows {
+        let outgoing = row.source_id == id;
+        let (mut source_id, mut target_id) = (row.source_id, row.target_id);
+        if resolve {
+            if outgoing {
+                target_id = resolve_memoized(store, &mut memo, target_id).await;
             } else {
-                "incoming"
-            };
-            EdgeRecord {
-                source_id: row.source_id,
-                target_id: row.target_id,
-                relation_type: row.relation_type,
-                direction: dir_str.to_string(),
-                depth: 1,
-                metadata: None, // always None in vnc-018 (ADR-004, R-15)
+                source_id = resolve_memoized(store, &mut memo, source_id).await;
             }
-        })
-        .collect();
+        }
+        edges.push(EdgeRecord {
+            source_id,
+            target_id,
+            relation_type: row.relation_type,
+            direction: if outgoing { "outgoing" } else { "incoming" }.to_string(),
+            depth: 1,
+            metadata: None, // always None in vnc-018 (ADR-004, R-15)
+        });
+    }
 
     Ok(edges)
 }

--- a/crates/unimatrix-server/src/mcp/graph_read_path.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_path.rs
@@ -132,7 +132,10 @@ pub(super) async fn handle_path(
 
     // Step 6: Resolve supersession endpoints BEFORE acquiring the graph lock
     // (lock discipline: all Store async calls happen before lock is held — ADR-006).
-    let resolve_supersessions = params.resolve_supersessions.unwrap_or(false);
+    // resolve_supersessions defaults TRUE (bugfix-881, overrides vnc-042 ADR-001 for
+    // context_graph per issue #881): deprecated endpoints resolve to their active terminal
+    // by default, aligning with context_get. Explicit `false` remains the raw/audit opt-out.
+    let resolve_supersessions = params.resolve_supersessions.unwrap_or(true);
 
     let effective_from: u64 = if resolve_supersessions {
         // follow_to_current returns None when chain exceeds 50 hops or entry is

--- a/crates/unimatrix-server/src/mcp/graph_read_subgraph.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_subgraph.rs
@@ -155,7 +155,11 @@ pub(super) async fn handle_subgraph(
         }
     };
 
-    let resolve_supersessions = params.resolve_supersessions.unwrap_or(false);
+    // resolve_supersessions defaults TRUE (bugfix-881, overrides vnc-042 ADR-001 for
+    // context_graph per issue #881): deprecated seeds/neighbors resolve to their active
+    // terminal by default. Explicit `false` remains the raw/audit opt-out. Node-collapse is
+    // expected — multiple deprecated variants resolving to one terminal shrink node/edge counts.
+    let resolve_supersessions = params.resolve_supersessions.unwrap_or(true);
 
     // Step 2: Acquire graph snapshot (lock -> clone -> release) BEFORE any async work.
     // Extract both typed_graph AND use_fallback in the same lock guard (GH #623).
@@ -274,11 +278,19 @@ pub(super) async fn handle_subgraph(
                             neighbor_id
                         };
 
-                        // Dedup edge by canonical stored triple.
+                        // Record the edge with the RESOLVED neighbor endpoint (bugfix-881):
+                        // the neighbor is resolved to its terminal for the node set, so the edge
+                        // must point at the same terminal or the post-BFS dangling filter drops
+                        // it (raw target absent from the resolved node set). Dedup still keys on
+                        // the raw stored triple; when resolve is off, effective_neighbor == raw.
+                        let (rec_src, rec_tgt) = match petgraph_dir {
+                            PetgraphDirection::Outgoing => (edge_src, effective_neighbor),
+                            PetgraphDirection::Incoming => (effective_neighbor, edge_tgt),
+                        };
                         if edge_set.insert(edge_key) {
                             collected_edges.push((
-                                edge_src,
-                                edge_tgt,
+                                rec_src,
+                                rec_tgt,
                                 rel_type_str,
                                 current_depth + 1,
                             ));
@@ -482,9 +494,14 @@ async fn subgraph_via_db(
                         neighbor_id
                     };
 
-                    // Dedup edge by canonical stored triple (R-02).
+                    // Record the edge with the RESOLVED neighbor endpoint (bugfix-881) — see the
+                    // in-memory path for rationale. Dedup still keys on the raw stored triple.
+                    let (rec_src, rec_tgt) = match petgraph_dir {
+                        PetgraphDirection::Outgoing => (edge_src, effective_neighbor),
+                        PetgraphDirection::Incoming => (effective_neighbor, edge_tgt),
+                    };
                     if edge_set.insert(edge_key) {
-                        collected_edges.push((edge_src, edge_tgt, rel_type_str, current_depth + 1));
+                        collected_edges.push((rec_src, rec_tgt, rel_type_str, current_depth + 1));
                     }
 
                     // Enqueue neighbor if not yet visited.

--- a/crates/unimatrix-server/src/mcp/graph_read_tests.rs
+++ b/crates/unimatrix-server/src/mcp/graph_read_tests.rs
@@ -394,3 +394,11 @@ mod vnc019;
 
 #[path = "graph_read_tests_vnc020.rs"]
 mod vnc020;
+
+// -----------------------------------------------------------------------
+// bugfix-881: cross-surface supersession-resolution consistency.
+// Declared in a child module to keep this file under 500 lines (500-line rule).
+// -----------------------------------------------------------------------
+
+#[path = "graph_read_cross_surface_tests.rs"]
+mod cross_surface;

--- a/crates/unimatrix-server/src/mcp/tools.rs
+++ b/crates/unimatrix-server/src/mcp/tools.rs
@@ -69,7 +69,7 @@ pub(crate) const CONTEXT_GRAPH_DESCRIPTION: &str = "Traverse the Unimatrix knowl
     - current: resolve any entry to its terminal active successor, following \
       superseded_by links until an Active entry is found.\n\
     - neighbors: retrieve entries connected by typed graph edges. \
-      Accepts edge_types filter, direction (incoming/outgoing/both), and depth (1..=10). \
+      Accepts edge_types filter, direction (incoming/outgoing/both), and depth (1..=10), and resolve_supersessions (resolve deprecated endpoints to their active terminal — default true; false for raw as-stored). \
       depth=1 queries the live database and reflects all committed writes immediately. \
       depth>1 queries the in-memory graph cache, which may lag recent writes by up to \
       one tick interval (typically 30-60 seconds). This asymmetry is intentional: \
@@ -86,7 +86,7 @@ pub(crate) const CONTEXT_GRAPH_DESCRIPTION: &str = "Traverse the Unimatrix knowl
       at depth>1. The depth_reached field reports the actual maximum BFS depth traversed; \
       truncated: true indicates the max_nodes cap was reached before BFS completed. \
       Seed IDs not present in the graph return an empty result — not an error. \
-      max_nodes must be in range 1..=200; values above 200 are rejected with a validation error.\n\
+      Deprecated seeds and neighbors resolve to their active terminal by default (resolve_supersessions, default true; false for raw as-stored). max_nodes must be in range 1..=200; values above 200 are rejected with a validation error.\n\
     - inverse: Return entries of a given category that have no incoming edges of ALL \
       the specified missing_edge_types (AND semantics — entries missing ALL listed types). \
       Example: missing_edge_types=[\"Cites\",\"Supports\"] returns entries that have \
@@ -104,7 +104,7 @@ pub(crate) const CONTEXT_GRAPH_DESCRIPTION: &str = "Traverse the Unimatrix knowl
       express a range. Queries the live database — no staleness.\n\
     - path: Find the shortest outgoing-edge path from from_id to to_id using BFS. \
       Required: from_id, to_id. Optional: edge_types (absent = all non-Supersedes \
-      types), depth (default 5, range [1,10]), resolve_supersessions (default false — \
+      types), depth (default 5, range [1,10]), resolve_supersessions (default true — \
       when true, deprecated endpoints are resolved to their terminal active successors \
       before BFS begins and deprecated intermediate nodes are resolved per-hop). \
       path mode uses the in-memory graph cache for BFS traversal. The cache is rebuilt \
@@ -112,7 +112,7 @@ pub(crate) const CONTEXT_GRAPH_DESCRIPTION: &str = "Traverse the Unimatrix knowl
       interval may not appear in the result. This is the same staleness contract as \
       neighbors mode at depth>1 and subgraph mode. If from_id or to_id is not present \
       in the current graph snapshot, the result is { found: false } — not an error. \
-      Use resolve_supersessions=true to have deprecated endpoints resolved to their \
+      resolve_supersessions defaults true across neighbors, subgraph, and path; pass resolve_supersessions=false to traverse the raw as-stored topology (audit). Deprecated endpoints otherwise resolve to their \
       active successors before BFS begins.\n\
     Requires Read capability. All modes are read-only.";
 
@@ -1095,11 +1095,18 @@ impl UnimatrixServer {
         let edges_view = match params.include_edges {
             Some(false) => None,
             None | Some(true) => Some(
-                crate::mcp::get_edges::build_edges_view(&self.store, effective_id)
-                    .await
-                    .map_err(|e| {
-                        rmcp::ErrorData::from(crate::error::ServerError::Core(CoreError::Store(e)))
-                    })?,
+                // NG-1: resolve displayed edge-TARGET labels to their active terminal unless
+                // the caller took the as-stored escape hatch (follow_supersessions=false),
+                // in which case targets stay raw to match the as-stored anchor.
+                crate::mcp::get_edges::build_edges_view(
+                    &self.store,
+                    effective_id,
+                    params.follow_supersessions != Some(false),
+                )
+                .await
+                .map_err(|e| {
+                    rmcp::ErrorData::from(crate::error::ServerError::Core(CoreError::Store(e)))
+                })?,
             ),
         };
 
@@ -3845,7 +3852,7 @@ impl UnimatrixServer {
             - current: resolve any entry to its terminal active successor, following \
               superseded_by links until an Active entry is found.\n\
             - neighbors: retrieve entries connected by typed graph edges. \
-              Accepts edge_types filter, direction (incoming/outgoing/both), and depth (1..=10). \
+              Accepts edge_types filter, direction (incoming/outgoing/both), and depth (1..=10), and resolve_supersessions (resolve deprecated endpoints to their active terminal — default true; false for raw as-stored). \
               depth=1 queries the live database and reflects all committed writes immediately. \
               depth>1 queries the in-memory graph cache, which may lag recent writes by up to \
               one tick interval (typically 30-60 seconds). This asymmetry is intentional: \
@@ -3862,7 +3869,7 @@ impl UnimatrixServer {
               at depth>1. The depth_reached field reports the actual maximum BFS depth traversed; \
               truncated: true indicates the max_nodes cap was reached before BFS completed. \
               Seed IDs not present in the graph return an empty result — not an error. \
-              max_nodes must be in range 1..=200; values above 200 are rejected with a validation error.\n\
+              Deprecated seeds and neighbors resolve to their active terminal by default (resolve_supersessions, default true; false for raw as-stored). max_nodes must be in range 1..=200; values above 200 are rejected with a validation error.\n\
             - inverse: Return entries of a given category that have no incoming edges of ALL \
               the specified missing_edge_types (AND semantics — entries missing ALL listed types). \
               Example: missing_edge_types=[\"Cites\",\"Supports\"] returns entries that have \
@@ -3880,7 +3887,7 @@ impl UnimatrixServer {
               express a range. Queries the live database — no staleness.\n\
             - path: Find the shortest outgoing-edge path from from_id to to_id using BFS. \
               Required: from_id, to_id. Optional: edge_types (absent = all non-Supersedes \
-              types), depth (default 5, range [1,10]), resolve_supersessions (default false — \
+              types), depth (default 5, range [1,10]), resolve_supersessions (default true — \
               when true, deprecated endpoints are resolved to their terminal active successors \
               before BFS begins and deprecated intermediate nodes are resolved per-hop). \
               path mode uses the in-memory graph cache for BFS traversal. The cache is rebuilt \
@@ -3888,7 +3895,7 @@ impl UnimatrixServer {
               interval may not appear in the result. This is the same staleness contract as \
               neighbors mode at depth>1 and subgraph mode. If from_id or to_id is not present \
               in the current graph snapshot, the result is { found: false } — not an error. \
-              Use resolve_supersessions=true to have deprecated endpoints resolved to their \
+              resolve_supersessions defaults true across neighbors, subgraph, and path; pass resolve_supersessions=false to traverse the raw as-stored topology (audit). Deprecated endpoints otherwise resolve to their \
               active successors before BFS begins.\n\
             Requires Read capability. All modes are read-only."
     )]
@@ -12783,7 +12790,9 @@ mod get_resolution_tests {
         // (what MCP clients actually receive) against the mirror const the substring test asserts
         // on. A single-byte divergence between the two now fails here.
         assert_eq!(
-            UnimatrixServer::context_get_tool_attr().description.as_deref(),
+            UnimatrixServer::context_get_tool_attr()
+                .description
+                .as_deref(),
             Some(CONTEXT_GET_DESCRIPTION),
             "live context_get tool-attr description must be byte-identical to CONTEXT_GET_DESCRIPTION"
         );

--- a/product/features/bugfix-881/agents/881-agent-1-fix-report.md
+++ b/product/features/bugfix-881/agents/881-agent-1-fix-report.md
@@ -1,0 +1,39 @@
+# Agent Report: 881-agent-1-fix (uni-rust-dev)
+
+Fix committed: `ee75d043` on `bugfix/881-graph-resolve-supersessions-default`.
+Fix-summary posted: https://github.com/dug-21/unimatrix/issues/881#issuecomment-4870444570
+
+## Outcome
+All five approved steps implemented, plus one required extension.
+
+### Files modified
+- `crates/unimatrix-server/src/mcp/graph_read_neighbors.rs` — default flip + G1 (depth-1 `neighbors_sql` resolve) + `resolve_memoized` per-request memo (N1).
+- `crates/unimatrix-server/src/mcp/graph_read_subgraph.rs` — default flip + record RESOLVED edge endpoints (in-memory + DB-fallback) so resolved edges survive the dangling filter.
+- `crates/unimatrix-server/src/mcp/graph_read_path.rs` — default flip.
+- `crates/unimatrix-server/src/mcp/get_edges.rs` — NG-1 edge-target resolution threaded on `resolve_targets`, byte-identity-preserving.
+- `crates/unimatrix-server/src/mcp/graph_read.rs` — `GraphParams.resolve_supersessions` field doc.
+- `crates/unimatrix-server/src/mcp/tools.rs` — both `CONTEXT_GRAPH_DESCRIPTION` copies + `build_edges_view` call site.
+- `crates/unimatrix-server/src/mcp/get_edges_tests.rs` — call-site arg + 2 NG-1 tests.
+- `crates/unimatrix-server/src/mcp/graph_read_tests.rs` — register cross-surface child module.
+- `crates/unimatrix-server/src/mcp/graph_read_cross_surface_tests.rs` (new) — 2 cross-surface tests.
+
+### Extension beyond the 5 steps (subgraph edge endpoints)
+The subgraph handler resolved the neighbor NODE but recorded the edge with the RAW target; the post-BFS dangling-edge filter then dropped that edge (raw target absent from the resolved node set), leaving X' as a disconnected node. Latent even under explicit `true`; subgraph resolve had zero test coverage, so it was invisible. Fixed both edge-recording sites to substitute the resolved endpoint. Required for the cross-surface consistency deliverable. No existing subgraph test regressed (all fixtures use active targets => resolved == raw).
+
+### New tests
+- `test_cross_surface_default_resolves_to_terminal` — supersede X->X' once; assert context_get + neighbors@**default depth 1** + subgraph + path all surface X' by default.
+- `test_neighbors_explicit_false_returns_raw` — `resolve_supersessions:false` returns raw X.
+- `test_ng1_deprecated_target_resolves_to_terminal` / `test_ng1_escape_hatch_keeps_raw_target`.
+
+### Tests: pass/fail
+Full-workspace `cargo test` green (0 failures). Targeted `mcp::` lib: 961 passed. `graph_subgraph_integration`: 3 passed. clippy clean, fmt applied (out-of-scope churn reverted). All source files <=500 lines.
+
+### ADR correction (step 5, atomic)
+`context_correct` #5388 -> #5409: retracted only the graph flip-direction prohibition; preserved the per-intent principle; kept the reverse prohibition (never flip context_get to as-stored); recorded N2 (silent vs loud resolution, incl. uni-capability gating risk) and N3 (subgraph node-collapse deliberate). 2 incoming edges redirected.
+
+### Issues / blockers
+None. Follow-up flagged (not in this PR): vision session must correct SL7 (#5390) non-goal post-merge.
+
+## Knowledge Stewardship
+- Queried: `mcp__unimatrix__context_briefing` — surfaced #5388, #5387, #4507, #4494, #4468; applied directly (ADR override, NG-1 semantics, resolution mechanics, 50-hop CTE cap).
+- Stored: corrected #5388 -> #5409 via `context_correct` (the load-bearing stewardship action). Nothing else novel — remaining findings are issue-specific code defects (bugs are GH issues, not lessons); resolution mechanics already exist as patterns #4494/#4468.

--- a/product/features/bugfix-881/agents/881-investigator-report.md
+++ b/product/features/bugfix-881/agents/881-investigator-report.md
@@ -1,0 +1,27 @@
+# Agent Report: 881-investigator (uni-bug-investigator)
+
+Diagnosis posted: https://github.com/dug-21/unimatrix/issues/881#issuecomment-4870060638
+
+## Outcome
+Root cause confirmed with high confidence, plus two findings beyond the issue text:
+
+1. Reported defaults verified: `unwrap_or(false)` at `graph_read_subgraph.rs:158`, `graph_read_neighbors.rs:164`, **and a third site the issue omits — `graph_read_path.rs:135`**.
+2. **G1 (new)**: the depth-1 neighbors arm (`graph_read_neighbors.rs:161-162`, depth default 1) never consults `resolve_supersessions` — even explicit `true` silently no-ops. Flipping the :164 default alone leaves the most common neighbors call broken; `neighbors_sql` needs resolve support.
+3. NG-1 confirmed: `build_edges_view` (`get_edges.rs:44`) renders stored target ids/titles with no resolution — a deliberate vnc-042 deferral (ADR-003 #5387) now promoted to fix.
+4. **ADR conflict**: vnc-042 ADR-001 (entry #5388, stored 2026-07-01) explicitly forbids this flip ("Do NOT unify… either consistency fix is a regression"). Issue #881 (human, 2026-07-02) overrides it. The fix MUST `context_correct` #5388 or a future agent will revert the flip per the ADR's own instruction.
+
+Fix approach (5 steps), blast radius (no internal `handle_graph` callers; no JS-client `context_graph` callers; agent-side consumers all want terminals), regression risk (medium-low; ~31 graph-read + ~18 get-edges test references need review), and missing tests (cross-surface consistency test; depth-1 resolve test; get-edges deprecated-target test) — all in the GH comment.
+
+## Follow-up: consumer map (human question)
+Posted: https://github.com/dug-21/unimatrix/issues/881#issuecomment-4870158848
+
+Per-consumer verdict — is the OFF default reachable by briefing/injection/gating?
+- **context_briefing**: NOT a context_graph consumer. `tools.rs:1547` → `IndexBriefingService::index` (`index_briefing.rs:135`) → SearchService `RetrievalMode::Strict` (hard Active-only + non-superseded, `search.rs:759-763`) + Active post-filter (`index_briefing.rs:207-212`). Output shape has zero edge data (`response/briefing.rs:25-37`).
+- **Injection (UserPromptSubmit/SubagentStart/UDS Briefing)**: NOT a context_graph consumer. `listener.rs:1336/1498/1661` — same Strict search path; renders entries only, no edges.
+- **Gating**: no server-side gating code reads the graph — `handle_graph`'s only caller is the MCP tool dispatch (`tools.rs:~3911`). Real gating exposure is agent-side: `uni-capability` SKILL.md:171/:207 recomputes the next-unblocked capability set via default-parameter `context_graph` (depth-1 neighbors → hit by G1: flag bypassed entirely).
+
+**Bottom line**: defect reachable ONLY via external agent MCP calls of context_graph; internal pipelines are provably immune via RetrievalMode::Strict. Fix still justified (agents are the tool's whole consumer base and universally omit the undocumented flag), severity framing softens, G1 rises in importance. Issue/changelog wording should say "external agent callers", not "briefing/injection/gating consumers".
+
+## Knowledge Stewardship
+- Queried: mcp__unimatrix__context_briefing — direct hits: #5388 (ADR forbidding the flip), #5387 (NG-1 deferral), #4507 (original audit-mode default rationale), #4494/#4468 (resolution mechanics patterns).
+- Stored: nothing novel to store — findings are issue-specific code defects (bugs are GH issues, not lessons); ADR-conflict handling is encoded in the fix plan (context_correct #5388), not a lesson.


### PR DESCRIPTION
Fixes #881.

## Root cause
`context_graph`'s `resolve_supersessions` defaulted **OFF** while `context_get` resolves anchors **ON** (vnc-042). The only real consumers are **external agent callers of `context_graph`** (e.g. the `uni-capability` skill) — `context_briefing` and context injection are immune (they use `SearchService` `RetrievalMode::Strict`, not the graph path), and no server-side gating consumer exists.

Investigation surfaced two defects beyond the reported default mismatch:
- **G1 (load-bearing):** the depth-1 neighbors arm (the default depth) dispatched to `neighbors_sql`, which never consulted the flag — so even an explicit `resolve_supersessions: true` was ignored there. Flipping the default alone would have been a **no-op** for the flagship consumer.
- **N3:** subgraph resolved the neighbor *node* but recorded the edge with the *raw* target, so the dangling-edge filter dropped it, leaving the terminal as a disconnected node.

## Fix
1. Flip `resolve_supersessions` default OFF→ON in `graph_read_subgraph.rs`, `graph_read_neighbors.rs`, `graph_read_path.rs`. `false` stays as an explicit audit/raw opt-out.
2. **G1:** depth-1 `neighbors_sql` now resolves endpoints via a per-request memo (`resolve_memoized`) — bounds reads on hot nodes (in-degree ~110), one resolve per distinct endpoint.
3. **NG-1:** `build_edges_view` resolves the ≤3 displayed edge targets, substituting only when deprecated (byte-identity canary preserved).
4. **N3:** both subgraph edge-recording paths use resolved endpoints.
5. Docs: both `CONTEXT_GRAPH_DESCRIPTION` copies + `graph_read.rs` field doc now document the flag for all modes.
6. **Atomic ADR correction:** `context_correct` vnc-042 ADR #5388 → **#5409** — retracts only the graph flip-direction prohibition, preserves the per-intent principle, keeps the reverse prohibition (context_get stays default-resolve), records N2 (silent dead-end resolution + `uni-capability` gating risk) and N3.

## Tests
New cross-surface consistency test asserts `context_get`, neighbors (at **default depth 1** — the G1 catch), subgraph, and path all surface the terminal by default, and that explicit `resolve_supersessions: false` still returns raw. Plus NG-1 deprecated-target and escape-hatch tests.

- 4 new unit tests pass; `cargo test --workspace` rc=0; `cargo clippy --workspace -- -D warnings` rc=0
- Integration smoke 28 passed; graph/context-read integration 114 passed (6 pre-existing xfails, none touched)

## Post-merge follow-up
Vision session must correct SL7 (#5390) to drop the now-false "graph stays default-off" non-goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
