### PR TITLE
fix(infra-001): green blocking smoke for container-cloud HTTPS + operator client-works (#915, #916)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,11 @@
 
 services:
   unimatrix:
-    image: ghcr.io/dug-21/unimatrix:latest
+    # Operator-facing default stays ghcr :latest; the ${UNIMATRIX_IMAGE:-...} interpolation
+    # is back-compat (unset => :latest). The release smoke's compose-boot gate (#915)
+    # OVERRIDES it with UNIMATRIX_IMAGE=<version-under-test> + `--pull never` so the gate
+    # proves the candidate build, never the already-released :latest.
+    image: ${UNIMATRIX_IMAGE:-ghcr.io/dug-21/unimatrix:latest}
     # To build locally instead of pulling:
     #   build: .
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,12 @@ services:
     ports:
       # TLS port ONLY — pinned-TLS HTTPS (ADR-007, FR-A8, AC-W1-S2, R-12).
       # There is NO plaintext port: OSS posture has no plaintext-to-client mode.
-      - "8443:8443"
+      # The ${UNIMATRIX_HOST_BIND:-} prefix is back-compat and GATE-SCOPED: unset (the
+      # operator-facing default) => "8443:8443" (0.0.0.0, unchanged). The release smoke's
+      # compose-boot gate (#915) sets UNIMATRIX_HOST_BIND=127.0.0.1: so the GATE publishes
+      # on loopback only (no external exposure / parallel-run host-port collision) — it does
+      # NOT change this operator default; an operator may legitimately want 0.0.0.0.
+      - "${UNIMATRIX_HOST_BIND:-}8443:8443"
     volumes:
       - unimatrix-data:/data
       # /shared is READ-WRITE by default (ADR-003 nan-015 #4652). The image bakes

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -90,6 +90,8 @@ When TLS is terminated by a reverse proxy (nginx, Caddy, cloud load balancer), s
 
 ## Verifying the connection
 
+### 1. Liveness (server is up)
+
 The `/health` endpoint requires no authentication:
 
 ```bash
@@ -102,7 +104,27 @@ Returns:
 {"version": "x.y.z", "schema_version": 27}
 ```
 
-Use this for Docker HEALTHCHECK or external monitoring.
+Use this for Docker HEALTHCHECK or external monitoring. Note: `/health` proves only
+that the server is *up* — not that *your client works*. For that, do step 2.
+
+### 2. Client works (a real authenticated `context_*` op over the pinned-TLS bundle)
+
+After `unimatrix init --bundle …` writes `.mcp.json`, confirm the attached client can
+perform a real operation over the pinned-TLS bundle path — not just reach `/health`. This
+reads the bridge command your `init --bundle` wrote into `.mcp.json` and drives one
+stateless `context_status` call through it (requires `jq`):
+
+```bash
+printf '%s\n%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"verify","version":"1.0.0"}}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"context_status","arguments":{}}}' \
+  | node "$(jq -r '.mcpServers.unimatrix.args[0]' .mcp.json)" \
+         "$(jq -r '.mcpServers.unimatrix.args[1]' .mcp.json)"
+```
+
+A non-error JSON-RPC result (no `"error"` field, no `"isError": true`) confirms the client
+performs real `context_*` operations over the pinned-TLS bundle. This is the same check the
+release smoke's client-works gate runs (`docker-http-posture-smoke.sh`, Gate 9).
 
 ---
 

--- a/product/test/infra-001/scripts/bridge-single-call-driver.js
+++ b/product/test/infra-001/scripts/bridge-single-call-driver.js
@@ -1,0 +1,175 @@
+"use strict";
+
+// bridge-single-call-driver.js (#915/#916) — drive ONE stateless context_* tools/call
+// THROUGH the SHIPPED `node mcp-bridge.js <projectHash>` over stdio JSON-RPC. This is
+// the client-works proof (C15/#916): it proves the ATTACHED client can perform a REAL
+// context_* op over the pinned-TLS bundle path — not merely that /health is up.
+//
+// It is a thin test helper (test tree only): it adds NO transport/cert/credstore code —
+// it spawns the UNMODIFIED shipped bridge and speaks newline-delimited JSON-RPC to it
+// (the framing the bridge's StdioFramer reads/writes). The bridge owns the pinned-HTTPS
+// session, credstore read (keyed by the projectHash arg + HOME), Mcp-Session-Id
+// capture/replay, and SSE parse; this driver re-implements NONE of that (reuse-as-is,
+// pattern #5129 — never a native http MCP entry).
+//
+// Distinct from bridge-cycle-driver.js: that drives the full context_cycle parity
+// workload (start -> tools -> stop -> review) and needs a manifest. This driver makes
+// exactly ONE tools/call (default context_status — stateless, embed-free) so the fast
+// posture smoke never perturbs the shared-lane gate-8 credstore/cycle nor eats the
+// embed-retry window.
+//
+// Usage:
+//   node bridge-single-call-driver.js <projectHash> <toolName> --bridge <path-to-mcp-bridge.js>
+// Stdout: ONE json line: {ok, tool, error}. Diagnostics -> stderr.
+// Exit: 0 on a non-error tool result; 1 otherwise. The SHELL gate wraps this whole
+// process in `timeout` (bounded) so a bridge hang cannot eat the blocking lane's job
+// timeout; the internal rpc timeouts below are defense-in-depth.
+
+const { spawn } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+function emit(o) {
+  process.stdout.write(JSON.stringify(o) + "\n");
+}
+function die(msg) {
+  emit({ ok: false, tool: null, error: String(msg) });
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const pos = [];
+  const opt = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--bridge") {
+      opt.bridge = argv[++i];
+    } else {
+      pos.push(a);
+    }
+  }
+  return { projectHash: pos[0], tool: pos[1], opt };
+}
+
+async function main() {
+  const { projectHash, tool, opt } = parseArgs(process.argv);
+  if (!projectHash || !tool) {
+    die("usage: bridge-single-call-driver.js <projectHash> <toolName> --bridge <p>");
+  }
+  const bridgePath = opt.bridge;
+  if (!bridgePath || !fs.existsSync(bridgePath)) die("bridge path missing: " + bridgePath);
+
+  // ---- spawn the REAL bridge; HOME is inherited (the shell gate sets $SANDBOX/home) ----
+  // so credstore.read finds THIS run's remote.json keyed by projectHash. The bridge's
+  // own stderr (incl. #830 self-heal notices) is INHERITED to fd2, which the shell gate
+  // captured to a file it tail-dumps ON FAILURE ONLY.
+  const bridge = spawn(process.execPath, [path.resolve(bridgePath), projectHash], {
+    stdio: ["pipe", "pipe", "inherit"],
+    env: process.env,
+  });
+
+  let bridgeExitErr = null;
+  bridge.on("error", (e) => { bridgeExitErr = e; });
+  bridge.on("exit", (code, signal) => {
+    if (code !== 0 && code !== null) bridgeExitErr = new Error("bridge exited code=" + code);
+    else if (signal) bridgeExitErr = new Error("bridge killed signal=" + signal);
+  });
+
+  // ---- newline-delimited JSON-RPC over the bridge's stdio (StdioFramer) ----
+  const pending = new Map(); // id -> {resolve,reject}
+  let rbuf = "";
+  bridge.stdout.setEncoding("utf8");
+  bridge.stdout.on("data", (chunk) => {
+    rbuf += chunk;
+    let idx;
+    while ((idx = rbuf.indexOf("\n")) !== -1) {
+      const line = rbuf.slice(0, idx);
+      rbuf = rbuf.slice(idx + 1);
+      if (line.trim() === "") continue;
+      let msg;
+      try { msg = JSON.parse(line); } catch (_e) { continue; }
+      const h = msg && msg.id != null ? pending.get(msg.id) : null;
+      if (h) { pending.delete(msg.id); h.resolve(msg); }
+    }
+  });
+
+  let nextId = 1;
+  function send(obj) {
+    bridge.stdin.write(JSON.stringify(obj) + "\n");
+  }
+  function rpc(buildEnvelope, timeoutMs) {
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      const t = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error("timeout waiting for JSON-RPC id=" + id));
+      }, timeoutMs || 30000);
+      pending.set(id, {
+        resolve: (m) => { clearTimeout(t); resolve(m); },
+        reject: (e) => { clearTimeout(t); reject(e); },
+      });
+      send(buildEnvelope(id));
+    });
+  }
+  function notify(obj) { send(obj); }
+
+  function ensureOk(resp, what) {
+    if (!resp) throw new Error(what + ": no response");
+    if (resp.error) throw new Error(what + " failed: " + JSON.stringify(resp.error));
+    // tools/call surfaces tool-level errors inside result.isError.
+    const r = resp.result;
+    if (r && r.isError) {
+      const txt = r.content && r.content[0] && r.content[0].text ? r.content[0].text : "";
+      throw new Error(what + " tool error: " + txt);
+    }
+    return resp;
+  }
+
+  try {
+    const initResp = await rpc(
+      (id) => ({
+        jsonrpc: "2.0",
+        id,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "claim-floor-single-call-driver", version: "1.0.0" },
+        },
+      }),
+      45000
+    );
+    ensureOk(initResp, "initialize");
+    notify({ jsonrpc: "2.0", method: "notifications/initialized" });
+
+    // The ONE real context_* op — a non-error tool result is the client-works proof.
+    ensureOk(
+      await rpc((id) => ({
+        jsonrpc: "2.0",
+        id,
+        method: "tools/call",
+        params: { name: tool, arguments: {} },
+      })),
+      tool
+    );
+
+    bridge.stdin.end(); // EOF -> teardown DELETE -> bridge exit 0
+    await new Promise((r) => setTimeout(r, 200));
+    if (bridgeExitErr) throw bridgeExitErr;
+
+    emit({ ok: true, tool, error: null });
+    process.exit(0);
+  } catch (e) {
+    try { bridge.stdin.end(); } catch (_e) {}
+    try { bridge.kill("SIGTERM"); } catch (_e) {}
+    die((e && e.message) || e);
+  }
+}
+
+// Run main() ONLY when invoked as the entry script (so off-Docker tests can require this
+// module for parseArgs without spawning a bridge / calling exit).
+if (require.main === module) {
+  main();
+}
+
+module.exports = { parseArgs };

