### PR TITLE
fix: type the context_cycle_review transcript MCP axis so it is client-callable (#901)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3839,6 +3839,7 @@ version = "0.9.0"
 dependencies = [
  "bincode 2.0.1",
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ all = "warn"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bincode = { version = "2", features = ["serde"] }
+schemars = "1"
 
 # Patch anndists 0.1.4: fix cfg_if + #[cfg] block compilation with edition 2024.
 # Upstream declares edition = "2024" but has code incompatible with it.

--- a/crates/unimatrix-observe/Cargo.toml
+++ b/crates/unimatrix-observe/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1", features = ["rt"] }
 regex = "1"
 unimatrix-learn = { path = "../unimatrix-learn" }
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio"] }
+schemars = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/unimatrix-observe/src/types.rs
+++ b/crates/unimatrix-observe/src/types.rs
@@ -3,6 +3,7 @@
 //! Core observation types (HookType, ObservationRecord, ParsedSession, ObservationStats)
 //! are defined in unimatrix-core and re-exported here for backward compatibility (col-013 ADR-002).
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -673,41 +674,30 @@ pub struct TranscriptCandidatesSection {
 // Shapes are AUTHORITATIVE per pseudocode/OVERVIEW.md §Shared Types — not invented.
 // ---------------------------------------------------------------------------
 
-/// The all-optional, AND-composed filter block for the read-only `transcript`
-/// axis (crt-057, ADR-002/ADR-006). Deserialized from tool params.
-///
-/// Every present filter NARROWS (intersection, never union). All-`None`
-/// (`{}`) is the empty scope — equivalent to `match:".*"` at the retrieval
-/// layer (full candidate set under the existing per-cycle cap). Missing
-/// fields deserialize to `None` (serde's implicit default for `Option`), so
-/// `{}` yields an all-`None` scope rather than a deserialize error.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+/// Optional, AND-composed filter block for scoped `transcript` retrieval on
+/// `context_cycle_review`. Every present filter narrows the result
+/// (intersection, never union); an empty object `{}` selects the full
+/// candidate set. All fields are optional.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
 pub struct TranscriptScope {
-    /// Phase id → `cycle_events` bounds. Self-bounding: IGNORES `window`.
+    /// Restrict retrieval to transcript spanned by the given phase id.
     pub phase: Option<String>,
-    /// Finding id → `HotspotFinding.evidence[].ts` span `[min, max]`; honors `window`.
+    /// Restrict retrieval to transcript around the given finding id (honors `window`).
     pub anchor: Option<String>,
-    /// Regex over the WHOLE `TranscriptCandidate.text` block. `match` is a Rust
-    /// keyword, so the field is the raw identifier `r#match` renamed on the wire.
+    /// Regular expression matched against each transcript candidate's text.
     #[serde(rename = "match")]
     pub r#match: Option<String>,
-    /// ±radius applied to `anchor`/`match` hits; ignored by self-bounding `phase`.
+    /// Radius applied around `anchor`/`match` hits (ignored by `phase`).
     pub window: Option<Window>,
 }
 
-/// Time/block radius around `anchor`/`match` hits (crt-057, ADR-006).
-///
-/// Carries BOTH a time radius (`millis`, for ts-bearing candidates) and a block
-/// radius (`blocks`, for `ts:None` candidates via `byte_offset` proximity) so a
-/// caller who thinks only in time still gets the block fallback and `ts:None`
-/// candidates never silently drop. Unspecified fields resolve to the canonical
-/// [`DEFAULT_WINDOW_MILLIS`] / [`DEFAULT_WINDOW_BLOCKS`], NOT to zero (a
-/// zero-width window would re-introduce the silent-miss failure this design fixes).
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+/// Time/block radius applied around `anchor`/`match` hits. Both radii are
+/// optional; omitted fields fall back to server defaults rather than zero.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, JsonSchema)]
 pub struct Window {
-    /// Time radius (ms) for ts-bearing candidates; default [`DEFAULT_WINDOW_MILLIS`].
+    /// Time radius in milliseconds for timestamped candidates.
     pub millis: Option<u64>,
-    /// `byte_offset` block radius for `ts:None` candidates; default [`DEFAULT_WINDOW_BLOCKS`].
+    /// Block radius for candidates without a timestamp.
     pub blocks: Option<u32>,
 }
 

--- a/crates/unimatrix-server/Cargo.toml
+++ b/crates/unimatrix-server/Cargo.toml
@@ -33,7 +33,7 @@ sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "macros"] }
 rmcp = { version = "=1.7.0", features = ["server", "client", "transport-io", "macros", "transport-streamable-http-server", "transport-streamable-http-server-session"] }
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7" }
-schemars = "1"
+schemars = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 regex = "1"

--- a/crates/unimatrix-server/src/mcp/tools.rs
+++ b/crates/unimatrix-server/src/mcp/tools.rs
@@ -469,12 +469,7 @@ pub struct RetrospectiveParams {
     /// returns selected `TranscriptCandidate`s plus per-session `SessionLossInfo`
     /// / search-status; it NEVER purges — the review has no destructive verb
     /// (NG-6). Non-destructive and repeatable. See `TranscriptScope`.
-    ///
-    /// Schema note: `#[schemars(with = ...)]` exposes this as a free-form object
-    /// because the underlying `TranscriptScope`/`Window` (unimatrix-observe) are
-    /// serde-only (Wave 1); serde still deserializes to the strong type.
     #[serde(default)]
-    #[schemars(with = "Option<serde_json::Value>")]
     pub transcript: Option<unimatrix_observe::TranscriptScope>,
 }
 
@@ -6871,14 +6866,8 @@ mod tests {
         let hotspots = unimatrix_observe::detect_hotspots(&corpus, &rules);
         const PINNED_NOW: u64 = 2_000_000_000;
         let metrics = unimatrix_observe::compute_metric_vector(&corpus, &hotspots, PINNED_NOW);
-        let mut report = unimatrix_observe::build_report(
-            "crt-057-ac10",
-            &corpus,
-            metrics,
-            hotspots,
-            None,
-            None,
-        );
+        let mut report =
+            unimatrix_observe::build_report("crt-057-ac10", &corpus, metrics, hotspots, None, None);
         report.recommendations = unimatrix_observe::recommendations_for_hotspots(&report.hotspots);
         report.narratives = Some(unimatrix_observe::synthesize_narratives(&report.hotspots));
 

--- a/crates/unimatrix-server/src/server.rs
+++ b/crates/unimatrix-server/src/server.rs
@@ -3651,6 +3651,192 @@ pub(crate) mod tests {
         }
     }
 
+    // -- bugfix-901: transcript axis JsonSchema — schema snapshot + live boundary --
+    //
+    // #901: `RetrospectiveParams.transcript` (Option<TranscriptScope>) previously
+    // carried `#[schemars(with = "Option<serde_json::Value>")]`, so `tools/list`
+    // advertised it as a free-form any-value — no shape. A schema-driven client
+    // sent it as a string and rmcp strict extraction rejected the call with -32602
+    // before the handler ran. Deriving JsonSchema on the source types
+    // (TranscriptScope/Window in unimatrix-observe) makes tools/list advertise the
+    // real object shape. Both tests below guard that fix.
+
+    /// Extend of vnc-012 AC-10: `context_cycle_review`'s `transcript` property now
+    /// advertises the four sub-fields (`phase`/`anchor`/`match`/`window`) and the
+    /// nested `window` object (`millis`/`blocks`), NOT the empty/free-form fallback.
+    ///
+    /// Shape asserted against what rmcp 1.7 + schemars 1.2 actually emit: an
+    /// `Option<T>` field emits a nullable `anyOf: [{$ref}, {"type":"null"}]` and
+    /// the referenced struct lives in `$defs` (JSON Schema 2020-12; GH#684). The
+    /// wire key MUST be literally `match` (serde `rename = "match"`), not `r#match`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_schema_transcript_advertises_object_shape() {
+        let server = make_server().await;
+        let tools = server.tool_router.list_all();
+        let review = tools
+            .into_iter()
+            .find(|t| t.name == "context_cycle_review")
+            .expect("AC-10/901: context_cycle_review tool must exist");
+        let schema = serde_json::Value::Object(review.input_schema.as_ref().clone());
+
+        // `transcript` is optional → NOT in the top-level required array.
+        if let Some(required) = schema.get("required").and_then(|r| r.as_array()) {
+            assert!(
+                !required.iter().any(|v| v == "transcript"),
+                "901: transcript is optional and must not be in `required`"
+            );
+        }
+
+        // `transcript` property is the nullable union anyOf[$ref TranscriptScope, null]
+        // — NOT the empty `{}`/free-form object the bug advertised.
+        let transcript = &schema["properties"]["transcript"];
+        let any_of = transcript["anyOf"]
+            .as_array()
+            .expect("901: transcript must emit an `anyOf` nullable union, not free-form");
+        let scope_ref = any_of
+            .iter()
+            .find_map(|v| v.get("$ref").and_then(|r| r.as_str()))
+            .expect("901: transcript anyOf must reference the TranscriptScope $def");
+        assert_eq!(
+            scope_ref, "#/$defs/TranscriptScope",
+            "901: transcript must $ref the TranscriptScope definition"
+        );
+        assert!(
+            any_of.iter().any(|v| v["type"] == "null"),
+            "901: transcript must remain nullable (optional field)"
+        );
+
+        // Resolve the referenced definition and assert the four sub-fields.
+        let defs = schema
+            .get("$defs")
+            .expect("901: schema must carry a `$defs` block for the nested types");
+        let scope = &defs["TranscriptScope"];
+        assert_eq!(
+            scope["type"], "object",
+            "901: TranscriptScope must be an object schema"
+        );
+        let scope_props = scope["properties"]
+            .as_object()
+            .expect("901: TranscriptScope must advertise properties");
+        for field in ["phase", "anchor", "match", "window"] {
+            assert!(
+                scope_props.contains_key(field),
+                "901: TranscriptScope must advertise sub-field `{field}`; \
+                 the wire key for the regex axis MUST be `match` (serde rename), \
+                 not `r#match`/`match_`. Got keys: {:?}",
+                scope_props.keys().collect::<Vec<_>>()
+            );
+        }
+        // No sub-field is required (all-optional / AND-composition semantics).
+        if let Some(required) = scope.get("required").and_then(|r| r.as_array()) {
+            assert!(
+                required.is_empty(),
+                "901: no TranscriptScope sub-field may be required (all-optional)"
+            );
+        }
+
+        // Nested `window` resolves to the Window $def with millis/blocks.
+        let window_ref = scope_props["window"]["anyOf"]
+            .as_array()
+            .and_then(|a| {
+                a.iter()
+                    .find_map(|v| v.get("$ref").and_then(|r| r.as_str()))
+            })
+            .expect("901: window must $ref the Window definition (nested type)");
+        assert_eq!(window_ref, "#/$defs/Window");
+        let window = &defs["Window"];
+        let window_props = window["properties"]
+            .as_object()
+            .expect("901: Window must advertise properties");
+        for field in ["millis", "blocks"] {
+            assert!(
+                window_props.contains_key(field),
+                "901: Window must advertise sub-field `{field}`"
+            );
+        }
+    }
+
+    /// Live MCP-boundary `tools/call`: drive `context_cycle_review` with a real
+    /// `transcript` object (including a nested `window`) through the duplex
+    /// transport and assert extraction does NOT fail with -32602.
+    ///
+    /// This is the test class that was missing and let #901 ship through all three
+    /// crt-057 gates — every prior test drove the Rust types directly rather than
+    /// the MCP boundary. The nested `window` object forces the client to resolve
+    /// the emitted `$defs`/`$ref` (MCP `input_schema` must be self-contained).
+    ///
+    /// For a feature with no observations the handler returns the application error
+    /// `ERROR_NO_OBSERVATION_DATA` (-32010) — that is expected and PROVES the
+    /// transcript object deserialized past strict param extraction (the -32602 the
+    /// bug produced happened before the handler ever ran).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_cycle_review_transcript_object_passes_mcp_boundary() {
+        use rmcp::ServiceError;
+        use rmcp::model::{
+            CallToolRequestParams, ClientCapabilities, Implementation, ProtocolVersion,
+        };
+        use rmcp::service::ServiceExt;
+        use tokio::io::duplex;
+
+        let server = make_server().await;
+        let (server_transport, client_transport) = duplex(4096);
+
+        let client_info = rmcp::model::ClientInfo::new(
+            ClientCapabilities::default(),
+            Implementation::new("bugfix-901-client", "0.0.1"),
+        )
+        .with_protocol_version(ProtocolVersion::LATEST);
+
+        // Keep the server's RunningService alive by awaiting its event loop
+        // (`waiting()`); simply awaiting `serve()` yields the service then drops it,
+        // which closes the transport before any `tools/call` can be answered.
+        let server_task = tokio::spawn(async move {
+            if let Ok(running) = server.serve(server_transport).await {
+                let _ = running.waiting().await;
+            }
+        });
+
+        let client = rmcp::serve_client(client_info, client_transport)
+            .await
+            .expect("901: client initialize handshake must succeed");
+
+        // Real transcript object WITH a nested window — exercises the $ref/$defs
+        // resolution and the `match` wire key end-to-end.
+        let args = serde_json::json!({
+            "feature_cycle": "bugfix-901-ghost",
+            "transcript": {
+                "match": "context_cycle_review",
+                "window": { "millis": 1000, "blocks": 2 }
+            }
+        });
+        let args_obj = args
+            .as_object()
+            .expect("test setup: args is a JSON object")
+            .clone();
+
+        let result = client
+            .call_tool(CallToolRequestParams::new("context_cycle_review").with_arguments(args_obj))
+            .await;
+
+        client.cancel().await.ok();
+        server_task.abort();
+
+        match result {
+            Ok(_) => { /* extraction + handler both succeeded */ }
+            Err(ServiceError::McpError(err)) => {
+                assert_ne!(
+                    err.code,
+                    crate::error::ERROR_INVALID_PARAMS,
+                    "901: a real transcript object (with nested window) must pass \
+                     strict param extraction at the MCP boundary; got -32602 \
+                     (invalid_params) — the bug is not fixed. message: {}",
+                    err.message
+                );
+            }
+            Err(other) => panic!("901: unexpected transport/service error: {other:?}"),
+        }
+    }
+
     // -- vnc-014: client_type_map and initialize override tests --
 
     /// Helper: run MCP initialize handshake over in-memory duplex transport.

