### PR TITLE
fix: pin rmcp-macros so default cargo install compiles (#902)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,6 +3875,7 @@ dependencies = [
  "rcgen",
  "regex",
  "rmcp",
+ "rmcp-macros",
  "rustls-pemfile",
  "schemars",
  "serde",

--- a/crates/unimatrix-server/Cargo.toml
+++ b/crates/unimatrix-server/Cargo.toml
@@ -31,6 +31,11 @@ petgraph = { version = "0.8", default-features = false, features = ["stable_grap
 fs2 = "0.4"
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "macros"] }
 rmcp = { version = "=1.7.0", features = ["server", "client", "transport-io", "macros", "transport-streamable-http-server", "transport-streamable-http-server-session"] }
+# rmcp-macros: lockstep pin with rmcp. rmcp 1.7.0 depends on rmcp-macros = "^1.7.0", and
+# `cargo install` ignores Cargo.lock, so a fresh resolve would pair rmcp 1.7.0 with a newer
+# rmcp-macros whose #[tool] codegen references symbols absent in the pinned rmcp lib (#902).
+# Bump BOTH =pins together on any rmcp upgrade. Unreferenced in source — macros are re-exported through rmcp.
+rmcp-macros = "=1.7.0"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7" }
 schemars = { workspace = true }

--- a/docs/testing/eval-harness.md
+++ b/docs/testing/eval-harness.md
@@ -868,7 +868,7 @@ integration test environment, not in offline CI.
 | `eval report` exits 0 on gate failures | Do not use the exit code as a CI gate. Zero-Regression and Distribution Gate failures appear in the report body only. `eval report` exits non-zero only for I/O errors and corrupt `profile-meta.json`. |
 | UDS ≠ hook socket | `UnimatrixUdsClient` and `UnimatrixHookClient` use different framing and different sockets. Connecting to the wrong one produces framing errors, not a clean error message. |
 | Weight sum = 0.92 | All six `[confidence.weights]` fields must sum to exactly 0.92 ± 1e-9. |
-| `cargo install` for production binary | `cargo build --release` writes to `target/release/` and does NOT update the running daemon. Use `cargo install --path crates/unimatrix-server` to replace the installed binary. Run before deploying a new build; kill the running daemon first. |
+| `cargo install` for production binary | `cargo build --release` writes to `target/release/` and does NOT update the running daemon. Use `cargo install --locked --path crates/unimatrix-server` to replace the installed binary. Run before deploying a new build; kill the running daemon first. |
 
 ---
 
@@ -881,7 +881,7 @@ integration test environment, not in offline CI.
 #   cargo build --release -p unimatrix-server   -- writes to target/release/, does NOT update the running daemon
 #
 # To update the installed/running MCP server binary:
-#   cargo install --path crates/unimatrix-server -- replaces the binary in $CARGO_HOME/bin/
+#   cargo install --locked --path crates/unimatrix-server -- replaces the binary in $CARGO_HOME/bin/
 #   Kill the running daemon before installing; it will not auto-restart.
 #
 cargo build --release --workspace


### PR DESCRIPTION
## Summary
Fixes #902. `cargo install --path crates/unimatrix-server` (without `--locked`) failed with 14× `E0425: cannot find function schema_for_input` from the `#[tool]` macro.

## Root cause
`cargo install` ignores `Cargo.lock` and re-resolves. `rmcp` is already exact-pinned `=1.7.0`, but **rmcp 1.7.0's own manifest floats its companion proc-macro crate** as `rmcp-macros = "^1.7.0"`. A fresh resolve therefore pairs rmcp 1.7.0 (lib) with rmcp-macros **1.8.0** (macro), whose `#[tool]` expansion calls `schema_for_input` — a symbol present only in the rmcp 1.8.0 lib. Mismatched macro/lib → the E0425 errors. `Cargo.lock` pinned the good 1.7.0/1.7.0 pair, which is why `--locked` and `cargo build/test --workspace` always passed.

## Fix
- `crates/unimatrix-server/Cargo.toml`: add `rmcp-macros = "=1.7.0"` (lockstep with `rmcp`), with a comment instructing future upgraders to bump both `=` pins together. Unifies with rmcp's `^1.7.0` requirement so a fresh `cargo install` resolves the known-good pair.
- `docs/testing/eval-harness.md`: add `--locked` to the two documented install commands as a safety net.
- `Cargo.lock`: gains only the direct-dependency edge; **no resolved version changes** (rmcp-macros stays 1.7.0).

## Testing
- `cargo test --workspace`: 6762 passed, 0 failed
- `cargo clippy --workspace -- -D warnings`: 0 warnings
- integration smoke (`pytest -m smoke`): 28 passed
- Per human directive, `cargo install` was **not** run; the fix was verified by manifest/lockfile inspection + build gates. A manifest `=` pin has no expressible Rust `#[test]` — the pin is the guard.

## Follow-ups (out of scope)
- Fresh-resolution `cargo install` canary in the `/uni-release` path (no automated guard today; GH CI is JS-client-only).
- Short ADR extending ADR-001 documenting the lockstep proc-macro pin convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)