### PR TITLE
fix: waive documented D5 precompact exception in nan-021 parity gate (#893)

### DIFF
--- a/product/features/bugfix-893/agents/893-agent-1-fix-report.md
+++ b/product/features/bugfix-893/agents/893-agent-1-fix-report.md
@@ -1,0 +1,84 @@
+# Agent Report: 893-agent-1-fix (bugfix-893 implementer)
+
+## Task
+Wire the previously-unwired `blocks_c0_proof` documented-exception escape valve into the
+nan-021/nan-022 parity release-gate disposition (GH#893, Option A + B1 + C1). Test-only
+Python in `product/test/infra-001`; no production-code diff (NFR-1/NFR-2/AC-11).
+
+## Root cause (confirmed)
+`assert_rollup` raised on ANY INFRA row and never consulted `blocks_c0_proof` /
+`documented_exceptions`; `rollup`'s docstring claimed a flag-aware GREEN no code
+implemented; `documented_exceptions` was derived by a fragile `"MEASURABILITY" in detail`
+string sniff. The seam test stopped before `assert_rollup`, so "documented gap → red job"
+shipped untested.
+
+## Files modified
+- `product/test/infra-001/harness/parity_outcome.py`
+  - `DimensionResult`: added structural `documented_exception: bool = False`.
+  - `_classify` branch 1b (D5 measurable=False): sets `documented_exception=True` — the
+    ONLY setter (not spoofable by a comparator).
+  - Added `gate_disposition(results) -> (verdict, exit_code, waived)` + `_is_waivable_infra`
+    — the single-source job disposition (ADR-009, Unimatrix #5648). Waived iff ≥1 INFRA,
+    zero PARITY_FAIL, and every INFRA row is `documented_exception AND NOT blocks_c0_proof`
+    (keyed on the flag, never the id "precompact"; orphan id → blocking).
+  - `rollup`: docstring corrected to describe actual (blocks-blind, never-rounded-up)
+    behavior; **logic unchanged** — artifact stays verdict:ERROR / exit 7.
+- `product/test/infra-001/harness/parity_matrix_support.py`
+  - `evidence_table`: `documented_exceptions` now sourced from the STRUCTURAL flag
+    (`r.documented_exception`), not the string sniff. Added self-describing `waived` +
+    `gate_disposition` fields from the single helper (design-review B1). Honest
+    `verdict`/`exit_code` unchanged.
+  - `assert_rollup`: consumes `gate_disposition`; a documented-exception-only run is WAIVED
+    (returns without raising, prints the table + documented details to the job log) while
+    the emitted table still carries verdict:ERROR / exit 7 / documented_exceptions /
+    waived:true. Reordered so a PARITY_FAIL always raises RED (never masked behind ERROR),
+    and undocumented / still-blocking INFRA still raises.
+- `product/test/infra-001/harness/parity_dimensions.py`
+  - precompact `blocks_c0_proof=True → False` (ADR-009, Unimatrix #5648, human-signed
+    2026-07-08, bugfix-893), with the two revert conditions named in-comment. Other four
+    dims stay True.
+- `product/test/infra-001/suites/test_parity_dimensions.py`
+  - C1: `test_blocks_c0_proof_all_six_true` → `test_blocks_c0_proof_precompact_is_signed_documented_exception`,
+    asserting the four block True + precompact False against an explicit signed map
+    (non-tautological); the in-repo honesty record of the exception.
+- `product/test/infra-001/suites/test_https_uds_parity_matrix.py`
+  - Extended the seam test `test_matrix_orchestrator_seam_with_fixture_bundle` THROUGH
+    `assert_rollup` (the untested step); updated `test_matrix_evidence_table_routes_intra_and_documents_d5`
+    to set the structural flag; added five guard/pin tests (see below).
+
+## New / changed tests
+- `test_matrix_documented_exception_only_is_waived_but_artifact_stays_error` — waived run:
+  assert_rollup does not raise; table verdict ERROR / exit 7 / waived True / disposition PASS /
+  documented_exceptions non-empty (honesty pin, B1).
+- `test_matrix_undocumented_infra_still_raises` — GUARD.
+- `test_matrix_documented_exception_on_blocking_dim_still_raises` — GUARD (flag not id).
+- `test_matrix_documented_exception_with_real_parity_fail_raises_red` — GUARD (waiver never
+  masks a real divergence; raises RED).
+- `test_matrix_documented_exception_flag_set_only_by_branch_1b` — branch-1b-only origin pin.
+- Extended: `test_matrix_orchestrator_seam_with_fixture_bundle`, `test_matrix_evidence_table_routes_intra_and_documents_d5`.
+
+## Test results (component-level, off-Docker)
+- `suites/test_https_uds_parity_matrix.py` + `test_parity_dimensions.py` + `test_parity_legs.py`:
+  69 passed, 0 failed.
+- Full off-Docker parity-family regression (`-k parity -m "not integration and not parity"`,
+  covering test_parity_outcome / _comparator / _dimensions / _legs / _workload /
+  ranking_tolerance / https_uds_parity[_matrix]): **201 passed, 0 failed**.
+- Not run (out of scope, Phase 3): the full Docker integration harness (694 daemon-backed
+  tests) and the live `-m parity` matrix drive.
+
+## Issues / blockers
+None. A1 human sign-off (ADR-009, #5648) was obtained pre-implementation; the waiver cannot
+engage without the signed flag flip by construction. Node-20 action-pin chore left out of
+scope per Q3.
+
+## Knowledge Stewardship
+- Queried: `mcp__unimatrix__context_briefing` (bugfix-893 waiver task) — surfaced ADR-009
+  #5648 (the human-signed precompact flip) + release-signal lessons (#5267, #5192, #2758).
+  `context_get` #5648 (ADR-009 — revert + honesty invariants; keyed on the flag, verdict
+  stays ERROR). Applied: single-source disposition keyed on `blocks_c0_proof`, artifact
+  honesty preserved, C1 test as the in-repo exception record.
+- Stored: nothing novel to store. Per the standing rule, bugs are GH issues not lessons;
+  the disposition ADR (ADR-009 #5648) is already stored by the architect. The generalizable
+  lesson (a designed data-flag escape valve shipped un-wired; two decision sites over the
+  same results must be single-sourced + the artifact self-describing) belongs to the
+  bugfix-893 retro, not a mid-fix store.

--- a/product/features/bugfix-893/agents/893-agent-2-verify-report.md
+++ b/product/features/bugfix-893/agents/893-agent-2-verify-report.md
@@ -1,0 +1,48 @@
+# 893-agent-2-verify — Fresh Verification Report (GH #893)
+
+**Verdict: PASS** (REWORKABLE-clear). Branch `bugfix/893-parity-gate-d5-documented-waiver`. Fresh verifier — did not author the fix.
+
+## Scope of change (confirmed)
+Diff is **test-harness-only**, 5 files under `product/test/infra-001/`, +296/−25:
+- `harness/parity_outcome.py` — new `gate_disposition()` single-source waiver helper; `DimensionResult.documented_exception` structural flag; `rollup()` stays honest/blocks_c0_proof-blind.
+- `harness/parity_matrix_support.py` — `evidence_table` now sources `verdict/exit_code/waived` from `gate_disposition`, adds `waived` + `gate_disposition` keys; `documented_exceptions` keys on the structural flag, not a detail-string sniff.
+- `harness/parity_dimensions.py` — precompact `blocks_c0_proof` flipped `True→False` (ADR-009, Unimatrix #5648, human-signed).
+- `suites/test_https_uds_parity_matrix.py` — 5 new tests + honesty-pin asserts on the existing seam test.
+- `suites/test_parity_dimensions.py` — C1 rename `test_blocks_c0_proof_precompact_is_signed_documented_exception`.
+
+No Rust production code touched → #878 workspace-link smoke not applicable (no Rust change).
+
+## Test execution (all foreground)
+
+| Step | Command | Result |
+|------|---------|--------|
+| 1. Changed parity suites off-Docker | `pytest suites/test_https_uds_parity_matrix.py suites/test_parity_dimensions.py -v` | **48 passed** (incl. all 6 new #893 tests + C1 rename) |
+| 2. Rust workspace | hardened `cargo test --workspace` | **4513 passed, 1 pre-existing flake** (see below) |
+| 3. Clippy | `cargo clippy --workspace -- -D warnings` | **clean, RC=0** |
+| 4. Smoke gate | `pytest suites/ -v -m smoke --timeout=60` | **35 passed, 0 failed** |
+| 5. Parity `-m parity` | see below | off-Docker seam proven; live cross-leg env-blocked |
+
+### Rust flake (pre-existing, unrelated — NOT rework)
+`eval::corpus::fixtures_tests::test_ac14_scenario_search_returns_non_empty_ranked_list` failed once under full-workspace parallel load ("both rank_below anchors must be present"). **Passes 3/3 in isolation.** This is the HNSW approximate-retrieval membership flip already tracked in **GH#746** (family: #833, #790). The #893 diff is Python-only and cannot cause a Rust failure. No new issue filed (already tracked). Not fixed (out of scope).
+
+### Parity coverage — ran vs environment-blocked
+- **Ran (off-Docker):** 48 matrix+dimension tests including the 6 new #893 tests, plus `test_c3_orchestrator_seam_with_fixture_https_vector` (off-Docker orchestrator wiring proof) — PASSED. These drive the **real** production functions (`assert_rollup`, `gate_disposition`, `evidence_table`, `classify_dimension`) with synthetic capture bundles — the exact seam #893 changed.
+- **Environment-blocked:** the 2 live cross-leg HTTPS↔UDS drives (`test_https_uds_parity`, `test_https_uds_parity_matrix`) SKIP because `UNIMATRIX_HTTPS_SMOKE` is unset — they shell out to an external live HTTPS smoke executable (Stage 3c/cloud activity, not wired here). These exercise the transport drive, **not** the disposition/waiver logic #893 changed; that logic is fully covered off-Docker.
+
+## End-to-end intended behavior — verified
+Confirmed the disposition seam behaves as specified (assertions inspected + executed against real production functions):
+- **Documented-exception-only → JOB WAIVED, artifact stays honest:** `assert_rollup` does NOT raise; `evidence_table` carries `verdict:ERROR`, `exit_code:7`, non-empty `documented_exceptions`, `waived:true`, `gate_disposition:PASS`. (the honesty pin — `test_matrix_documented_exception_only_is_waived_but_artifact_stays_error` + the seam test)
+- **Undocumented infra still raises** (`test_matrix_undocumented_infra_still_raises`).
+- **Documented exception on a still-`blocks_c0_proof=True` dim still raises** — keyed on the registry flag, not the id (`test_matrix_documented_exception_on_blocking_dim_still_raises`).
+- **Real PARITY_FAIL alongside a documented gap still raises RED** — waiver never masks a divergence; RED checked before INFRA (`test_matrix_documented_exception_with_real_parity_fail_raises_red`).
+- **`documented_exception` set ONLY by classify branch 1b** — never by empty/misroute infra, never by a comparator (`test_matrix_documented_exception_flag_set_only_by_branch_1b`).
+- **precompact `blocks_c0_proof` flipped True→False** (`test_blocks_c0_proof_precompact_is_signed_documented_exception` + registry diff).
+
+Seam integrity: `gate_disposition` is the single source of the waiver, consumed by both `evidence_table` and `assert_rollup` (no drift); `rollup` measurement verdict remains blocks_c0_proof-blind and is never rounded up. Tests drive the real gate functions directly, not proxies.
+
+## GH issues filed
+None. The one Rust flake is already tracked (GH#746). No failure attributable to #893.
+
+## Knowledge Stewardship
+- Queried: `mcp__unimatrix__context_briefing` + `context_get(5648)` — ADR-009 (#5648) is the human-signed decision this fix implements; #5323/#5376 already codify the off-Docker seam-teeth verification discipline this run relied on; #746 is the pre-existing AC-14 flake.
+- Stored: nothing novel to store — the verification approach (drive real disposition functions off-Docker; live cross-leg is env-blocked and wouldn't exercise the changed logic) is already covered by #5323/#5376, and the flake triage is a known GH issue (bugs are GH issues, not lessons).

--- a/product/features/bugfix-893/agents/893-design-reviewer-report.md
+++ b/product/features/bugfix-893/agents/893-design-reviewer-report.md
@@ -1,0 +1,28 @@
+# Agent Report: 893-design-reviewer (design review of the proposed fix, GH #893)
+
+Review posted: https://github.com/dug-21/unimatrix/issues/893#issuecomment-4916438081
+
+## Assessment: APPROVED WITH NOTES
+Option A is the ADR-sanctioned mechanism; Option B correctly rejected. The four-way waiver conjunction (documented_exception AND NOT blocks_c0_proof AND zero PARITY_FAIL AND per-row over all infra) is provably conservative — no vector silently GREENs a real PARITY_FAIL, undocumented infra, or a documented exception on a still-C0-blocking dim.
+
+## Findings
+| # | Finding | Severity |
+|---|---------|----------|
+| A1 | Flipping precompact `blocks_c0_proof=True→False` is a C0-proof-scope change (dual-purpose flag: release-gate waiver AND C0 #5304 flip scope). Needs explicit maintainer sign-off + a new ADR (supersedes 2026-06-25 all-five-True). Bugfix must not self-authorize. | **Blocking (process)** |
+| B1 | Two decision sites diverge by design (rollup stamps verdict:ERROR; assert_rollup passes the job). Artifact can't distinguish waived-ERROR from failed-ERROR — the bug's own failure mode relocated to the artifact. Single-source the waiver in one pure helper in parity_outcome.py, record `gate_disposition`/`waived` in the table, have assert_rollup consume it. | Non-blocking (strongly recommended) |
+| B2 | `documented_exceptions` (string sniff) and the waiver would be two recomputations of the same conjunction — collapse to one via B1. | Non-blocking |
+| C1 | `suites/test_parity_dimensions.py:118` `test_blocks_c0_proof_all_six_true` BREAKS on the flip — missed in the investigator's blast radius. Update it to encode the signed exception (four block, precompact does not); the updated test becomes the in-repo record of the sign-off. | Non-blocking (must-fix-in-PR) |
+
+## Confirmations (no change)
+- rollup(): keep logic (verdict ERROR/exit 7 — ADR-006 honesty invariant); fix only its false docstring (line 350). The waiver belongs in assert_rollup + the single-source helper, NOT rollup.
+- Key the waiver on the `blocks_c0_proof` flag, not the id `"precompact"` (hard-coding the id = SR-05 second-source drift ADR-001 forbids). Generalization is latent and safe.
+- Pin (test) that `documented_exception` originates only from classify branch 1b; spoof surface is minimal (comparators emit PARITY_*, never INFRA_ERROR, so never enter the waived infra list).
+- AC-10 respected: waiver widens no EXCLUDED set; gated on human-signed data.
+- Structural flag replacing the string sniff fits ADR-001 single-source (pattern #5318 already flagged the detail-string as fragile).
+
+## Required tests (off-Docker)
+Investigator's five + (6) artifact self-description pin (waived table carries gate_disposition==PASS/waived:[precompact] while verdict=="ERROR"/exit 7) + extend the seam test through assert_rollup.
+
+## Knowledge Stewardship
+- Queried: mcp__unimatrix__context_briefing (bugfix-893) + context_get #5313 (ADR-002 §4 blocks_c0_proof escape valve, rollup ERROR>RED>GREEN), #5305 (ADR-001 registry data-only single-source), #5314 (ADR-006 measurable=False documented limitation, never rounded up, human-signed exception), #5381 (ADR-008 standing-disposition), #5322 (rollup-ERROR-dominates D5 fixture trap — known hazard), #5318 (branch-1b ordering, fragile detail-string). Applied to confirm the mechanism, the sign-off requirement, and the honesty verdict.
+- Declined to store: nothing novel now — bugs are GH issues not lessons (standing rule); disposition pends the A1 checkpoint. Generalizable lesson (designed escape valve shipped un-wired; two decision sites over one result set must be single-sourced + artifact self-describing) belongs to the bugfix-893 retro. Follow-up owned by the architect after sign-off: store the precompact documented-exception ADR via context_correct (supersedes the 2026-06-25 all-five-True confirmation).

--- a/product/features/bugfix-893/agents/893-investigator-report.md
+++ b/product/features/bugfix-893/agents/893-investigator-report.md
@@ -1,0 +1,24 @@
+# Agent Report: 893-investigator (bug diagnosis, GH #893)
+
+Diagnosis posted: https://github.com/dug-21/unimatrix/issues/893#issuecomment-4916387617
+
+## Outcome
+Root cause identified (HIGH confidence). Two-part:
+1. The human-signed documented-exception escape valve designed by ADR-002 (#5313) / ADR-006 (#5314) — `blocks_c0_proof` — is consulted NOWHERE in the gate decision. `rollup()` (`harness/parity_outcome.py:346-366`) has docstring-only flag awareness (any INFRA_ERROR → ERROR/exit 7 over all dimensions); `assert_rollup()` (`harness/parity_matrix_support.py:111-117`) raises on ANY infra row, ignoring `documented_exceptions` (already computed by `evidence_table`, via a fragile string sniff) and `blocks_c0_proof` (already in every table row).
+2. The seam test `test_matrix_orchestrator_seam_with_fixture_bundle` models the expected documented-gap live shape but stops before `assert_rollup` — the job disposition for the honest expected outcome was never tested.
+
+The "matched exit 7=7" in the failure message is `exit_code` vs the `EXIT_INFRA` constant (a tautology), not a per-leg comparison; the per-leg analogue is the `measurable` flags, semantics fixed by ADR-006 (either-leg unmeasurable = documented limitation).
+
+## Proposed fix (both options detailed on the issue; recommendation: Option A)
+- **A (recommended)**: waive at `assert_rollup` only when EVERY infra row is (classifier-set `documented_exception=True` via D5 branch 1b) AND (`blocks_c0_proof=False` — requires the human-signed data flip of precompact in `parity_dimensions.py`) AND zero PARITY_FAIL. `rollup` untouched → artifact retains `verdict: ERROR`/exit 7 + `documented_exceptions` (honesty invariant preserved verbatim). Structural flag replaces the string sniff.
+- **B**: tristate shell degrade in release.yml (jq over the emitted table); rejected as primary — exit-code swallowing false-green hazard, logic split out of the off-Docker seam. Job-level `continue-on-error` rejected outright (masks real REDs).
+
+## Missing tests (off-Docker, NFR-1/NFR-2/AC-11)
+Extend the seam test through `assert_rollup`; guard tests: undocumented infra raises, documented-on-blocking-dim raises, documented+PARITY_FAIL raises RED, flag set only by branch 1b, honesty pin (verdict ERROR retained when waived).
+
+## Secondary
+22 deprecated Node-20 action pins (ci.yml 3, release.yml 19) — recommend separate chore commit post-merge; out of scope here.
+
+## Knowledge Stewardship
+- Queried: mcp__unimatrix__context_briefing — surfaced ADR-002 #5313, ADR-006 #5314, patterns #5318/#5322 (the D5 always-INFRA fixture trap was a known hazard), lesson #5332; context_get #5313, #5314; context_search (ADR-006/OQ-2 precompact measurability).
+- Stored: nothing novel to store — defect diagnosis lives on GH #893 (standing rule: bugs are GH issues, not lessons); disposition pends the human Option A/B checkpoint; generalizable lessons belong to the bugfix retro after the fix direction is chosen.

--- a/product/features/bugfix-893/agents/bugfix-893-security-reviewer-report.md
+++ b/product/features/bugfix-893/agents/bugfix-893-security-reviewer-report.md
@@ -1,0 +1,49 @@
+# Security Review: bugfix-893-security-reviewer
+
+## Risk Level: low
+
+## Summary
+PR #939 is a test-only diff (Python parity harness under `product/test/infra-001/` + feature artifacts) — no production Rust/JS, no new dependencies, no secrets. The documented-exception waiver is provably conjunctive, single-sourced in `gate_disposition()`, fails closed on every adversarial case, and preserves the honesty invariant (`rollup()` unchanged; artifact keeps `verdict:ERROR`/`exit 7`). No blocking findings.
+
+## Findings
+
+### F1 — Waiver is conjunctive, single-sourced, and fails closed (confirmation, not a defect)
+- **Severity**: informational
+- **Location**: `harness/parity_outcome.py:392-431` (`_is_waivable_infra` / `gate_disposition`); `harness/parity_matrix_support.py:50,134` (consumers)
+- **Description**: `waived=True` requires (1) >=1 INFRA_ERROR row, (2) zero PARITY_FAIL rows, (3) every INFRA row `documented_exception is True` AND `blocks_c0_proof is False`. Both `evidence_table` and `assert_rollup` read the single `gate_disposition` pure function — no recomputation drift. Verified fail-closed for: real PARITY_FAIL (clause 2, RED raised before INFRA branch), undocumented/transport INFRA (flag False), documented exception on a still-blocking dim (flag-keyed, not id-keyed), documented exception coexisting with a real PARITY_FAIL (RED), and preflight/ingest InfraError (`emit_infra_and_fail` unchanged).
+- **Recommendation**: none.
+- **Blocking**: no
+
+### F2 — `documented_exception` confined to a single non-spoofable setter (confirmation)
+- **Severity**: informational
+- **Location**: `harness/parity_outcome.py:207-214` (branch 1b)
+- **Description**: grep across the harness confirms `documented_exception=True` is set in exactly one place — the D5 `measurable=False` classifier branch. Comparators only return PARITY_PASS/PARITY_FAIL, so the flag cannot be set by a comparator. `dimension_by_id` KeyError on an orphan id fails closed to non-waivable.
+- **Recommendation**: none.
+- **Blocking**: no
+
+### F3 — Pre-existing one-leg-`None` precompact `AttributeError` (out of scope)
+- **Severity**: low
+- **Location**: `harness/parity_outcome.py:194-195` (branch 1b `.get` on a possibly-`None` capture)
+- **Description**: When a `None` precompact capture is `continue`-skipped in branch 1, branch 1b calls `cap.get("measurable")` on `None` → `AttributeError`. Pre-existing (this diff only adds the flag to the existing return path); not reached by the documented-gap fixture (both legs supply `measurable=False` dicts). Fails loud (crash), never a silent green, so it cannot produce a spurious waiver.
+- **Recommendation**: track separately if desired; not for this bugfix.
+- **Blocking**: no
+
+## OWASP Assessment
+- Injection / command / path traversal: N/A — no shell, no filesystem path from external input, no format strings over untrusted data.
+- Deserialization: `json.dumps` of an internally-built table only (no untrusted `loads`).
+- Access control / trust boundaries: N/A — off-Docker pure-Python test harness, no privilege surface.
+- Vulnerable/new dependencies: none added (only intra-harness imports).
+- Secrets: none in diff (scanned).
+
+## Blast Radius Assessment
+Worst case if the waiver had a subtle bug: the nan-021 release-gate job greens on an unmeasured dimension. Structurally bounded — the only waivable dimension is the human-signed `blocks_c0_proof=False` precompact; any PARITY_FAIL or undocumented/still-blocking INFRA still fails the job; the on-disk artifact retains the honest `verdict:ERROR`/`exit 7` for audit. Failure mode is fail-closed. No production code path is touched, so runtime blast radius outside CI is nil.
+
+## Regression Risk
+Minimal. `rollup()` behavior is byte-for-byte unchanged (docstring-only edit) — verified against its existing tests. `emit_infra_and_fail` and all preflight/ingest InfraError paths still raise. The single behavioral change is the intended waiver in `assert_rollup`, gated on the conjunctive `gate_disposition`. The evidence artifact gains `waived`/`gate_disposition` fields, making a waived run distinguishable from a genuine ERROR — resolving #893's core concern. `blocks_c0_proof` data flip is precompact-only (test `test_blocks_c0_proof_precompact_is_signed_documented_exception` pins the other four to True).
+
+## PR Comments
+- Posted 1 review comment on PR #939 (`--comment`, non-blocking).
+- Blocking findings: no.
+
+## Knowledge Stewardship
+- Stored: nothing novel to store — the honesty/waiver invariants are ADR-governed (ADR-001/002/006/009, Unimatrix #5648) and PR-specific; per "Bugs are GH issues, not lessons" and the fresh-eyes confirmation yielded no generalizable cross-feature security anti-pattern.

--- a/product/test/infra-001/harness/parity_dimensions.py
+++ b/product/test/infra-001/harness/parity_dimensions.py
@@ -84,11 +84,14 @@ class Dimension:
 # =============================================================================
 # Flags taken EXACTLY from the brief's Data Structures table:
 #   intra_transport_check=True ONLY for retrieval + proactive (embedding-ranked dims).
-#   blocks_c0_proof=True for ALL FIVE — CONFIRMED correct (human, 2026-06-25): the
-#   corrected C0 (#5304) done_when makes parity the TOTAL bar; the dimension list
-#   grows with the pipeline and never narrows the bar. Any unreachable dimension is a
-#   human-signed DOCUMENTED EXCEPTION (the flag is the data-only escape valve), never
-#   a silent exclusion. `comparator` holds the K2 class NAME until K2 binds it.
+#   blocks_c0_proof=True for the four measurable dimensions. precompact flips to
+#   False per ADR-009 (Unimatrix #5648), human-signed 2026-07-08, bugfix-893 — the
+#   data-only escape valve (ADR-001) exercised for a DOCUMENTED, human-signed
+#   measurability exception (never a silent exclusion). This SUPERSEDES the
+#   2026-06-25 all-five-True confirmation FOR PRECOMPACT ONLY; the other four remain
+#   True. The corrected C0 (#5304) done_when still makes parity the TOTAL bar for the
+#   measurable dimensions; the list grows with the pipeline and never narrows the bar.
+#   `comparator` holds the K2 class NAME until K2 binds it.
 DIMENSIONS: tuple[Dimension, ...] = (
     Dimension(
         id="retrieval",
@@ -128,7 +131,14 @@ DIMENSIONS: tuple[Dimension, ...] = (
         wire_surface=WIRE_HOOK_OBSERVE,
         comparator="PreCompactComparator",
         intra_transport_check=False,
-        blocks_c0_proof=True,
+        # ADR-009 (Unimatrix #5648), human-signed 2026-07-08, bugfix-893: True→False.
+        # AC-06 CompactContext-restoration parity is not test-only-measurable AS
+        # SHIPPED (Claude-Code host-side component the nan-021 harness cannot drive) —
+        # NOT unmeasurable in principle. Reverts to True (data-only, ADR-001) when
+        # EITHER lands: a widened harness compares the server-assembled CompactPayload
+        # cross-transport; OR a full AC-06 host-driven C0-flip measurement proves the
+        # payload is restored into the compacted context.
+        blocks_c0_proof=False,
     ),
 )
 

--- a/product/test/infra-001/harness/parity_matrix_support.py
+++ b/product/test/infra-001/harness/parity_matrix_support.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import Any
 
 from harness.parity_dimensions import DIMENSIONS, dimension_by_id
-from harness.parity_outcome import DimensionResult, Outcome, rollup
+from harness.parity_outcome import DimensionResult, Outcome, gate_disposition
 from harness.transport_health import EXIT_INFRA, InfraError
 
 
@@ -39,8 +39,15 @@ def evidence_table(results: list[DimensionResult], run_token: str) -> dict:
     redden); D5 measurability call-outs under `documented_exceptions` (honest, never
     a vacuous pass). The roll-up verdict + exit code are embedded so the table alone
     tells the flip session GREEN / RED / ERROR.
+
+    The table is SELF-DESCRIBING about the job disposition (design-review B1): a
+    WAIVED-ERROR (documented human-signed exception only, job green — ADR-009 /
+    Unimatrix #5648) is distinguishable from a genuine failing ERROR by the
+    `waived` / `gate_disposition` fields — sourced from the SINGLE `gate_disposition`
+    helper. The honest measurement `verdict` / `exit_code` are UNCHANGED (a waived
+    run still reports ERROR / exit 7; never rounded up).
     """
-    verdict, exit_code = rollup(results)
+    verdict, exit_code, waived = gate_disposition(results)
     rows: list[dict] = []
     intra: list[str] = []
     documented: list[dict] = []
@@ -61,15 +68,19 @@ def evidence_table(results: list[DimensionResult], run_token: str) -> dict:
         )
         if r.outcome == Outcome.INTRA_TRANSPORT_NONDETERMINISM:
             intra.append(r.dimension)
-        # A D5 documented measurability limitation surfaces as INFRA-ERROR with a
-        # MEASURABILITY-flagged detail — record it honestly (never rounded up).
-        if r.outcome == Outcome.INFRA_ERROR and "MEASURABILITY" in r.detail.upper():
+        # A D5 documented measurability limitation surfaces as INFRA-ERROR carrying
+        # the STRUCTURAL classifier flag (not a detail-string sniff — design-review
+        # B2). Record it honestly (never rounded up).
+        if r.outcome == Outcome.INFRA_ERROR and r.documented_exception:
             documented.append({"dimension": r.dimension, "detail": r.detail})
     return {
         "run_token": run_token,
         "dimensions": rows,
-        "verdict": verdict,
+        "verdict": verdict,  # honest measurement verdict — unchanged, never rounded up
         "exit_code": exit_code,
+        "waived": waived,  # job passes despite ERROR (documented human-signed exception)
+        # PASS iff GREEN or a documented-exception-only waiver engaged; else FAIL.
+        "gate_disposition": "PASS" if (verdict == "GREEN" or waived) else "FAIL",
         "intra_nondeterminism": intra,  # routed to GH#746; does NOT redden the gate
         "documented_exceptions": documented,  # D5 host-side gap call-outs (honest)
     }
@@ -97,6 +108,15 @@ def assert_rollup(
 
     INTRA-NONDET rows are recorded in the table and do NOT redden — they are routed
     to a separately-filed GH#746 bug.
+
+    WAIVED-ERROR (ADR-009, Unimatrix #5648): when every INFRA-ERROR row is a human-
+    signed documented exception (`documented_exception` AND `blocks_c0_proof is
+    False`) and there is NO PARITY-FAIL, the JOB passes WITHOUT raising — but the
+    emitted `table` still carries the honest `verdict:ERROR` / `exit_code:7` +
+    `documented_exceptions` + `waived:true`. The waiver decision is taken from the
+    SINGLE `gate_disposition` helper (design-review B1 — no recomputation, no drift).
+    The waiver covers ONLY documented-exception INFRA rows; it NEVER masks a real
+    divergence — a PARITY-FAIL always raises RED (even alongside a documented gap).
     """
     if verdict == "GREEN" and exit_code == 0:
         return
@@ -108,13 +128,23 @@ def assert_rollup(
 
     table_str = _json.dumps(table, indent=2, default=str)
 
-    if infra:
+    # Single-source waiver disposition (ADR-009 / #5648). `waived` is True ONLY when
+    # there are no PARITY-FAIL rows and every INFRA row is a signed documented
+    # exception — so this branch cannot fire alongside a real divergence.
+    _v, _e, waived = gate_disposition(results)
+    if waived:
         details = "; ".join(f"{r.dimension}: {r.detail}" for r in infra)
-        raise AssertionError(
-            f"parity matrix INFRA-ERROR (distinct exit {exit_code}={EXIT_INFRA}) — "
-            f"NOT a parity RED; diagnose transport / honour the D5 documented gap. "
+        print(
+            f"parity matrix WAIVED-ERROR — JOB PASSES; artifact keeps honest "
+            f"verdict={verdict}/exit {exit_code} + documented_exceptions (never rounded "
+            f"up). Documented human-signed exception(s) only (ADR-009, Unimatrix #5648): "
             f"{details}\n--- evidence table (run_token-keyed) ---\n{table_str}"
         )
+        return
+
+    # A REAL cross-transport divergence always fails RED — checked BEFORE INFRA so a
+    # PARITY-FAIL is never masked behind an ERROR message (the waiver never engages
+    # here, `waived` is False when any fail exists).
     if fails:
         details = "; ".join(
             f"{r.dimension}: {r.detail} diffs={r.diffs}" for r in fails
@@ -123,6 +153,13 @@ def assert_rollup(
             f"parity matrix RED (exit {exit_code}) — REAL cross-transport divergence; "
             f"file a NEW GH bug, fix NOT absorbed (AC-10). {details}\n"
             f"--- evidence table (run_token-keyed) ---\n{table_str}"
+        )
+    if infra:
+        details = "; ".join(f"{r.dimension}: {r.detail}" for r in infra)
+        raise AssertionError(
+            f"parity matrix INFRA-ERROR (distinct exit {exit_code}={EXIT_INFRA}) — "
+            f"NOT a parity RED; diagnose transport / honour the D5 documented gap. "
+            f"{details}\n--- evidence table (run_token-keyed) ---\n{table_str}"
         )
     # Defensive: a non-GREEN verdict with neither class present is itself a fault.
     raise AssertionError(

--- a/product/test/infra-001/harness/parity_outcome.py
+++ b/product/test/infra-001/harness/parity_outcome.py
@@ -27,6 +27,7 @@ from enum import Enum
 from typing import Any
 
 from harness.parity_comparator import ParityMismatch
+from harness.parity_dimensions import dimension_by_id
 from harness.ranking_tolerance import (
     STABLE_PREFIX_FLOOR,  # single source for the non-degenerate floor (R-06)
     ranking_parity,  # the ONE tolerance — intra reuses the cross-leg policy (R-07 sc.4)
@@ -67,12 +68,20 @@ class DimensionResult:
     diffs      the comparator diff list (empty unless PARITY_FAIL).
     detail     human-readable: which guard tripped / which leg was intra-unstable /
                the D5 host_side_gap call-out / the ParityMismatch summary.
+    documented_exception
+               STRUCTURAL flag (single source), NOT a detail-string sniff: True ONLY
+               for a human-signed DOCUMENTED measurability limitation set inside
+               `_classify` branch 1b (the D5 measurable=False call-out). It is the
+               classifier-owned input to the job-disposition waiver (`gate_disposition`,
+               ADR-009 / Unimatrix #5648) — a comparator can NEVER set it (comparators
+               only return PARITY_PASS/PARITY_FAIL), so it is not spoofable.
     """
 
     dimension: str
     outcome: Outcome
     diffs: list = field(default_factory=list)
     detail: str = ""
+    documented_exception: bool = False
 
 
 # =============================================================================
@@ -192,12 +201,16 @@ def _classify(dim: Any, cap_uds: Any, cap_https: Any) -> DimensionResult:
             )
             # DOCUMENTED-EXCEPTION call-out — NOT a pass, NOT a parity RED. Recorded
             # distinctly as INFRA-ERROR; NEVER rounded up to "fully measured" (R-08).
+            # documented_exception=True is set ONLY here (branch 1b) — the structural,
+            # classifier-owned single source the job-disposition waiver keys on
+            # (ADR-009, Unimatrix #5648). This is the ONLY setter in the codebase.
             return DimensionResult(
                 dim.id,
                 Outcome.INFRA_ERROR,
                 [],
                 f"DOCUMENTED MEASURABILITY LIMITATION: {gap} "
                 f"(D5 measured-where-drivable; NEVER rounded up to fully-measured)",
+                documented_exception=True,
             )
         # both measurable -> fall through to PARITY with non-null payloads.
 
@@ -344,19 +357,26 @@ def _retrieval_rank(queries: Any) -> dict:
 # 5. rollup — matrix roll-up (ADR-002 §4): ERROR > RED > GREEN precedence
 # =============================================================================
 def rollup(results: list[DimensionResult]) -> tuple[str, int]:
-    """Reduce per-dimension results to a ``(verdict, exit_code)``.
+    """Reduce per-dimension results to the MEASUREMENT ``(verdict, exit_code)``.
 
-    Rules (ADR-002 §4):
-      GREEN iff every blocks_c0_proof dimension is PARITY_PASS.
-      Any PARITY_FAIL                       -> RED.
-      Any INFRA_ERROR (even amid passes)    -> ERROR (distinct exit code).
+    Rules (ADR-002 §4) — the artifact's honest verdict, NEVER rounded up (ADR-006):
+      All PARITY_PASS (INTRA rows ignored)  -> GREEN / EXIT_OK.
+      Any PARITY_FAIL                       -> RED / EXIT_PARITY_FAIL.
+      Any INFRA_ERROR (even amid passes)    -> ERROR / EXIT_INFRA (distinct code).
       INTRA_TRANSPORT_NONDETERMINISM        -> recorded; does NOT redden, does NOT
                                                error (a separately-filed GH#746 bug).
 
     Precedence when multiple classes are present: ERROR > RED > GREEN — an
     INFRA-ERROR means the gate could not MEASURE and must not be reported green or
     red-only; a PARITY-FAIL reddens even alongside an INTRA record (intra never
-    masks a real RED)."""
+    masks a real RED).
+
+    This is deliberately blocks_c0_proof-BLIND and documented_exception-BLIND: a
+    documented, human-signed measurability gap (ADR-009, Unimatrix #5648) STILL
+    yields verdict:ERROR / exit 7 here — the artifact stays honest and is never
+    rounded up to GREEN. Whether such an ERROR run WAIVES the JOB is a separate
+    disposition computed by `gate_disposition` and consumed by `assert_rollup`;
+    `rollup`'s measurement verdict is never altered by the waiver."""
     has_fail = any(r.outcome == Outcome.PARITY_FAIL for r in results)
     has_infra = any(r.outcome == Outcome.INFRA_ERROR for r in results)
     if has_infra:
@@ -364,3 +384,48 @@ def rollup(results: list[DimensionResult]) -> tuple[str, int]:
     if has_fail:
         return ("RED", EXIT_PARITY_FAIL)
     return ("GREEN", EXIT_OK)
+
+
+# =============================================================================
+# 6. gate_disposition — single-source JOB disposition (ADR-009 / #5648 waiver)
+# =============================================================================
+def _is_waivable_infra(r: DimensionResult) -> bool:
+    """Is THIS INFRA-ERROR row a human-signed documented exception the job may waive?
+
+    True iff the row is a structural documented exception (branch-1b flag) AND its
+    dimension is NOT blocks_c0_proof (the human-signed data flip, ADR-009). Keyed on
+    the registry FLAG, never on the id "precompact" (ADR-001 single-source — hard-
+    coding the id would re-introduce the second-source drift the registry prevents).
+    An orphan id (no registry row) is conservatively BLOCKING → never waivable
+    (mirrors `evidence_table`'s KeyError → blocks=True)."""
+    if not r.documented_exception:
+        return False
+    try:
+        return dimension_by_id(r.dimension).blocks_c0_proof is False
+    except KeyError:
+        return False
+
+
+def gate_disposition(results: list[DimensionResult]) -> tuple[str, int, bool]:
+    """The ONE source of the job-pass-despite-ERROR waiver (ADR-009, Unimatrix #5648).
+
+    Returns ``(verdict, exit_code, waived)``:
+      * `verdict` / `exit_code` are `rollup(results)` VERBATIM — the honest
+        measurement verdict, never rounded up (ADR-006). A waived run still reports
+        verdict:ERROR / exit 7 in the artifact.
+      * `waived` — whether the JOB passes despite that ERROR verdict.
+
+    WAIVED iff ALL hold:
+      1. there is >=1 INFRA_ERROR row, AND
+      2. there are ZERO PARITY_FAIL rows (a real divergence is NEVER masked), AND
+      3. EVERY INFRA_ERROR row is waivable — `documented_exception is True` AND its
+         dimension's `blocks_c0_proof is False` (via the registry).
+    Clause 3 subsumes "zero undocumented / still-blocking INFRA rows": any infra row
+    that is undocumented, or documented on a still-C0-blocking dimension, forces
+    `waived=False`. Both evidence_table and assert_rollup consume THIS helper, so the
+    conjunction lives in exactly one place (no drift — design-review B1/B2)."""
+    verdict, exit_code = rollup(results)
+    infra = [r for r in results if r.outcome == Outcome.INFRA_ERROR]
+    has_fail = any(r.outcome == Outcome.PARITY_FAIL for r in results)
+    waived = bool(infra) and not has_fail and all(_is_waivable_infra(r) for r in infra)
+    return (verdict, exit_code, waived)

--- a/product/test/infra-001/suites/test_https_uds_parity_matrix.py
+++ b/product/test/infra-001/suites/test_https_uds_parity_matrix.py
@@ -28,6 +28,7 @@ from harness.parity_outcome import (
     DimensionResult,
     Outcome,
     classify_dimension,
+    gate_disposition,
     rollup,
 )
 from harness.parity_workload import default_workload
@@ -101,6 +102,14 @@ def test_matrix_orchestrator_seam_with_fixture_bundle(tmp_path):
     assert table["verdict"] == "ERROR"
     assert table["exit_code"] == EXIT_INFRA
     assert table["documented_exceptions"], "D5 host-side gap must be surfaced honestly"
+
+    # ADR-009 (Unimatrix #5648): precompact blocks_c0_proof=False makes the documented
+    # gap a WAIVED-ERROR — the JOB passes (assert_rollup does NOT raise) while the
+    # artifact stays honest (verdict ERROR / exit 7). This is the disposition the
+    # untested step (assert_rollup) let ship red; it is now asserted here.
+    assert table["waived"] is True
+    assert table["gate_disposition"] == "PASS"
+    assert_rollup(table["verdict"], table["exit_code"], results, table)  # must NOT raise
 
 
 def test_matrix_seam_all_measurable_is_green(tmp_path):
@@ -325,6 +334,125 @@ def test_matrix_emit_infra_and_fail_is_distinct_class():
 
 
 # ===========================================================================
+# ADR-009 (#5648 / GH#893) documented-exception WAIVER — the escape valve wired
+# into the job disposition. The waiver waives ONLY human-signed documented
+# exceptions on non-blocks_c0_proof dims; every other INFRA/RED still fails.
+# ===========================================================================
+
+
+def test_matrix_documented_exception_only_is_waived_but_artifact_stays_error():
+    """A documented-gap bundle (precompact measurable=False, blocks_c0_proof=False per
+    ADR-009): `assert_rollup` does NOT raise (job WAIVED) AND the artifact stays honest
+    — verdict ERROR / exit 7 / non-empty documented_exceptions / waived True / disposition
+    PASS. The honesty pin (design-review B1): the two decision sites' relationship is
+    asserted in the artifact, not just the raise path."""
+    wl = default_workload()
+    uds = fixture_dimension_bundle(feature_cycle=wl.feature_cycle)
+    https = fixture_dimension_bundle(feature_cycle=wl.feature_cycle)
+    results = _classify_all(uds, https)  # precompact fixture is the documented gap
+    table = evidence_table(results, wl.session_id)
+
+    # Honest measurement verdict is never rounded up.
+    assert table["verdict"] == "ERROR"
+    assert table["exit_code"] == EXIT_INFRA
+    assert table["documented_exceptions"]
+    # Self-describing job disposition (single-sourced from gate_disposition).
+    assert table["waived"] is True
+    assert table["gate_disposition"] == "PASS"
+    _v, _e, waived = gate_disposition(results)
+    assert (_v, _e, waived) == ("ERROR", EXIT_INFRA, True)
+    # The JOB passes — assert_rollup must NOT raise on a documented-exception-only run.
+    assert_rollup(table["verdict"], table["exit_code"], results, table)
+
+
+def test_matrix_undocumented_infra_still_raises():
+    """GUARD: an UNDOCUMENTED INFRA row (documented_exception=False — e.g. a measurable
+    leg with an empty/missing capture) is NOT waivable; `assert_rollup` STILL raises.
+    The waiver never engages for a real transport/ingest error."""
+    results = [DimensionResult(d.id, Outcome.PARITY_PASS) for d in DIMENSIONS]
+    # behavioral is blocks_c0_proof=True AND undocumented → non-waivable INFRA.
+    results[1] = DimensionResult(
+        "behavioral", Outcome.INFRA_ERROR, [], "https capture empty", documented_exception=False
+    )
+    table = evidence_table(results, "tok-undoc")
+    assert table["waived"] is False
+    assert table["gate_disposition"] == "FAIL"
+    with pytest.raises(AssertionError) as ei:
+        assert_rollup(table["verdict"], table["exit_code"], results, table)
+    assert "INFRA-ERROR" in str(ei.value)
+
+
+def test_matrix_documented_exception_on_blocking_dim_still_raises():
+    """GUARD: a documented-exception row on a dimension that is STILL blocks_c0_proof=True
+    is NOT waivable — the waiver refuses to engage without the human-signed data flip.
+    Keyed on the FLAG, not the id (ADR-001): retrieval remains blocks_c0_proof=True."""
+    assert dimension_by_id("retrieval").blocks_c0_proof is True  # precondition
+    results = [DimensionResult(d.id, Outcome.PARITY_PASS) for d in DIMENSIONS]
+    results[0] = DimensionResult(
+        "retrieval",
+        Outcome.INFRA_ERROR,
+        [],
+        "DOCUMENTED MEASURABILITY LIMITATION: spoofed on a still-blocking dim",
+        documented_exception=True,
+    )
+    table = evidence_table(results, "tok-blocking")
+    assert table["waived"] is False
+    assert table["gate_disposition"] == "FAIL"
+    with pytest.raises(AssertionError):
+        assert_rollup(table["verdict"], table["exit_code"], results, table)
+
+
+def test_matrix_documented_exception_with_real_parity_fail_raises_red():
+    """GUARD: a documented exception (waivable) coexisting with a REAL PARITY-FAIL on
+    another dim → `assert_rollup` raises RED. The waiver NEVER masks a real divergence
+    (ADR-009 honesty invariant b); the RED message names the divergence, not the gap."""
+    results = [DimensionResult(d.id, Outcome.PARITY_PASS) for d in DIMENSIONS]
+    # precompact: the (now non-blocking) documented exception.
+    results[4] = DimensionResult(
+        "precompact",
+        Outcome.INFRA_ERROR,
+        [],
+        "DOCUMENTED MEASURABILITY LIMITATION: host-side gap",
+        documented_exception=True,
+    )
+    # behavioral: a real cross-transport divergence.
+    results[1] = DimensionResult(
+        "behavioral", Outcome.PARITY_FAIL, [("topic_signals", "a", "b")], "cross-transport divergence"
+    )
+    table = evidence_table(results, "tok-red-plus-gap")
+    assert table["waived"] is False
+    assert table["gate_disposition"] == "FAIL"
+    with pytest.raises(AssertionError) as ei:
+        assert_rollup(table["verdict"], table["exit_code"], results, table)
+    assert "RED" in str(ei.value), "a real divergence must surface RED, not be masked by the gap"
+
+
+def test_matrix_documented_exception_flag_set_only_by_branch_1b():
+    """`classify_dimension` sets `documented_exception=True` ONLY via the D5 branch-1b
+    measurability call-out — never for empty/null/misroute INFRA, and never for a
+    PARITY verdict (not spoofable by a comparator)."""
+    # Branch 1b: precompact measurable=False → documented exception.
+    gap = classify_dimension(
+        dimension_by_id("precompact"),
+        {"restored_payload": None, "measurable": False, "host_side_gap": "g"},
+        {"restored_payload": None, "measurable": False, "host_side_gap": "g"},
+    )
+    assert gap.outcome == Outcome.INFRA_ERROR
+    assert gap.documented_exception is True
+    # An ordinary empty-capture INFRA (measurable dim) is NOT a documented exception.
+    empty_infra = classify_dimension(dimension_by_id("behavioral"), None, {"topic_signals": ["x"]})
+    assert empty_infra.outcome == Outcome.INFRA_ERROR
+    assert empty_infra.documented_exception is False
+    # A PARITY-PASS carries the default False (comparators never set the flag).
+    wl = default_workload()
+    uds = fixture_dimension_bundle(feature_cycle=wl.feature_cycle)
+    https = fixture_dimension_bundle(feature_cycle=wl.feature_cycle)
+    passed = classify_dimension(dimension_by_id("behavioral"), uds["behavioral"], https["behavioral"])
+    assert passed.outcome == Outcome.PARITY_PASS
+    assert passed.documented_exception is False
+
+
+# ===========================================================================
 # Evidence-table emit keyed by run_token (AC-08 — the C0 proof artifact).
 # ===========================================================================
 
@@ -355,7 +483,13 @@ def test_matrix_evidence_table_routes_intra_and_documents_d5():
     results = [
         DimensionResult("retrieval", Outcome.INTRA_TRANSPORT_NONDETERMINISM, [], "flip"),
         DimensionResult(
-            "precompact", Outcome.INFRA_ERROR, [], "DOCUMENTED MEASURABILITY LIMITATION: gap"
+            "precompact",
+            Outcome.INFRA_ERROR,
+            [],
+            "DOCUMENTED MEASURABILITY LIMITATION: gap",
+            # documented_exceptions now keys on the STRUCTURAL flag, not the detail
+            # string (design-review B2) — set it as branch 1b would.
+            documented_exception=True,
         ),
         DimensionResult("behavioral", Outcome.PARITY_PASS),
     ]

--- a/product/test/infra-001/suites/test_parity_dimensions.py
+++ b/product/test/infra-001/suites/test_parity_dimensions.py
@@ -115,8 +115,33 @@ def test_intra_transport_check_only_retrieval_and_proactive():
     assert intra == {"retrieval", "proactive"}
 
 
-def test_blocks_c0_proof_all_six_true():
-    assert all(d.blocks_c0_proof is True for d in DIMENSIONS)
+# The human-signed blocks_c0_proof disposition (ADR-009, Unimatrix #5648, bugfix-893,
+# 2026-07-08): the four measurable dimensions block the C0 flip; precompact does NOT —
+# its AC-06 restoration parity is a documented, human-signed measurability exception
+# (not test-only-measurable as shipped). Supersedes the 2026-06-25 all-five-True
+# confirmation FOR PRECOMPACT ONLY. This map IS the in-repo record of that exception.
+EXPECTED_BLOCKS_C0_PROOF = {
+    "retrieval": True,
+    "behavioral": True,
+    "analytics": True,
+    "proactive": True,
+    "precompact": False,
+}
+
+
+def test_blocks_c0_proof_precompact_is_signed_documented_exception():
+    """precompact `blocks_c0_proof` is the human-signed documented exception (ADR-009,
+    Unimatrix #5648, GH#893): the four measurable dimensions block the C0 (#5304) flip,
+    precompact does not. NOT a tautology — each dimension is checked against the signed
+    map. Reverts to all-True (data-only, ADR-001) only when a revert path lands."""
+    actual = {d.id: d.blocks_c0_proof for d in DIMENSIONS}
+    assert actual == EXPECTED_BLOCKS_C0_PROOF
+    # The precompact exception is explicit; the other four still block.
+    assert dimension_by_id("precompact").blocks_c0_proof is False
+    assert all(
+        dimension_by_id(dim_id).blocks_c0_proof is True
+        for dim_id in ("retrieval", "behavioral", "analytics", "proactive")
+    )
 
 
 # ===========================================================================


### PR DESCRIPTION
Fixes #893.

## Problem
The `nan-021-https-uds-parity` job failed the **Release** workflow whenever the `precompact` dimension returned its documented D5 measurability limitation (`INFRA_ERROR`, exit 7) — even though every real parity dimension passed and no HTTPS-vs-UDS divergence existed. A documented-gap run was indistinguishable from a real regression.

## Root cause
The `blocks_c0_proof` escape valve (designed in ADR-002 §4 / ADR-006) was never wired into the gate decision. `rollup()` treated **any** `INFRA_ERROR` as `ERROR`/exit 7 and `assert_rollup()` raised on any infra row — the flag was read nowhere, and `documented_exceptions` was derived by a fragile `"MEASURABILITY" in detail` string sniff.

## Fix — Option A (human-signed, ADR-009 / Unimatrix #5648)
- **Structural** `DimensionResult.documented_exception`, set **only** in `classify_dimension` branch 1b (the D5 `measurable=False` path) — not spoofable by a comparator.
- Single-source `gate_disposition()` helper keyed on the `blocks_c0_proof` **flag** (never the id `"precompact"` — ADR-001 single-source), consumed by `assert_rollup`.
- Self-describing artifact: `evidence_table` records `waived` / `gate_disposition` (B1) so a waived-ERROR is distinguishable from a genuine failing ERROR.
- precompact `blocks_c0_proof` **True→False** (data-only per ADR-001; the ADR-006/ADR-002 pre-authorized documented-exception valve). C1: the all-True registry test rewritten as the signed-exception record.

### Honesty invariant (preserved)
`rollup()` logic is **untouched** — the artifact keeps `verdict:ERROR` / `exit 7` / non-empty `documented_exceptions` (never rounded up to fully-measured). The waiver only ever covers documented-exception INFRA rows: **undocumented infra, a documented exception on a still-blocking dimension, and any real `PARITY_FAIL` each still fail the gate.**

### Measurability status
precompact is **not test-only-measurable as shipped** (host-side Claude-Code component, ADR-006 / OQ-2) — **not unmeasurable in principle**. ADR-009 names the two revert conditions (server-side `CompactPayload` cross-transport compare; or full AC-06 host-driven C0-flip measurement); the flag returns to True as a data-only change when either lands.

## Tests (test-only diff — NFR-1/NFR-2/AC-11)
New guard tests extend the seam through `assert_rollup`:
- `test_matrix_documented_exception_only_is_waived_but_artifact_stays_error` (honesty pin)
- `test_matrix_undocumented_infra_still_raises`
- `test_matrix_documented_exception_on_blocking_dim_still_raises`
- `test_matrix_documented_exception_with_real_parity_fail_raises_red`
- `test_matrix_documented_exception_flag_set_only_by_branch_1b`
- C1 rename `test_blocks_c0_proof_precompact_is_signed_documented_exception`

**Verification (fresh, foreground):** 48 changed-suite + 35 smoke tests pass; workspace 4513 pass; clippy clean. Sole Rust flake is pre-existing HNSW/AC-14, tracked in #746 (Python-only diff cannot cause it). Gate: **PASS** (12/12).

Out of scope: the deprecated `actions/*` Node-20 pins (#893 secondary) — separate chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)