--- a/product/features/bugfix-901/agents/901-agent-1-fix-report.md
+++ b/product/features/bugfix-901/agents/901-agent-1-fix-report.md
@@ -1,0 +1,36 @@
+# Agent Report: 901-agent-1-fix (bugfix-901)
+
+## Fix
+Root cause was the `transcript` retrieval axis of `context_cycle_review` advertising a
+free-form any-value schema (`#[schemars(with = "Option<serde_json::Value>")]`) while the
+deserializer demanded an exact `TranscriptScope` struct — a schema/deserializer contract
+mismatch. A schema-driven client sent the value as a string; rmcp strict extraction
+rejected it with -32602 before the handler ran.
+
+Fixed by deriving `JsonSchema` on the source types so `tools/list` advertises the real
+object shape. Serde deserialization path untouched (zero runtime behavior change).
+
+## Files modified
+- `Cargo.toml` — promoted `schemars = "1"` to `[workspace.dependencies]` (prevents observe/server/rmcp generator version drift; matches the serde/serde_json/bincode convention).
+- `crates/unimatrix-server/Cargo.toml` — `schemars = { workspace = true }`.
+- `crates/unimatrix-observe/Cargo.toml` — added `schemars = { workspace = true }`.
+- `crates/unimatrix-observe/src/types.rs` — `import schemars::JsonSchema`; derived `JsonSchema` on `TranscriptScope` and `Window`; trimmed internals-leaking doc comments (they surface as client-facing schema `description`s).
+- `crates/unimatrix-server/src/mcp/tools.rs` — removed the `#[schemars(with = "Option<serde_json::Value>")]` escape hatch and the stale Wave-1 "Schema note" doc on `RetrospectiveParams.transcript`.
+- `crates/unimatrix-server/src/server.rs` — two new tests (below).
+- `Cargo.lock` — schemars added to unimatrix-observe.
+
+## New tests
+- `test_schema_transcript_advertises_object_shape` (server.rs) — schema-snapshot (extends vnc-012 AC-10 region). Asserts `context_cycle_review`'s `transcript` emits the nullable union `anyOf:[{$ref #/$defs/TranscriptScope},{null}]`, resolves `$defs/TranscriptScope` to an object with sub-fields `phase`/`anchor`/`match`/`window` (wire key literally `match`), `window` `$ref`s `$defs/Window` (`millis`/`blocks`), and none required. Teeth verified: fails when the escape hatch is restored.
+- `test_cycle_review_transcript_object_passes_mcp_boundary` (server.rs) — live duplex `tools/call`. Drives `context_cycle_review` with a real `transcript` object including a nested `window` through the MCP boundary; asserts extraction does NOT return -32602 (ERROR_NO_OBSERVATION_DATA/-32010 for the ghost feature is expected and proves the object deserialized past strict extraction). First `call_tool` client test in the workspace (seed only — no generalized harness, per scope hold).
+
+## Tests
+unimatrix-observe + unimatrix-server: all pass (server lib 4364 passed; observe 578 passed; 0 failed). Workspace build clean. clippy clean on both crates.
+
+## Notes / boundaries honored
+- Did NOT modify pattern #3813 or add a serde_json::Value-escape-hatch convention (deferred to retro).
+- Did NOT build a generalized MCP-boundary schema-contract harness (separate follow-up).
+- Boundary test caveat: sending a valid object deserializes regardless of advertised schema, so this test alone does not reproduce the client-side string coercion; the schema-snapshot test is the class-specific regression catch. The boundary test seeds the missing test CLASS (self-contained `$defs`/`$ref` resolution + real object round-trip through duplex).
+
+## Knowledge Stewardship
+- Queried: `mcp__unimatrix__context_briefing` (bugfix-901) — surfaced crt-033/crt-025 ADRs on `RetrospectiveReport` shape and unimatrix-server schema patterns; none altered the approved fix. Investigator/reviewer briefings already covered pattern #3813, ADR #4734 (typed `schemars(with)`), ADR #3795 (derive on observe source types, no DTO shim), lesson #5444 (consumer-callable gate class).
+- Stored: nothing novel — this is a bug fix, not a reusable pattern. The typing convention is pattern #3813, the gate class is lesson #5444, and per project policy defect specifics live on GH #901. Whether #3813 should be extended ("no `serde_json::Value` escape hatch on MCP params") is a crt-057/901 retro decision, not this fix's to store.