--- a/product/test/infra-001/scripts/claim-floor-lib.sh
+++ b/product/test/infra-001/scripts/claim-floor-lib.sh
@@ -36,6 +36,11 @@ SINGLE_DRIVER_JS="$SCRIPTS_DIR/bridge-single-call-driver.js"
 # (constraint 1) caps a bridge hang so it cannot eat the blocking lane's job timeout.
 CLIENT_CALL_TOOL="${CLIENT_CALL_TOOL:-context_status}"
 CLIENT_CALL_DEADLINE_S="${CLIENT_CALL_DEADLINE_S:-60}"
+# S4: SIGKILL escalation grace for the bounded drive. `setsid -w timeout -k <grace>` runs
+# the drive in its OWN session/process group and, on deadline, TERMs the WHOLE group (the
+# driver AND the spawned bridge child), then KILLs after <grace> if any member ignores TERM
+# — so a Gate-9 timeout can never leave an orphaned node/bridge process on the runner.
+CLIENT_CALL_KILL_GRACE_S="${CLIENT_CALL_KILL_GRACE_S:-5}"
 
 # Gate 10 shipped defaults (verified against docker-compose.yml: image service
 # `unimatrix`, SAN cloud.example, TLS port 8443). Project-scoped so a mid-gate failure
@@ -69,9 +74,10 @@ drive_client_call() {
   local project_hash="$1" out="$2" err="$3"
   if [ -n "${SMOKE_CLIENT_CALL_CMD:-}" ]; then
     # Stub seam (mirrors SMOKE_*_CMD): drive control flow without node/Docker. Bounded by
-    # `timeout` exactly as the real path is (a stub hang is a real-path hang here too).
+    # the SAME process-group `setsid -w timeout -k` as the real path (a stub hang — and any
+    # child it spawns — is torn down exactly as a real-path hang is; S4).
     # shellcheck disable=SC2086
-    HOME="$SANDBOX/home" timeout "$CLIENT_CALL_DEADLINE_S" \
+    HOME="$SANDBOX/home" setsid -w timeout -k "$CLIENT_CALL_KILL_GRACE_S" "$CLIENT_CALL_DEADLINE_S" \
       $SMOKE_CLIENT_CALL_CMD "$project_hash" "$CLIENT_CALL_TOOL" >"$out" 2>"$err"
   else
     command -v node >/dev/null 2>&1 \
@@ -80,9 +86,10 @@ drive_client_call() {
       || fail "client-works: shipped bridge $BRIDGE_JS not found (reuse-as-is)"
     [ -f "$SINGLE_DRIVER_JS" ] \
       || fail "client-works: single-call driver $SINGLE_DRIVER_JS not found"
-    # HOME=$SANDBOX/home so credstore.read finds THIS run's remote.json. `timeout` bounds
-    # a bridge hang so it cannot eat the blocking lane's job timeout (constraint 1).
-    HOME="$SANDBOX/home" timeout "$CLIENT_CALL_DEADLINE_S" \
+    # HOME=$SANDBOX/home so credstore.read finds THIS run's remote.json. `setsid -w timeout
+    # -k` bounds the drive in its OWN process group (constraint 1) so the deadline TERM/KILL
+    # reaps the driver AND the spawned bridge child — no orphaned process on timeout (S4).
+    HOME="$SANDBOX/home" setsid -w timeout -k "$CLIENT_CALL_KILL_GRACE_S" "$CLIENT_CALL_DEADLINE_S" \
       node "$SINGLE_DRIVER_JS" "$project_hash" "$CLIENT_CALL_TOOL" --bridge "$BRIDGE_JS" \
         >"$out" 2>"$err"
   fi
@@ -126,7 +133,13 @@ client_works_gate() {
 # docker/curl commands.
 
 compose_plugin_present()   { docker compose version >/dev/null 2>&1; }
-compose_do_up()            { UNIMATRIX_IMAGE="$IMAGE" docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" up -d --pull never >/dev/null 2>&1; }
+# S2: bind the GATE's published port to loopback ONLY (127.0.0.1:8443:8443) via the
+# UNIMATRIX_HOST_BIND interpolation the shipped compose exposes with an EMPTY default. This
+# is GATE-SCOPED — it never mutates the operator-facing default (unset => 0.0.0.0:8443:8443,
+# an operator may legitimately want 0.0.0.0). Consistent with the gate's pinned
+# `--resolve cloud.example:8443:127.0.0.1`, and avoids external exposure / parallel-run
+# host-port collision during the gate.
+compose_do_up()            { UNIMATRIX_IMAGE="$IMAGE" UNIMATRIX_HOST_BIND="127.0.0.1:" docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" up -d --pull never >/dev/null 2>&1; }
 compose_service_cid()      { docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" ps -q unimatrix 2>/dev/null; }
 compose_expected_digest()  { docker image inspect "$IMAGE" --format '{{.Id}}' 2>/dev/null; }
 compose_container_digest() { docker inspect "$1" --format '{{.Image}}' 2>/dev/null; }
@@ -153,12 +166,18 @@ compose_boot_gate() {
   [ -n "${IMAGE:-}" ] \
     || fail "compose boot: IMAGE unset — the gate needs the version-under-test image"
 
+  # S1: ARM the cleanup-trap teardown BEFORE `compose up` (the project name is already
+  # captured in $COMPOSE_PROJECT at source time). ANY outcome of the up — partial start
+  # then nonzero, a timeout, or any later mid-gate fail() — now still runs the project-
+  # scoped `docker compose -p <proj> down -v` in the smoke's cleanup() trap, so no
+  # containers/volumes are orphaned on a failed/partial up. `down -v` on a no-op stack is
+  # harmless (compose_teardown swallows its rc).
+  # shellcheck disable=SC2034  # read cross-file by the smoke's cleanup() trap
+  COMPOSE_UP=1
   # Constraint 4: bind UNIMATRIX_IMAGE=$IMAGE + --pull never so compose boots the VERSION
   # UNDER TEST (locally the freshly-built tag, in CI the resolve_image digest), never the
   # ghcr :latest release image.
   compose_do_up || fail "compose boot: docker compose up failed (image under test: $IMAGE)"
-  # shellcheck disable=SC2034  # read cross-file by the smoke's cleanup() trap
-  COMPOSE_UP=1   # arm the cleanup-trap teardown (docker compose down -v)
 
   local cid
   cid="$(compose_service_cid)"

--- a/product/test/infra-001/scripts/claim-floor-lib.sh
+++ b/product/test/infra-001/scripts/claim-floor-lib.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# claim-floor-lib.sh (#915/#916) — the two personal-cloud claim-floor gates, factored
+# out of docker-http-posture-smoke.sh to keep each file <=500 lines (workspace rule) and
+# to mirror cloud-cycle-lib.sh's sourced-library pattern. SOURCED by the smoke (and by
+# the pre-merge logic test) — it does NOT execute on its own; it only DEFINES functions.
+# It relies on the parent providing log(), fail(), and $SANDBOX/$IMAGE/$TMP (all in the
+# smoke's scope when these gates run, after C1's Gates 1-7). Append-only fail()/exit-1
+# contract (nan-019 ADR-001) — every new failure folds into the EXISTING fail().
+#
+# GATE 9 — client-works (#916/C15): after bundle_attach_gates, drive ONE stateless
+#   context_* tools/call (context_status) THROUGH the SHIPPED mcp-bridge.js using the
+#   Gate-6 credstore (HOME=$SANDBOX/home, projectHash READ BACK — never recomputed). This
+#   is the only green gate that proves the ATTACHED client performs a real context_* op
+#   over the pinned-TLS bundle path (the proof previously lived only in the permanently-
+#   red nan-021 parity_matrix lane). The bridge drive is wrapped in `timeout` (bounded).
+#
+# GATE 10 — compose boot (#915/C1): boot the LITERAL shipped docker-compose.yml (the
+#   operator's first command, `docker compose up`) with the VERSION UNDER TEST pinned,
+#   wait for the HTTPS listener, then a pinned-TLS /health probe on the shipped SAN/port.
+#   Scoped HONESTLY as boot+serve proof (NOT volume-mode/posture-drift — /health alone is
+#   not posture proof; Gates 1-4 own posture on the docker-run path).
+#
+# Stub seam (mirrors SMOKE_*_CMD): SMOKE_CLIENT_CALL_CMD overrides the single-call bridge
+# drive so the pre-merge logic test drives Gate-9 control flow without node/Docker. Gate
+# 10's live-only docker/curl steps are small single-purpose helpers the logic test
+# OVERRIDES in its own harness (never in this shipped file), mirroring how the C5 logic
+# test overrides _fire_observe_hooks / cycle_durability_barrier.
+
+REPO_ROOT_DEFAULT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)}"
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BRIDGE_JS="$REPO_ROOT_DEFAULT/packages/unimatrix/lib/hook-client/mcp-bridge.js"
+SINGLE_DRIVER_JS="$SCRIPTS_DIR/bridge-single-call-driver.js"
+
+# Gate 9 knobs. context_status is stateless + embed-free (won't perturb the shared-lane
+# gate-8 credstore/cycle nor eat the #767 embed-retry window). The bounded deadline
+# (constraint 1) caps a bridge hang so it cannot eat the blocking lane's job timeout.
+CLIENT_CALL_TOOL="${CLIENT_CALL_TOOL:-context_status}"
+CLIENT_CALL_DEADLINE_S="${CLIENT_CALL_DEADLINE_S:-60}"
+
+# Gate 10 shipped defaults (verified against docker-compose.yml: image service
+# `unimatrix`, SAN cloud.example, TLS port 8443). Project-scoped so a mid-gate failure
+# tears down exactly THIS run's stack (cleanup trap in the smoke).
+COMPOSE_FILE="${COMPOSE_FILE:-$REPO_ROOT_DEFAULT/docker-compose.yml}"
+COMPOSE_PROJECT="${COMPOSE_PROJECT:-uni-$$}"
+COMPOSE_SAN="${COMPOSE_SAN:-cloud.example}"
+COMPOSE_PORT="${COMPOSE_PORT:-8443}"
+COMPOSE_LISTENER_DEADLINE_S="${COMPOSE_LISTENER_DEADLINE_S:-90}"
+
+# ===========================================================================
+# GATE 9 — client-works (#916/C15)
+# ===========================================================================
+
+# Tail-dump the captured single-call bridge stderr ON FAILURE ONLY. The bridge is a
+# token-free child (NFR-06: never logs Authorization). Bounded to cap CI-log volume.
+_dump_client_err() {
+  local errf="$1"
+  log "---- mcp-bridge.js (single-call) stderr (tail, on failure) ----"
+  if [ -s "$errf" ]; then
+    tail -n 40 "$errf" | while IFS= read -r line; do log "bridge: $line"; done
+  else
+    log "bridge: (no output captured)"
+  fi
+  log "---- end mcp-bridge.js stderr ----"
+}
+
+# Drive ONE context_* tools/call through the SHIPPED bridge, bounded by `timeout`
+# (constraint 1). Stub seam: SMOKE_CLIENT_CALL_CMD overrides the drive for the logic test.
+drive_client_call() {
+  local project_hash="$1" out="$2" err="$3"
+  if [ -n "${SMOKE_CLIENT_CALL_CMD:-}" ]; then
+    # Stub seam (mirrors SMOKE_*_CMD): drive control flow without node/Docker. Bounded by
+    # `timeout` exactly as the real path is (a stub hang is a real-path hang here too).
+    # shellcheck disable=SC2086
+    HOME="$SANDBOX/home" timeout "$CLIENT_CALL_DEADLINE_S" \
+      $SMOKE_CLIENT_CALL_CMD "$project_hash" "$CLIENT_CALL_TOOL" >"$out" 2>"$err"
+  else
+    command -v node >/dev/null 2>&1 \
+      || fail "client-works: node not available — the shipped bridge cannot be driven"
+    [ -f "$BRIDGE_JS" ] \
+      || fail "client-works: shipped bridge $BRIDGE_JS not found (reuse-as-is)"
+    [ -f "$SINGLE_DRIVER_JS" ] \
+      || fail "client-works: single-call driver $SINGLE_DRIVER_JS not found"
+    # HOME=$SANDBOX/home so credstore.read finds THIS run's remote.json. `timeout` bounds
+    # a bridge hang so it cannot eat the blocking lane's job timeout (constraint 1).
+    HOME="$SANDBOX/home" timeout "$CLIENT_CALL_DEADLINE_S" \
+      node "$SINGLE_DRIVER_JS" "$project_hash" "$CLIENT_CALL_TOOL" --bridge "$BRIDGE_JS" \
+        >"$out" 2>"$err"
+  fi
+}
+
+client_works_gate() {
+  # ---- read the projectHash BACK from the Gate-6 credstore (OQ1/R-11 — never recompute) ----
+  local cred_root="$SANDBOX/home/.unimatrix" project_hash hash_count cred_file
+  [ -d "$cred_root" ] \
+    || fail "client-works: credstore root $cred_root absent — bundle attach (Gate 6) incomplete"
+  hash_count="$(find "$cred_root" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+  [ "$hash_count" = "1" ] \
+    || fail "client-works: projectHash read-back ambiguous: expected 1 dir under $cred_root, found $hash_count (init.js contract drift)"
+  project_hash="$(find "$cred_root" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)"
+  cred_file="$cred_root/$project_hash/remote.json"
+  [ -f "$cred_file" ] \
+    || fail "client-works: credstore $cred_file absent — the bridge cannot attach"
+
+  # ---- drive ONE stateless context_* op THROUGH the shipped bridge (bounded) ----
+  local CALL_OUT="$SANDBOX/client_call.json" CALL_ERR="$SANDBOX/client_call.stderr" call_rc
+  set +e
+  drive_client_call "$project_hash" "$CALL_OUT" "$CALL_ERR"
+  call_rc=$?
+  set -e
+  if [ "$call_rc" -eq 124 ]; then
+    _dump_client_err "$CALL_ERR"
+    fail "client-works: ${CLIENT_CALL_TOOL} over the bridge timed out after ${CLIENT_CALL_DEADLINE_S}s (bounded — a hang must not eat the blocking lane's job timeout)"
+  fi
+  [ "$call_rc" -eq 0 ] \
+    || { _dump_client_err "$CALL_ERR"; fail "client-works: bridge single-call driver failed (rc=$call_rc) — the attached client cannot reach the server over the pinned-TLS bundle"; }
+  grep -q '"ok": *true\|"ok":true' "$CALL_OUT" \
+    || { _dump_client_err "$CALL_ERR"; fail "client-works: ${CLIENT_CALL_TOOL} via mcp-bridge.js did not return ok — no real context_* op over the pinned-TLS bundle (#916/C15)"; }
+  log "client performed ${CLIENT_CALL_TOOL} via the SHIPPED mcp-bridge.js over the pinned-TLS bundle (projectHash $project_hash). PASS gate 9 (client-works, #916/C15)"
+}
+
+# ===========================================================================
+# GATE 10 — compose boot (#915/C1)
+# ===========================================================================
+# Live-only helpers — single-purpose so the pre-merge logic test can OVERRIDE each in its
+# OWN harness (the shipped bytes stay untouched). Their default bodies run the real
+# docker/curl commands.
+
+compose_plugin_present()   { docker compose version >/dev/null 2>&1; }
+compose_do_up()            { UNIMATRIX_IMAGE="$IMAGE" docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" up -d --pull never >/dev/null 2>&1; }
+compose_service_cid()      { docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" ps -q unimatrix 2>/dev/null; }
+compose_expected_digest()  { docker image inspect "$IMAGE" --format '{{.Id}}' 2>/dev/null; }
+compose_container_digest() { docker inspect "$1" --format '{{.Image}}' 2>/dev/null; }
+compose_listener_active()  { docker logs "$1" 2>&1 | grep -q "HTTP transport active"; }
+# Extract the served self-signed leaf from the compose data volume via a busybox sidecar
+# (the runtime image is distroless — no shell, so never `docker exec`). Volume name is
+# compose's `<project>_<volume>` for the shipped `unimatrix-data` volume.
+compose_extract_cert()     { docker run --rm -v "${COMPOSE_PROJECT}_unimatrix-data:/data:ro" busybox sh -c 'f=$(ls /data/.unimatrix/*/tls/cert.pem 2>/dev/null | head -1); [ -n "$f" ] && cat "$f"' > "$1" 2>/dev/null; }
+# Pinned TLS /health on the LITERAL shipped SAN+port. --resolve maps the shipped SAN to
+# loopback so hostname verification holds against the SAN (a bare localhost curl would
+# fail hostname verification); --cacert pins the container's leaf (constraint 3).
+compose_health_code()      { curl -sS --cacert "$1" --resolve "${COMPOSE_SAN}:${COMPOSE_PORT}:127.0.0.1" -o /dev/null -w '%{http_code}' "https://${COMPOSE_SAN}:${COMPOSE_PORT}/health" 2>/dev/null; }
+# Project-scoped teardown (`down -v`), called from the smoke's cleanup trap when the gate
+# armed COMPOSE_UP=1 — so a mid-gate failure still removes the stack + its volumes.
+compose_teardown()         { docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" down -v >/dev/null 2>&1 || true; }
+
+compose_boot_gate() {
+  # Constraint 2: compose-plugin absence is a mis-provisioned lane => HARD fail (exit 1),
+  # NEVER a self-skip. Mirrors the node-absence backstop in bundle_attach_gates.
+  compose_plugin_present \
+    || fail "compose boot: docker compose plugin absent — the operator's first command (docker compose up) cannot be exercised (mis-provisioned lane; never self-skip)"
+  [ -f "$COMPOSE_FILE" ] \
+    || fail "compose boot: compose file $COMPOSE_FILE not found — cannot exercise the shipped docker compose up"
+  [ -n "${IMAGE:-}" ] \
+    || fail "compose boot: IMAGE unset — the gate needs the version-under-test image"
+
+  # Constraint 4: bind UNIMATRIX_IMAGE=$IMAGE + --pull never so compose boots the VERSION
+  # UNDER TEST (locally the freshly-built tag, in CI the resolve_image digest), never the
+  # ghcr :latest release image.
+  compose_do_up || fail "compose boot: docker compose up failed (image under test: $IMAGE)"
+  # shellcheck disable=SC2034  # read cross-file by the smoke's cleanup() trap
+  COMPOSE_UP=1   # arm the cleanup-trap teardown (docker compose down -v)
+
+  local cid
+  cid="$(compose_service_cid)"
+  [ -n "$cid" ] \
+    || fail "compose boot: could not resolve the unimatrix service container id after up"
+
+  # Constraint 4 guard: the digest compose ACTUALLY booted MUST equal $IMAGE's digest, so
+  # a future refactor cannot silently re-introduce a :latest pull.
+  local want_digest got_digest
+  want_digest="$(compose_expected_digest || true)"
+  got_digest="$(compose_container_digest "$cid" || true)"
+  [ -n "$want_digest" ] \
+    || fail "compose boot: could not resolve the image-under-test digest ($IMAGE)"
+  [ "$want_digest" = "$got_digest" ] \
+    || fail "compose boot: booted image digest '$got_digest' != version-under-test '$IMAGE' digest '$want_digest' — compose used the wrong image (:latest regression guard, #915)"
+
+  # boot+serve proof: wait for the HTTPS listener log (the same signal Gate 1 waits on).
+  local deadline
+  deadline=$(( $(date +%s) + COMPOSE_LISTENER_DEADLINE_S ))
+  while :; do
+    compose_listener_active "$cid" && break
+    [ "$(date +%s)" -gt "$deadline" ] \
+      && fail "compose boot: HTTPS listener never became active within ${COMPOSE_LISTENER_DEADLINE_S}s"
+    sleep 2
+  done
+
+  # Constraint 3: pinned TLS /health against the LITERAL shipped defaults.
+  local cert="$TMP/compose-cert.pem" code
+  compose_extract_cert "$cert"
+  [ -s "$cert" ] \
+    || fail "compose boot: could not extract the served TLS cert from the compose data volume"
+  code="$(compose_health_code "$cert" || true)"
+  [ "$code" = "200" ] \
+    || fail "compose boot: pinned TLS /health on the shipped defaults (${COMPOSE_SAN}:${COMPOSE_PORT}) returned HTTP ${code:-none} (expected 200)"
+
+  log "docker compose up booted a serving HTTPS instance on the shipped defaults (${COMPOSE_SAN}:${COMPOSE_PORT}), pinned /health 200, booted image digest matches the version under test. PASS gate 10 (compose boot, #915/C1)"
+}

--- a/product/test/infra-001/scripts/docker-http-posture-smoke.sh
+++ b/product/test/infra-001/scripts/docker-http-posture-smoke.sh
@@ -36,6 +36,7 @@ cleanup() {
   if [ "${KEEP:-0}" != "1" ]; then
     docker rm -f "$CNAME" >/dev/null 2>&1 || true
     docker volume rm "$VOL" >/dev/null 2>&1 || true
+    [ "${COMPOSE_UP:-0}" = "1" ] && compose_teardown  # #915 Gate 10: compose down -v from trap
   fi
   [ -n "${TMP:-}" ] && rm -rf "$TMP"
   [ -n "${SANDBOX:-}" ] && rm -rf "$SANDBOX"   # nan-020: hermetic sandbox teardown
@@ -331,14 +332,13 @@ bundle_attach_gates() {
 }
 # === end nan-020 seam ======================================================
 
-# === nan-021 C2: cloud cycle gate (sourced) ===============================
-# The bridge-driven Gate 8 (cloud_cycle_gates) lives in cloud-cycle-lib.sh to
-# keep this file <=500 lines (workspace rule). Sourced here so it runs in the
-# smoke's scope (uses log/fail/store_size/vol + $SLUG/$SLUG_DIR/$TMP/$TOKEN).
-# Like release-gate-lib.sh, it only DEFINES functions on source.
+# === Sourced gate libs (<=500-line split; each only DEFINES functions on source) ===
+# cloud-cycle-lib.sh: Gate 8 cloud cycle. claim-floor-lib.sh: Gate 9 client-works (#916),
+# Gate 10 compose boot (#915), compose_teardown. Both use the smoke's log/fail + scope.
 # shellcheck source=product/test/infra-001/scripts/cloud-cycle-lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/cloud-cycle-lib.sh"
-# === end nan-021 C2 sourced seam ==========================================
+# shellcheck source=product/test/infra-001/scripts/claim-floor-lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/claim-floor-lib.sh"
 
 # Sourced-guard (#5192): when this file is SOURCED (the pre-merge gate-logic
 # test sources it to call bundle_attach_gates against stubs), stop here — do
@@ -481,6 +481,8 @@ log "per-slug store grew ($SLUG_BEFORE -> $SLUG_AFTER) and hash store unchanged 
 # bundle_attach_gates(); reuses the SAME container/volume/slug/port/cert as Gates 1–4.
 bundle_attach_gates
 
+client_works_gate  # Gate 9 (#916/C15): ONE stateless context_status THROUGH the shipped bridge
+
 # Gate 8 (nan-021 C2 cloud cycle) — runs ONLY when the pytest orchestrator wired
 # the C2 inputs (MANIFEST_PATH/RUN_TOKEN/HTTPS_VECTOR_OUT). The standalone #783
 # smoke (no nan-021 env) skips it so its contract is unchanged (append-only).
@@ -490,5 +492,7 @@ if [ -n "${MANIFEST_PATH:-}" ] && [ -n "${RUN_TOKEN:-}" ] && [ -n "${HTTPS_VECTO
 else
   log "nan-021 C2 inputs absent — skipping gate 8 (standalone #783 posture smoke)."
 fi
+
+compose_boot_gate  # Gate 10 (#915/C1): boot the shipped docker-compose.yml (version-under-test pinned)
 
 log "ALL GATES PASSED — clean image boots HTTP-on and routes the registered slug over HTTPS."

--- a/product/test/infra-001/scripts/docker-http-posture-smoke.sh
+++ b/product/test/infra-001/scripts/docker-http-posture-smoke.sh
@@ -34,7 +34,7 @@ fail() { printf '[783-smoke] FAIL: %s\n' "$*" >&2; exit 1; }
 
 cleanup() {
   if [ "${KEEP:-0}" != "1" ]; then
-    docker rm -f "$CNAME" >/dev/null 2>&1 || true
+    docker rm -f -v "$CNAME" >/dev/null 2>&1 || true  # -v reaps the container's anonymous volumes (image VOLUME /shared is unmounted => anon; #915/#916 leak fix)
     docker volume rm "$VOL" >/dev/null 2>&1 || true
     [ "${COMPOSE_UP:-0}" = "1" ] && compose_teardown  # #915 Gate 10: compose down -v from trap
   fi

--- a/product/test/infra-001/scripts/multi-tenant-isolation-smoke.sh
+++ b/product/test/infra-001/scripts/multi-tenant-isolation-smoke.sh
@@ -78,7 +78,7 @@ infra_fail() { printf '[%s] INFRA: %s\n' "$TAG" "$*" >&2; exit 2; }   # INFRA (d
 
 cleanup() {
   if [ "${KEEP:-0}" != "1" ]; then
-    docker rm -f "$CNAME" >/dev/null 2>&1 || true
+    docker rm -f -v "$CNAME" >/dev/null 2>&1 || true
     docker volume rm "$VOL" >/dev/null 2>&1 || true
   fi
   [ -n "${TMP:-}" ] && rm -rf "$TMP"

--- a/product/test/infra-001/scripts/release-gate-claim-floor-logic-test.sh
+++ b/product/test/infra-001/scripts/release-gate-claim-floor-logic-test.sh
@@ -150,6 +150,49 @@ test_gate9_node_absent_hard_fails() {
 }
 test_gate9_node_absent_hard_fails
 
+# S4: on a Gate-9 timeout the bounded drive must leave NO orphaned process. The stub spawns
+# a background child (its PID recorded OUTSIDE $SANDBOX so the smoke's cleanup() rm -rf can't
+# race it), then hangs past the deadline. `setsid -w timeout -k` group-kills the stub AND its
+# child; we assert rc=1 + the bounded-timeout message (rc=124->fail() intact) AND that the
+# recorded child PID is gone (no orphan).
+test_gate9_timeout_no_orphan() {
+  local sb pidf stub out rc child
+  sb="$(mktemp -d)"
+  pidf="$(mktemp -u)"   # outside $sb: cleanup() rm -rf "$SANDBOX" must not delete it
+  mkdir -p "$sb/home/.unimatrix/deadbeefcafe1234"
+  printf '{"observe_url":"https://localhost:18443/v1/arch-research/observe","token":"t","fingerprint":"sha256:x"}\n' \
+    > "$sb/home/.unimatrix/deadbeefcafe1234/remote.json"
+  stub="$sb/orphan-stub.sh"
+  cat > "$stub" <<'STUBEOF'
+#!/usr/bin/env bash
+# a would-be orphan: a background child that outlives the direct child on a naive kill.
+sleep 30 &
+echo $! > "$PIDF"
+sleep 30
+STUBEOF
+  chmod +x "$stub"
+  out="$(
+    env SANDBOX="$sb" PIDF="$pidf" SMOKE_CLIENT_CALL_CMD="bash $stub" \
+        CLIENT_CALL_DEADLINE_S=1 CLIENT_CALL_KILL_GRACE_S=2 \
+      bash -c 'set -uo pipefail; source "'"$SMOKE"'" >/dev/null 2>&1 || true; compose_teardown(){ :; }; client_works_gate' 2>&1
+  )"
+  rc=$?
+  sleep 1   # let the group TERM settle
+  child="$(cat "$pidf" 2>/dev/null)"
+  if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -qF "timed out after 1s (bounded"; then
+    if [ -n "$child" ] && kill -0 "$child" 2>/dev/null; then
+      kill -9 "$child" 2>/dev/null || true
+      oops "test_gate9_timeout_no_orphan" "background child $child SURVIVED the Gate-9 timeout (orphan)"
+    else
+      pass "test_gate9_timeout_no_orphan (process-group kill left no orphaned child; rc=124->fail intact)"
+    fi
+  else
+    oops "test_gate9_timeout_no_orphan" "expected rc=1 + bounded-timeout message; rc=$rc out=$out"
+  fi
+  rm -rf "$sb"; rm -f "$pidf"
+}
+test_gate9_timeout_no_orphan
+
 # =============================================================================
 # Part B — Gate 10 (compose boot) control flow, live-only helpers OVERRIDDEN in-harness.
 # =============================================================================
@@ -236,20 +279,81 @@ run_gate10_case test_gate10_cert_absent_red 1 \
 run_gate10_case test_gate10_health_non200_red 1 \
   "pinned TLS /health on the shipped defaults" -- OV_HEALTH=503
 
+# S1: teardown must FIRE on a partial/failed `up`. With COMPOSE_UP armed BEFORE compose_do_up,
+# a nonzero up still leaves the trap flag set, so the smoke's cleanup() runs compose_teardown
+# (`down -v`) — no orphaned containers/volumes. The teardown marker lives OUTSIDE $sb so the
+# cleanup() rm -rf "$SANDBOX" can't race it. Fails on the pre-fix ordering (flag armed AFTER up
+# => trap skips teardown on a failed up).
+test_gate10_teardown_fires_on_failed_up() {
+  local sb marker out rc
+  sb="$(mktemp -d)"
+  marker="$(mktemp -u)"   # outside $sb: survives cleanup() rm -rf "$SANDBOX"
+  out="$(
+    env IMAGE="unimatrix:claim-floor-test" TMP="$sb" SANDBOX="$sb" \
+        OV_UP_RC=1 TEARDOWN_MARKER="$marker" \
+      bash -c '
+        set -uo pipefail
+        source "'"$SMOKE"'" >/dev/null 2>&1 || true
+        compose_plugin_present() { return 0; }
+        compose_do_up()          { return "${OV_UP_RC:-1}"; }
+        compose_teardown()       { printf fired > "$TEARDOWN_MARKER"; }
+        compose_boot_gate
+      ' 2>&1
+  )"
+  rc=$?
+  if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -qF "docker compose up failed" && [ -f "$marker" ]; then
+    pass "test_gate10_teardown_fires_on_failed_up (COMPOSE_UP armed before up => trap tears down on a failed up)"
+  else
+    oops "test_gate10_teardown_fires_on_failed_up" \
+      "rc=$rc marker=$( [ -f "$marker" ] && echo present || echo ABSENT ) out=$out"
+  fi
+  rm -rf "$sb"; rm -f "$marker"
+}
+test_gate10_teardown_fires_on_failed_up
+
 # =============================================================================
 # Part C — static (source/YAML grep) assertions binding the four blocking constraints.
 # =============================================================================
 echo "== Part C: four blocking constraints present in the shipped bytes (static) =="
 
 test_c1_bridge_drive_bounded_by_timeout() {
-  # Constraint 1: the single-call bridge drive is wrapped in `timeout $CLIENT_CALL_DEADLINE_S`.
-  if grep -q 'timeout "\$CLIENT_CALL_DEADLINE_S"' "$CLAIM_LIB"; then
+  # Constraint 1 (intact after S4): the single-call bridge drive is still bounded by the
+  # deadline `timeout ... "$CLIENT_CALL_DEADLINE_S"` — now hardened to a process-group form.
+  if grep -q 'timeout -k "\$CLIENT_CALL_KILL_GRACE_S" "\$CLIENT_CALL_DEADLINE_S"' "$CLAIM_LIB"; then
     pass "test_c1_bridge_drive_bounded_by_timeout"
   else
-    oops "test_c1_bridge_drive_bounded_by_timeout" "bridge drive not wrapped in timeout \$CLIENT_CALL_DEADLINE_S"
+    oops "test_c1_bridge_drive_bounded_by_timeout" "bridge drive not bounded by timeout \$CLIENT_CALL_DEADLINE_S"
   fi
 }
 test_c1_bridge_drive_bounded_by_timeout
+
+test_s4_drive_process_group_kill() {
+  # S4: the bounded drive runs in its OWN process group (`setsid -w timeout -k <grace>`) so
+  # a Gate-9 timeout TERMs/KILLs the driver AND the spawned bridge child — no orphan. Both
+  # drive branches (stub + real) must use the process-group form.
+  local n
+  n="$(grep -c 'setsid -w timeout -k "\$CLIENT_CALL_KILL_GRACE_S" "\$CLIENT_CALL_DEADLINE_S"' "$CLAIM_LIB")"
+  if [ "$n" -eq 2 ]; then
+    pass "test_s4_drive_process_group_kill (both drive branches use setsid process-group kill + kill-after)"
+  else
+    oops "test_s4_drive_process_group_kill" "expected 2 setsid -w timeout -k drive sites, found $n"
+  fi
+}
+test_s4_drive_process_group_kill
+
+test_s2_gate_publishes_loopback_only() {
+  # S2: the GATE binds its published port to loopback (compose_do_up sets
+  # UNIMATRIX_HOST_BIND=127.0.0.1:) AND the shipped compose exposes that as an interpolation
+  # whose EMPTY default preserves the operator-facing 0.0.0.0 default (gate-scoped, no
+  # operator-default change).
+  if grep -q 'UNIMATRIX_HOST_BIND="127.0.0.1:" docker compose' "$CLAIM_LIB" \
+     && grep -qF '${UNIMATRIX_HOST_BIND:-}8443:8443' "$COMPOSE_YML"; then
+    pass "test_s2_gate_publishes_loopback_only"
+  else
+    oops "test_s2_gate_publishes_loopback_only" "gate does not loopback-bind via UNIMATRIX_HOST_BIND, or compose lost the empty-default interpolation"
+  fi
+}
+test_s2_gate_publishes_loopback_only
 
 test_c2_compose_plugin_absent_fails_never_skips() {
   # Constraint 2: plugin-absence calls fail() ("never self-skip") — NOT exit 3 / a skip.
@@ -278,7 +382,7 @@ test_c3_health_pins_shipped_san_via_resolve
 test_c4_compose_binds_image_under_test_pull_never() {
   # Constraint 4: compose up binds UNIMATRIX_IMAGE=$IMAGE + --pull never, and asserts the
   # booted digest == $IMAGE's digest; the compose file keeps a back-compat interpolation.
-  if grep -q 'UNIMATRIX_IMAGE="\$IMAGE" docker compose' "$CLAIM_LIB" \
+  if grep -q 'UNIMATRIX_IMAGE="\$IMAGE" .*docker compose' "$CLAIM_LIB" \
      && grep -q -- '--pull never' "$CLAIM_LIB" \
      && grep -q 'want_digest="\$(compose_expected_digest' "$CLAIM_LIB" \
      && grep -q 'docker inspect "\$1" --format' "$CLAIM_LIB" \

--- a/product/test/infra-001/scripts/release-gate-claim-floor-logic-test.sh
+++ b/product/test/infra-001/scripts/release-gate-claim-floor-logic-test.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# release-gate-claim-floor-logic-test.sh — pre-merge HARD gate for the #915/#916 claim-
+# floor gates: Gate 9 (client-works, #916/C15) + Gate 10 (compose boot, #915/C1).
+# Companion to release-gate-bundle-logic-test.sh (Gates 5–7) and
+# release-gate-cloud-cycle-logic-test.sh (Gate 8). It `source`s the SHIPPED
+# docker-http-posture-smoke.sh (whose sourced-guard suppresses the Docker preflight +
+# Gates 1–4) to get the REAL client_works_gate / compose_boot_gate, then drives them
+# off-Docker: Gate 9 via the SMOKE_CLIENT_CALL_CMD stub seam; Gate 10 by OVERRIDING its
+# live-only docker/curl helpers IN THIS HARNESS (never in the shipped file), mirroring how
+# the C5 logic test overrides _fire_observe_hooks / cycle_durability_barrier. A paraphrased
+# copy of the gate would test nothing (R-01); sourcing the shipped bytes is the SoT (#5192).
+#
+# Fully local + deterministic: no Docker, no node, no network, no tag push.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SMOKE="${SCRIPT_DIR}/docker-http-posture-smoke.sh"
+CLAIM_LIB="${SCRIPT_DIR}/claim-floor-lib.sh"
+COMPOSE_YML="$(cd "$SCRIPT_DIR/../../../.." && pwd)/docker-compose.yml"
+
+PASS=0
+FAIL=0
+pass() { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+oops() { FAIL=$((FAIL+1)); printf '  FAIL %s\n' "$1"; [ -n "${2:-}" ] && printf '       %s\n' "$2"; }
+
+# ---- source the SHIPPED smoke bytes (single source of truth) -----------------
+# The sourced-guard stops before the Docker preflight / Gates 1–4, so sourcing defines
+# client_works_gate() + compose_boot_gate() + the seam helpers WITHOUT running Docker.
+set +e
+# shellcheck source=docker-http-posture-smoke.sh
+source "$SMOKE"
+set +e; set +u 2>/dev/null; set -uo pipefail
+if ! declare -F client_works_gate >/dev/null || ! declare -F compose_boot_gate >/dev/null; then
+  echo "FATAL: client_works_gate/compose_boot_gate not found after sourcing $SMOKE" >&2
+  exit 1
+fi
+
+# =============================================================================
+# Part A — Gate 9 (client-works) truth table via the SMOKE_CLIENT_CALL_CMD stub seam.
+# =============================================================================
+# The stub emits the single-call driver envelope ({ok,tool,error}) client_works_gate
+# greps. STUB_CALL_OK / STUB_CALL_RC / STUB_CALL_SLEEP drive the ok:false / rc / timeout
+# rows. It is invoked exactly as the real driver is: under `timeout $CLIENT_CALL_DEADLINE_S`.
+make_call_stub() {
+  cat > "$1" <<'STUBEOF'
+#!/usr/bin/env bash
+# stub bridge single-call drive.
+[ -n "${STUB_CALL_SLEEP:-}" ] && sleep "$STUB_CALL_SLEEP"
+printf '{"ok": %s, "tool": "context_status", "error": null}\n' "${STUB_CALL_OK:-true}"
+exit "${STUB_CALL_RC:-0}"
+STUBEOF
+  chmod +x "$1"
+}
+
+# run_gate9_case <name> <want_rc> <want_sub> -- <env assignments...>
+run_gate9_case() {
+  local name="$1" want_rc="$2" want_sub="$3"; shift 3
+  [ "${1:-}" = "--" ] && shift
+  local sb out got_rc stub
+  sb="$(mktemp -d)"
+  mkdir -p "$sb/home/.unimatrix/deadbeefcafe1234"
+  printf '{"observe_url":"https://localhost:18443/v1/arch-research/observe","token":"t","fingerprint":"sha256:x"}\n' \
+    > "$sb/home/.unimatrix/deadbeefcafe1234/remote.json"
+  stub="$sb/call-stub.sh"; make_call_stub "$stub"
+  out="$(
+    env SANDBOX="$sb" SMOKE_CLIENT_CALL_CMD="bash $stub" \
+      "$@" \
+      bash -c '
+        set -uo pipefail
+        source "'"$SMOKE"'" >/dev/null 2>&1 || true
+        compose_teardown() { :; }
+        client_works_gate
+      ' 2>&1
+  )"
+  got_rc=$?
+  rm -rf "$sb"
+  if [ "$got_rc" -ne "$want_rc" ]; then
+    oops "$name (rc)" "expected rc=$want_rc got=$got_rc; out: $out"; return
+  fi
+  if [ -n "$want_sub" ] && ! printf '%s' "$out" | grep -qF "$want_sub"; then
+    oops "$name (substr)" "expected '$want_sub' in: $out"; return
+  fi
+  pass "$name"
+}
+
+echo "== Part A: Gate 9 client-works truth table (SMOKE_CLIENT_CALL_CMD stub) =="
+
+# Happy path: driver ok:true, rc 0 => the ONLY green.
+run_gate9_case test_gate9_happy_path_green 0 "PASS gate 9 (client-works, #916/C15)" --
+
+# Driver rc nonzero => bridge single-call failed (client cannot reach the server).
+run_gate9_case test_gate9_drive_rc_nonzero_red 1 \
+  "bridge single-call driver failed (rc=5)" -- STUB_CALL_RC=5
+
+# rc 0 but ok:false => no real context_* op landed.
+run_gate9_case test_gate9_not_ok_red 1 \
+  "did not return ok — no real context_* op over the pinned-TLS bundle" -- STUB_CALL_OK=false
+
+# Constraint 1: a hang is bounded by `timeout` (rc 124) => a distinct timeout failure,
+# NEVER an unbounded wait that eats the blocking lane's job timeout.
+run_gate9_case test_gate9_bounded_timeout_red 1 \
+  "timed out after 1s (bounded" -- CLIENT_CALL_DEADLINE_S=1 STUB_CALL_SLEEP=3
+
+# Missing credstore read-back => RED precondition (Gate-6 -> Gate-9 boundary).
+test_gate9_missing_credstore_red() {
+  local sb out rc stub
+  sb="$(mktemp -d)"; mkdir -p "$sb/home/.unimatrix"   # NO hash dir => read-back fails
+  stub="$sb/s.sh"; make_call_stub "$stub"
+  out="$(
+    env SANDBOX="$sb" SMOKE_CLIENT_CALL_CMD="bash $stub" \
+      bash -c 'set -uo pipefail; source "'"$SMOKE"'" >/dev/null 2>&1 || true; compose_teardown(){ :; }; client_works_gate' 2>&1
+  )"
+  rc=$?
+  rm -rf "$sb"
+  if [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -qiE 'read-back ambiguous|credstore root .* absent'; then
+    pass "test_gate9_missing_credstore_red (read-back precondition enforced)"
+  else
+    oops "test_gate9_missing_credstore_red" "expected rc=1 + read-back diagnostic; rc=$rc out=$out"
+  fi
+}
+test_gate9_missing_credstore_red
+
+# node-absent on the REAL path (SMOKE_CLIENT_CALL_CMD unset) => HARD fail exit 1, NOT a
+# self-skip (mirrors the bundle-gate node-absence backstop).
+test_gate9_node_absent_hard_fails() {
+  local sb out rc
+  sb="$(mktemp -d)"
+  mkdir -p "$sb/home/.unimatrix/deadbeefcafe1234" "$sb/bin"
+  printf '{"observe_url":"x","token":"t","fingerprint":"sha256:x"}\n' > "$sb/home/.unimatrix/deadbeefcafe1234/remote.json"
+  out="$(
+    env -i PATH="$sb/bin:/usr/bin:/bin" SANDBOX="$sb" \
+      bash -c '
+        set -uo pipefail
+        if command -v node >/dev/null 2>&1; then echo "PRECOND-FAIL: node present"; exit 99; fi
+        source "'"$SMOKE"'" >/dev/null 2>&1 || true
+        compose_teardown() { :; }
+        client_works_gate
+      ' 2>&1
+  )"
+  rc=$?
+  rm -rf "$sb"
+  if [ "$rc" -eq 99 ]; then
+    oops "test_gate9_node_absent_hard_fails" "could not construct node-absent PATH (node leaked in)"
+  elif [ "$rc" -eq 1 ] && printf '%s' "$out" | grep -qF "node not available"; then
+    pass "test_gate9_node_absent_hard_fails (exit 1, distinct message, no self-skip)"
+  else
+    oops "test_gate9_node_absent_hard_fails" "expected rc=1 + node-absent message; rc=$rc out=$out"
+  fi
+}
+test_gate9_node_absent_hard_fails
+
+# =============================================================================
+# Part B — Gate 10 (compose boot) control flow, live-only helpers OVERRIDDEN in-harness.
+# =============================================================================
+# The docker/curl helpers (compose_plugin_present/do_up/service_cid/expected_digest/
+# container_digest/listener_active/extract_cert/health_code) are re-defined in the inner
+# subshell AFTER sourcing (never in the shipped file) so the SHIPPED compose_boot_gate
+# control flow — plugin-absence hard-fail, digest guard, listener wait, pinned /health —
+# runs off-Docker. OV_* env vars drive each override.
+#
+# run_gate10_case <name> <want_rc> <want_sub> -- <env assignments...>
+run_gate10_case() {
+  local name="$1" want_rc="$2" want_sub="$3"; shift 3
+  [ "${1:-}" = "--" ] && shift
+  local sb out got_rc
+  sb="$(mktemp -d)"
+  # SANDBOX is set so the sourced smoke's EXIT trap (cleanup) ends on a 0-status command;
+  # compose_boot_gate itself never reads SANDBOX (it uses only IMAGE/TMP).
+  out="$(
+    env IMAGE="unimatrix:claim-floor-test" TMP="$sb" SANDBOX="$sb" COMPOSE_LISTENER_DEADLINE_S=6 \
+      "$@" \
+      bash -c '
+        set -uo pipefail
+        source "'"$SMOKE"'" >/dev/null 2>&1 || true
+        compose_plugin_present()   { return "${OV_PLUGIN_RC:-0}"; }
+        compose_do_up()            { return "${OV_UP_RC:-0}"; }
+        compose_service_cid()      { printf "%s" "${OV_CID-fake-cid}"; }
+        compose_expected_digest()  { printf "%s" "${OV_WANT_DIGEST:-sha256:aaa}"; }
+        compose_container_digest() { printf "%s" "${OV_GOT_DIGEST:-sha256:aaa}"; }
+        compose_listener_active()  { return "${OV_LISTENER_RC:-0}"; }
+        compose_extract_cert()     { if [ -n "${OV_CERT_EMPTY:-}" ]; then : > "$1"; else printf certdata > "$1"; fi; }
+        compose_health_code()      { printf "%s" "${OV_HEALTH:-200}"; }
+        compose_teardown()         { :; }
+        compose_boot_gate
+      ' 2>&1
+  )"
+  got_rc=$?
+  rm -rf "$sb"
+  if [ "$got_rc" -ne "$want_rc" ]; then
+    oops "$name (rc)" "expected rc=$want_rc got=$got_rc; out: $out"; return
+  fi
+  if [ -n "$want_sub" ] && ! printf '%s' "$out" | grep -qF "$want_sub"; then
+    oops "$name (substr)" "expected '$want_sub' in: $out"; return
+  fi
+  pass "$name"
+}
+
+echo "== Part B: Gate 10 compose-boot control flow (helpers overridden in-harness) =="
+
+# Happy path: plugin present, up ok, digests match, listener active, /health 200.
+run_gate10_case test_gate10_happy_path_green 0 "PASS gate 10 (compose boot, #915/C1)" --
+
+# Constraint 2 (THE critical row): compose-plugin absent => HARD fail, NEVER self-skip.
+run_gate10_case test_gate10_plugin_absent_hard_fails 1 \
+  "docker compose plugin absent" -- OV_PLUGIN_RC=1
+run_gate10_case test_gate10_plugin_absent_never_self_skip 1 \
+  "never self-skip" -- OV_PLUGIN_RC=1
+
+# IMAGE unset => the version-under-test cannot be pinned => RED (constraint 4 precondition).
+run_gate10_case test_gate10_image_unset_red 1 \
+  "IMAGE unset" -- OV_PLUGIN_RC=0 IMAGE=
+
+# docker compose up fails => RED.
+run_gate10_case test_gate10_up_fails_red 1 \
+  "docker compose up failed" -- OV_UP_RC=1
+
+# Empty service container id after up => RED.
+run_gate10_case test_gate10_no_cid_red 1 \
+  "could not resolve the unimatrix service container id" -- OV_CID=
+
+# Constraint 4 guard: booted-image digest != version-under-test digest => RED
+# (:latest regression guard — a future refactor can't silently re-introduce a :latest pull).
+run_gate10_case test_gate10_digest_mismatch_red 1 \
+  ":latest regression guard" -- OV_WANT_DIGEST=sha256:aaa OV_GOT_DIGEST=sha256:bbb
+
+# Listener never active within deadline => RED (boot+serve proof).
+run_gate10_case test_gate10_listener_timeout_red 1 \
+  "HTTPS listener never became active" -- OV_LISTENER_RC=1 COMPOSE_LISTENER_DEADLINE_S=0
+
+# Cert not extractable from the compose data volume => RED (can't pin TLS).
+run_gate10_case test_gate10_cert_absent_red 1 \
+  "could not extract the served TLS cert" -- OV_CERT_EMPTY=1
+
+# Constraint 3: pinned TLS /health non-200 => RED.
+run_gate10_case test_gate10_health_non200_red 1 \
+  "pinned TLS /health on the shipped defaults" -- OV_HEALTH=503
+
+# =============================================================================
+# Part C — static (source/YAML grep) assertions binding the four blocking constraints.
+# =============================================================================
+echo "== Part C: four blocking constraints present in the shipped bytes (static) =="
+
+test_c1_bridge_drive_bounded_by_timeout() {
+  # Constraint 1: the single-call bridge drive is wrapped in `timeout $CLIENT_CALL_DEADLINE_S`.
+  if grep -q 'timeout "\$CLIENT_CALL_DEADLINE_S"' "$CLAIM_LIB"; then
+    pass "test_c1_bridge_drive_bounded_by_timeout"
+  else
+    oops "test_c1_bridge_drive_bounded_by_timeout" "bridge drive not wrapped in timeout \$CLIENT_CALL_DEADLINE_S"
+  fi
+}
+test_c1_bridge_drive_bounded_by_timeout
+
+test_c2_compose_plugin_absent_fails_never_skips() {
+  # Constraint 2: plugin-absence calls fail() ("never self-skip") — NOT exit 3 / a skip.
+  if grep -q 'compose_plugin_present \\' "$CLAIM_LIB" \
+     && grep -q 'never self-skip' "$CLAIM_LIB" \
+     && ! grep -q 'exit 3' "$CLAIM_LIB"; then
+    pass "test_c2_compose_plugin_absent_fails_never_skips"
+  else
+    oops "test_c2_compose_plugin_absent_fails_never_skips" "plugin-absence does not hard-fail via fail() (or introduces a skip)"
+  fi
+}
+test_c2_compose_plugin_absent_fails_never_skips
+
+test_c3_health_pins_shipped_san_via_resolve() {
+  # Constraint 3: pinned /health uses --resolve on the shipped SAN:port (cloud.example:8443).
+  if grep -q -- '--resolve "\${COMPOSE_SAN}:\${COMPOSE_PORT}:127.0.0.1"' "$CLAIM_LIB" \
+     && grep -q 'COMPOSE_SAN:-cloud.example' "$CLAIM_LIB" \
+     && grep -q 'COMPOSE_PORT:-8443' "$CLAIM_LIB"; then
+    pass "test_c3_health_pins_shipped_san_via_resolve"
+  else
+    oops "test_c3_health_pins_shipped_san_via_resolve" "pinned /health does not --resolve the shipped SAN cloud.example:8443"
+  fi
+}
+test_c3_health_pins_shipped_san_via_resolve
+
+test_c4_compose_binds_image_under_test_pull_never() {
+  # Constraint 4: compose up binds UNIMATRIX_IMAGE=$IMAGE + --pull never, and asserts the
+  # booted digest == $IMAGE's digest; the compose file keeps a back-compat interpolation.
+  if grep -q 'UNIMATRIX_IMAGE="\$IMAGE" docker compose' "$CLAIM_LIB" \
+     && grep -q -- '--pull never' "$CLAIM_LIB" \
+     && grep -q 'want_digest="\$(compose_expected_digest' "$CLAIM_LIB" \
+     && grep -q 'docker inspect "\$1" --format' "$CLAIM_LIB" \
+     && grep -qF '${UNIMATRIX_IMAGE:-ghcr.io/dug-21/unimatrix:latest}' "$COMPOSE_YML"; then
+    pass "test_c4_compose_binds_image_under_test_pull_never"
+  else
+    oops "test_c4_compose_binds_image_under_test_pull_never" "compose gate does not pin \$IMAGE with --pull never + digest assertion, or compose file lost the interpolation"
+  fi
+}
+test_c4_compose_binds_image_under_test_pull_never
+
+test_gates_wired_append_only_before_marker() {
+  # Both new gates are called after bundle_attach_gates and before the single terminal marker.
+  local ba c9 c10 marker
+  ba="$(grep -n '^bundle_attach_gates$' "$SMOKE" | tail -1 | cut -d: -f1)"
+  c9="$(grep -n '^client_works_gate' "$SMOKE" | tail -1 | cut -d: -f1)"
+  c10="$(grep -n '^compose_boot_gate' "$SMOKE" | tail -1 | cut -d: -f1)"
+  marker="$(grep -n 'log "ALL GATES PASSED' "$SMOKE" | tail -1 | cut -d: -f1)"
+  if [ -n "$ba" ] && [ -n "$c9" ] && [ -n "$c10" ] && [ -n "$marker" ] \
+     && [ "$ba" -lt "$c9" ] && [ "$c9" -lt "$marker" ] && [ "$c10" -lt "$marker" ]; then
+    pass "test_gates_wired_append_only_before_marker (ba=$ba c9=$c9 c10=$c10 marker=$marker)"
+  else
+    oops "test_gates_wired_append_only_before_marker" "ba=$ba c9=$c9 c10=$c10 marker=$marker (not append-only before the marker)"
+  fi
+}
+test_gates_wired_append_only_before_marker
+
+test_compose_teardown_from_trap() {
+  # Teardown is project-scoped `down -v` invoked from cleanup() (the trap), not inline.
+  if grep -q 'compose_teardown' "$SMOKE" \
+     && grep -q 'docker compose -p "\$COMPOSE_PROJECT" -f "\$COMPOSE_FILE" down -v' "$CLAIM_LIB"; then
+    pass "test_compose_teardown_from_trap"
+  else
+    oops "test_compose_teardown_from_trap" "compose teardown is not a project-scoped down -v called from the trap"
+  fi
+}
+test_compose_teardown_from_trap
+
+echo
+echo "release-gate-claim-floor-logic-test: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/product/test/infra-001/scripts/release-gate-claim-floor-logic-test.sh
+++ b/product/test/infra-001/scripts/release-gate-claim-floor-logic-test.sh
@@ -421,6 +421,18 @@ test_compose_teardown_from_trap() {
 }
 test_compose_teardown_from_trap
 
+test_cleanup_container_removal_reaps_anon_volumes() {
+  # #915/#916 leak fix: the cleanup() container removal must carry -v so the runtime image's
+  # unmounted VOLUME (/shared, anonymous each run) is reaped on removal — WITHOUT -v it orphans
+  # one anonymous volume per run (unbounded disk growth). Static grep over the shipped smoke.
+  if grep -qE 'docker rm -f -v "\$CNAME"' "$SMOKE"; then
+    pass "test_cleanup_container_removal_reaps_anon_volumes (docker rm -f -v \$CNAME reaps the anon /shared volume)"
+  else
+    oops "test_cleanup_container_removal_reaps_anon_volumes" "cleanup() docker rm is missing -v => orphans the anonymous /shared volume each run (#915/#916 leak)"
+  fi
+}
+test_cleanup_container_removal_reaps_anon_volumes
+
 echo
 echo "release-gate-claim-floor-logic-test: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]

--- a/product/test/infra-001/scripts/release-gate-isolation-logic-test.sh
+++ b/product/test/infra-001/scripts/release-gate-isolation-logic-test.sh
@@ -487,6 +487,20 @@ echo "== (c) #859 nonce is construction-safe: default path + adversarial battery
 . "${SCRIPT_DIR}/fixtures/isolation-nonce-logic-cases.sh"
 run_nonce_safety_cases
 
+echo "== #915/#916 cleanup reaps the anon /shared volume (docker rm carries -v) =="
+test_cleanup_container_removal_reaps_anon_volumes() {
+  # The cleanup() container removal must carry -v so the runtime image's unmounted
+  # VOLUME (/shared, anonymous each run since boot mounts only /data) is reaped on
+  # removal — WITHOUT -v it orphans one anonymous volume per run (unbounded disk
+  # growth). Static grep over the shipped smoke (mirrors the claim-floor logic test).
+  if grep -qE 'docker rm -f -v "\$CNAME"' "$GATE"; then
+    pass "test_cleanup_container_removal_reaps_anon_volumes (docker rm -f -v \$CNAME reaps the anon /shared volume)"
+  else
+    oops "test_cleanup_container_removal_reaps_anon_volumes" "cleanup() docker rm is missing -v => orphans the anonymous /shared volume each run (#915/#916 leak)"
+  fi
+}
+test_cleanup_container_removal_reaps_anon_volumes
+
 echo
 echo "release-gate-isolation-logic-test: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Closes #915 (C1 personal-cloud claim floor) and #916 (C15 personal-cloud claim floor).

## Root cause
Both floors were **attestation gaps, not defects** — the container-cloud HTTPS path works, but:
- the only green client-carried `context_*` proof lived in a permanently-red, non-blocking lane (`test_https_uds_parity_matrix`, deadlocked by the D5 measurability limit → #837 C0-flip);
- nothing anywhere ran `docker compose up` (the operator's first command — the #5248 drift class);
- the runbook verify step was `curl /health` only (proves the server is up, not that a client works).

## Fix — one smoke, two appended gates
Rides the already-blocking `smoke-amd64/arm64` release lanes (nan-020 ADR-001 append-only exit-1 contract); no CI wiring changes.
- **Gate 9 `client_works_gate` (#916/C15):** drives a real `context_status` through the **shipped** `mcp-bridge.js` over the pinned-TLS bundle, using the Gate-6 credstore. First green *blocking* client-carried `context_*` proof.
- **Gate 10 `compose_boot_gate` (#915/C1):** `docker compose up` on the literal shipped defaults → pinned TLS `/health` → `down -v`.

### Four blocking constraints (all implemented + validated in the diff)
1. Gate-9 bridge drive wrapped in `timeout` (rc=124 → `fail()`).
2. Gate-10 compose-plugin absent → `fail()` (exit 1), never self-skip.
3. Gate-10 curl pinned `--resolve cloud.example:8443:127.0.0.1 --cacert` (tests the shipped SAN).
4. Gate-10 binds `UNIMATRIX_IMAGE=$IMAGE --pull never` and asserts booted-image digest == `$IMAGE` — **tests the version under test, never ghcr `:latest`**.

## Files
- new `product/test/infra-001/scripts/claim-floor-lib.sh` (Gates 9+10 + teardown)
- new `product/test/infra-001/scripts/bridge-single-call-driver.js` (one `context_status` via shipped bridge)
- new `product/test/infra-001/scripts/release-gate-claim-floor-logic-test.sh` (22 off-Docker stub-seam cases)
- mod `docker-http-posture-smoke.sh` (source lib, extend cleanup, call Gates 9+10)
- mod `docker-compose.yml` (`image:` → back-compat `${UNIMATRIX_IMAGE:-…:latest}`)
- mod `docs/client-setup.md` (client-works verify step)

Out of scope / untouched: `mcp-bridge.js`, `packages/unimatrix/**`, `harness/parity_outcome.py`, `harness/parity_matrix_support.py` (#837).

## Verification
- Gate: Bug Fix Validation **PASS** (7/7, from artifacts).
- Tester (foreground): new logic test **22/22**; sibling logic tests green; **Gates 1-10 end-to-end PASS on a real Docker build from HEAD** (Gate 9 real bridge path + Gate 10 compose boot with digest match); `cargo test`/`clippy` clean; `pytest -m smoke` **32 passed**; zero new shellcheck codes.

## Follow-up (deferred, non-blocking)
The C1 (#5527) / C15 (#5570) `delivery:` tag flips are evidence-gated on the next **green release tag** and will be done post-tag/at retro — noted on both issues so the claim isn't stranded un-flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)