--- a/product/features/bugfix-901/agents/901-investigator-report.md
+++ b/product/features/bugfix-901/agents/901-investigator-report.md
@@ -1,0 +1,27 @@
+# Agent Report: 901-investigator (bugfix-901)
+
+Diagnosis posted: https://github.com/dug-21/unimatrix/issues/901#issuecomment-4884236020
+
+## Verdict
+Root cause confirmed (confidence: high). Two-part:
+1. `TranscriptScope` / `Window` (`crates/unimatrix-observe/src/types.rs:685`, `:707`) are serde-only — no `JsonSchema` derive; `unimatrix-observe/Cargo.toml` has no schemars dep.
+2. `RetrospectiveParams.transcript` (`crates/unimatrix-server/src/mcp/tools.rs:476-478`) uses `#[schemars(with = "Option<serde_json::Value>")]` — the tool schema advertises a free-form object, clients send a string, rmcp `Parameters` extraction rejects with `-32602` before the handler runs.
+
+## Proposed Fix (minimal)
+- Add `schemars = "1"` to unimatrix-observe (workspace already locks 1.2.1, same as rmcp 1.7.0).
+- Derive `JsonSchema` on `TranscriptScope` + `Window` (serde `rename = "match"` is honored).
+- Remove the `schemars(with)` attr + stale "Schema note" doc on `RetrospectiveParams.transcript`.
+- Rejected: params-layer mirror struct (drift class this bug embodies; crt-057 already mutated the shape mid-delivery).
+
+## Missing Tests
+1. Schema-shape assertion in the vnc-012 AC-10 region (`server.rs:3578`): `context_cycle_review.input_schema.properties.transcript` must advertise phase/anchor/match/window (window → millis/blocks).
+2. Live duplex `tools/call` test with a real `transcript` object (extend `run_initialize_handshake`, `server.rs:3660`; rmcp `client` feature already enabled). No `call_tool` client test exists workspace-wide.
+
+## Risks
+- schemars nested-struct `$ref`/`$defs` emission — assert actual rmcp 1.7 output shape in the test.
+- `Option<TranscriptScope>` emits the 2020-12 nullable union under rmcp ≥ 1.7 (GH#684) — assertions must accept it.
+- Zero runtime behavior change (serde path untouched).
+
+## Knowledge Stewardship
+- Queried: mcp__unimatrix__context_briefing — pattern #3813 (real type in `schemars(with)`), ADR #4734 (vnc-012), ADR #5434 (crt-057 ADR-002); context_get #5444 (interface consistent but not consumer-callable — same class).
+- Stored: nothing novel to store — convention covered by #3813, gate class by #5444; defect specifics live on GH #901 per project policy. Possible #3813 extension ("no `serde_json::Value` escape hatch on MCP params") is a post-fix retro call.


### PR DESCRIPTION
## Summary
Fixes #901. The crt-057 `transcript` scoped-retrieval axis on `context_cycle_review` was exposed as a free-form untyped object in the MCP tool schema, so schema-driven clients sent it as a string and the strict deserializer rejected it with `-32602` — the opt-in scoped retrieval was uncallable by a real client.

## Root cause
`TranscriptScope` and `Window` (`unimatrix-observe`) derived only `Deserialize`, no `JsonSchema`; `RetrospectiveParams.transcript` papered over it with `#[schemars(with = "Option<serde_json::Value>")]`. `tools/list` therefore never advertised `{ phase?, anchor?, match?, window? }`. Every crt-057 gate exercised the Rust types directly — no live schema-driven MCP call — so it passed (lesson #5444: internally consistent but not consumer-callable).

## Fix
- Promote `schemars = "1"` to `[workspace.dependencies]`; `unimatrix-observe` and `unimatrix-server` both reference `schemars.workspace = true` (no generator-version drift).
- Derive `JsonSchema` on `TranscriptScope` and `Window` (serde `rename = "match"` preserved and verified as the literal wire key).
- Remove the `#[schemars(with = ...)]` escape hatch and the stale Wave-1 doc note on `RetrospectiveParams.transcript`; the schema now infers from the derived impl.
- Serde deserialization path untouched — zero runtime behavior change.

`transcript` now advertises `anyOf: [ { $ref: #/$defs/TranscriptScope }, { type: null } ]`, with `TranscriptScope` → `phase`/`anchor`/`match`/`window` and `window` → `$ref Window`. Self-contained `$defs`; no field required.

## Tests
- `test_schema_transcript_advertises_object_shape` — schema-snapshot; asserts the emitted `anyOf`/`$ref`/`$defs`, four sub-fields, literal `match` key, nested `window`→`Window`, non-required. Teeth-verified (fails with the escape hatch restored).
- `test_cycle_review_transcript_object_passes_mcp_boundary` — first live duplex `tools/call` client test in the workspace; drives `context_cycle_review` with a real `transcript` including a nested `window` and asserts extraction does not return `-32602`.

Workspace `cargo test` rc=0, clippy clean, 28 smoke + 13 protocol + 40 tools-subset green. Gate: Bug Fix Validation — PASS (11/11).

## Follow-ups (out of scope, deferred by direction)
- Reusable MCP-boundary schema-contract harness across all tools — this PR seeds the first `tools/call` test only.
- Extending pattern #3813 ("no `serde_json::Value` escape hatch on MCP params") — a convention decision for the crt-057/901 retro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
