### PR TITLE
fix: persist context_cycle tags via the JS hook-client + delete lying MCP ack (#944)

### DIFF
--- a/crates/unimatrix-server/src/mcp/tools.rs
+++ b/crates/unimatrix-server/src/mcp/tools.rs
@@ -542,40 +542,14 @@ pub struct CycleParams {
     /// starts are a whole-set no-op. Values are opaque — stored verbatim, non-empty is
     /// the only check (no vocabulary/length/prefix validation). Old callers omitting this
     /// field receive None. Persistence rides the hook path (not this handler); this field
-    /// declares the interface and feeds only the best-effort ack echo.
+    /// only declares the interface — frame writers read `tool_input.tags` from this
+    /// schema-declared param exactly like `goal`. The MCP handler does nothing extra for
+    /// tags: no recording claim, no read-back (parity with `goal`).
     pub tags: Option<Vec<String>>,
     /// Agent making the request.
     pub agent_id: Option<String>,
     /// Response format: summary, markdown, or json.
     pub format: Option<String>,
-}
-
-/// Build the best-effort tag-ack phrase appended to the `context_cycle` response (vnc-047
-/// C12, ADR-007). NON-GATING: echoes the CALLER's own input — never reads stored `cycle_tags`
-/// and never surfaces the whole-set-once freeze outcome (Non-Goal #6). Applies the same
-/// non-empty filter as the write path (value-opaque; no other validation). An empty/all-blank
-/// list yields an empty string, leaving the base ack unchanged. Wording is accept-for-recording
-/// (fire-and-forget), NOT a durability guarantee — `context_cycle_review` is authoritative.
-/// `pub(crate)` for unit testability without full handler construction.
-pub(crate) fn cycle_tag_ack_phrase(cycle_type: CycleType, tags: Option<&[String]>) -> String {
-    let tag_view: Vec<&str> = tags
-        .unwrap_or(&[])
-        .iter()
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-        .collect();
-    if tag_view.is_empty() {
-        String::new()
-    } else if cycle_type == CycleType::Start {
-        format!(
-            " {} run-identity label(s) accepted for recording at cycle start: [{}]. \
-             Recording is fire-and-forget; use context_cycle_review to confirm.",
-            tag_view.len(),
-            tag_view.join(", ")
-        )
-    } else {
-        " tags ignored — labels are only recorded at cycle start.".to_string()
-    }
 }
 
 /// Extract the active workflow phase for a session — infallible, O(1) clone.
@@ -4202,7 +4176,11 @@ impl UnimatrixServer {
             }
         }
 
-        let base_ack = if let Some(ref g) = validated_goal {
+        // tags parity with goal: the schema-declared `params.tags` is read by frame
+        // writers off `tool_input.tags` (the hook path persists it). The MCP handler does
+        // NOTHING extra for tags — no recording claim in the ack, no read-back (vnc-047 fix,
+        // #944). `context_cycle_review` is authoritative for what actually persisted.
+        let response_text = if let Some(ref g) = validated_goal {
             format!(
                 "Acknowledged: {} for topic '{}' with goal: '{}'. \
                  Attribution is applied via the hook path (fire-and-forget). \
@@ -4217,12 +4195,6 @@ impl UnimatrixServer {
                 action, validated.topic
             )
         };
-
-        // 4c. vnc-047 (C12, ADR-007): best-effort, NON-GATING tag ack echo on the EXISTING
-        // ack string (no new interface, no read-back API). Echoes the CALLER's own input —
-        // never reads stored cycle_tags, never surfaces the freeze outcome (Non-Goal #6).
-        let tag_phrase = cycle_tag_ack_phrase(validated.cycle_type, params.tags.as_deref());
-        let response_text = format!("{base_ack}{tag_phrase}");
 
         // 5. Audit log (fire-and-forget)
         let metadata_json = match ctx.client_type.as_deref().filter(|s| !s.is_empty()) {
@@ -8162,59 +8134,43 @@ mod tests {
         assert_eq!(params.tags, None);
     }
 
-    // -- vnc-047 (C12): best-effort, NON-GATING ack echo strings (AC-09, FR-12) --
-    // A miss here MUST NOT block delivery/any gate.
+    // -- #944 fix: the MCP handler makes NO tags-recording claim (parity with goal) --
+    // The former `cycle_tag_ack_phrase` accept-for-recording ack was deleted: it lied
+    // (the handler never persisted tags; the hook path does). The response must NOT claim
+    // tags were recorded. `tags` remains a schema field (frame writers read tool_input.tags).
 
     #[test]
-    fn test_ack_start_with_tags_accept_for_recording() {
-        let tags = vec!["arm:A".to_string(), "workflow:v1".to_string()];
-        let phrase = cycle_tag_ack_phrase(CycleType::Start, Some(&tags));
-        assert!(
-            phrase.contains("accepted for recording"),
-            "start-with-tags ack must use accept-for-recording wording: {phrase}"
+    fn test_cycle_start_tags_response_makes_no_recording_claim() {
+        // Regression guard for #944: whatever text the Start arm emits, it must never
+        // assert that run-identity tags were accepted/recorded. Only cycle_cycle_review
+        // is authoritative. We reconstruct the exact base ack the handler builds.
+        let action = "cycle started";
+        let topic = "vnc-047";
+        let goal = "measure arm A reuse";
+        let with_goal = format!(
+            "Acknowledged: {action} for topic '{topic}' with goal: '{goal}'. \
+             Attribution is applied via the hook path (fire-and-forget). \
+             Use context_cycle_review to confirm session attribution."
         );
-        assert!(
-            phrase.contains("context_cycle_review"),
-            "ack must point at context_cycle_review to confirm: {phrase}"
+        let no_goal = format!(
+            "Acknowledged: {action} for topic '{topic}'. \
+             Attribution is applied via the hook path (fire-and-forget). \
+             Use context_cycle_review to confirm session attribution."
         );
-        assert!(phrase.contains('2'), "ack must name the count: {phrase}");
-        assert!(
-            phrase.contains("arm:A") && phrase.contains("workflow:v1"),
-            "ack echoes the caller's own labels verbatim: {phrase}"
-        );
-    }
-
-    #[test]
-    fn test_ack_non_start_with_tags_ignored_note() {
-        let tags = vec!["arm:A".to_string()];
-        for ct in [CycleType::PhaseEnd, CycleType::Stop] {
-            let phrase = cycle_tag_ack_phrase(ct, Some(&tags));
+        for text in [&with_goal, &no_goal] {
             assert!(
-                phrase.contains("tags ignored") && phrase.contains("only recorded at cycle start"),
-                "non-start-with-tags ack must carry the ignored note: {phrase}"
+                !text.contains("accepted for recording"),
+                "ack must not claim tags were recorded: {text}"
+            );
+            assert!(
+                !text.to_lowercase().contains("label"),
+                "ack must not surface run-identity labels: {text}"
+            );
+            assert!(
+                !text.contains("tags ignored"),
+                "ack must not carry a tags-ignored note: {text}"
             );
         }
-    }
-
-    #[test]
-    fn test_ack_no_tags_unchanged() {
-        // No tags, empty, or all-blank → no phrase (pre-vnc-047 ack unchanged).
-        assert_eq!(cycle_tag_ack_phrase(CycleType::Start, None), "");
-        assert_eq!(cycle_tag_ack_phrase(CycleType::Start, Some(&[])), "");
-        let blank = vec!["".to_string(), "   ".to_string()];
-        assert_eq!(cycle_tag_ack_phrase(CycleType::Start, Some(&blank)), "");
-        assert_eq!(cycle_tag_ack_phrase(CycleType::Stop, None), "");
-    }
-
-    #[test]
-    fn test_ack_value_opacity_colon_and_bare_pass_through() {
-        // Colon-prefixed and bare tags both echoed unchanged (no namespace branching).
-        let tags = vec!["bare".to_string(), "ns:val".to_string()];
-        let phrase = cycle_tag_ack_phrase(CycleType::Start, Some(&tags));
-        assert!(
-            phrase.contains("bare") && phrase.contains("ns:val"),
-            "{phrase}"
-        );
     }
 
     // -- col-025: Goal validation logic (AC-13a, AC-17) --

--- a/crates/unimatrix-server/src/uds/parity_corpus_cases_b.rs
+++ b/crates/unimatrix-server/src/uds/parity_corpus_cases_b.rs
@@ -29,6 +29,12 @@ pub(crate) const ARM_KEYS_B: &[&str] = &[
     "cycle::stop",
     "cycle::goal_truncation",
     "cycle::goal_ignored_non_start",
+    // vnc-047 Step 4c tags block (#944): the parity gate that was missing when vnc-047
+    // shipped the oracle change without a corpus case. Mirrors the goal arms above.
+    "cycle::tags",          // start with surviving tags → key present, order preserved
+    "cycle::tags_filtered", // non-string / blank members dropped from the emitted set
+    "cycle::tags_omitted_when_empty", // all-blank / empty tags → key omitted (lock unburned)
+    "cycle::tags_ignored_non_start", // tags present on non-start → key omitted
     // SubagentStart build_request arm
     "build_request::SubagentStart::context_search",
     "build_request::SubagentStart::empty_snippet",
@@ -128,12 +134,22 @@ pub(crate) fn cases() -> Vec<Case> {
     v.push(Case::new(
         "cycle-stop",
         "PreToolUse",
-        &["cycle::stop", "cycle::goal_ignored_non_start"],
-        // goal present but type != start → goal must NOT enter the payload.
+        &[
+            "cycle::stop",
+            "cycle::goal_ignored_non_start",
+            "cycle::tags_ignored_non_start",
+        ],
+        // goal AND tags present but type != start → neither enters the payload
+        // (Step 4c extracts tags for Start only; vnc-047 #944 parity).
         json!({
             "session_id": "sess-corpus",
             "tool_name": "context_cycle",
-            "tool_input": { "type": "stop", "topic": "vnc-026", "goal": "ignored for stop" }
+            "tool_input": {
+                "type": "stop",
+                "topic": "vnc-026",
+                "goal": "ignored for stop",
+                "tags": ["arm:A", "should-not-persist"]
+            }
         })
         .to_string(),
     ));
@@ -155,6 +171,69 @@ pub(crate) fn cases() -> Vec<Case> {
             "session_id": "sess-corpus",
             "tool_name": "context_cycle",
             "tool_input": { "type": "start", "topic": "vnc-026", "goal": "€".repeat(342) }
+        })
+        .to_string(),
+    ));
+
+    // -- vnc-047 Step 4c: cycle_start run-identity tags (#944 parity gate) --
+    //
+    // These pin the hook.rs Step 4c oracle (:860-917): Start-only, string members only,
+    // dropped when blank-after-trim, NO byte cap, key omitted when the surviving set is
+    // empty (so a tagless start leaves the whole-set-once lock unburned). The JS port
+    // (build-request-tools.js) must reproduce these goldens byte-for-byte.
+
+    v.push(Case::new(
+        "cycle-start-tags",
+        "PreToolUse",
+        &["cycle::tags"],
+        // Clean string tags on a start → payload.tags present, order preserved verbatim
+        // (no trim of surviving members, no cap, no namespace parsing of "arm:A").
+        json!({
+            "session_id": "sess-corpus",
+            "tool_name": "context_cycle",
+            "tool_input": {
+                "type": "start",
+                "topic": "vnc-047",
+                "goal": "measure arm A reuse",
+                "tags": ["arm:A", "workflow:v1.3", "region:us-east"]
+            }
+        })
+        .to_string(),
+    ));
+
+    v.push(Case::new(
+        "cycle-start-tags-filtered",
+        "PreToolUse",
+        &["cycle::tags_filtered"],
+        // Mixed members: only string, non-blank-after-trim survive. Non-string members
+        // (number, null, object, nested array) and blank/whitespace strings are dropped.
+        // Oracle result: ["keep", "also-keep"] in input order.
+        json!({
+            "session_id": "sess-corpus",
+            "tool_name": "context_cycle",
+            "tool_input": {
+                "type": "start",
+                "topic": "vnc-047",
+                "tags": ["keep", 42, "", "   ", "also-keep", null, {"o": 1}, ["nested"]]
+            }
+        })
+        .to_string(),
+    ));
+
+    v.push(Case::new(
+        "cycle-start-tags-empty",
+        "PreToolUse",
+        &["cycle::tags_omitted_when_empty"],
+        // All members blank-after-trim → surviving set empty → tags key OMITTED entirely
+        // (payload carries feature_cycle only). Keeps the whole-set-once lock unburned.
+        json!({
+            "session_id": "sess-corpus",
+            "tool_name": "context_cycle",
+            "tool_input": {
+                "type": "start",
+                "topic": "vnc-047",
+                "tags": ["", "   ", "\t"]
+            }
         })
         .to_string(),
     ));

--- a/packages/unimatrix/lib/hook-client/build-request-tools.js
+++ b/packages/unimatrix/lib/hook-client/build-request-tools.js
@@ -323,8 +323,10 @@ function buildCycleEventOrFallthrough(event, sessionId, input) {
   put("goal", goal);
 
   // tags only on Start (vnc-047, hook.rs:860-917). Value-opacity: strings only,
-  // dropped when blank-after-trim, NO byte cap (parity — the oracle has none;
-  // contrast MAX_GOAL_BYTES on goal). Omit the key entirely when nothing
+  // dropped when blank-after-trim. The ABSENCE of a byte/count cap is INTENTIONAL
+  // — the oracle (hook.rs Step 4c) has none (value-opacity, no MAX_*_BYTES);
+  // do NOT add one here or it breaks parity with the oracle and the goldens
+  // (contrast MAX_GOAL_BYTES on goal). Omit the key entirely when nothing
   // survives, so a tagless/all-blank start leaves the whole-set-once lock
   // unburned (server C5 routes an empty-tags start to the unchanged arm).
   // Placed AFTER put("goal") and fully guarded: any malformed input (non-array,

--- a/packages/unimatrix/lib/hook-client/build-request-tools.js
+++ b/packages/unimatrix/lib/hook-client/build-request-tools.js
@@ -322,6 +322,28 @@ function buildCycleEventOrFallthrough(event, sessionId, input) {
   put("next_phase", validated.nextPhase);
   put("goal", goal);
 
+  // tags only on Start (vnc-047, hook.rs:860-917). Value-opacity: strings only,
+  // dropped when blank-after-trim, NO byte cap (parity — the oracle has none;
+  // contrast MAX_GOAL_BYTES on goal). Omit the key entirely when nothing
+  // survives, so a tagless/all-blank start leaves the whole-set-once lock
+  // unburned (server C5 routes an empty-tags start to the unchanged arm).
+  // Placed AFTER put("goal") and fully guarded: any malformed input (non-array,
+  // null, nested junk, non-string members) degrades to no key and MUST NEVER
+  // throw — a throw here drops the entire cycle frame (topic + goal + tags).
+  let tags = null;
+  if (validated.cycleType === "start") {
+    try {
+      const raw = tiObj.tags;
+      if (Array.isArray(raw)) {
+        const filtered = raw.filter((t) => typeof t === "string" && t.trim() !== "");
+        if (filtered.length > 0) tags = filtered;
+      }
+    } catch (_e) {
+      tags = null; // infallible (FR-03.7): treat any problem as no tags
+    }
+  }
+  put("tags", tags);
+
   // topic_signal = topic (the cycle declaration keeps it).
   return recordEventFrame(eventType, sessionId, payload, validated.topic, input.provider);
 }

--- a/packages/unimatrix/test/fixtures/parity/MANIFEST.json
+++ b/packages/unimatrix/test/fixtures/parity/MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "generated_by": "parity_corpus_gen.rs",
-  "case_count": 76,
+  "case_count": 79,
   "conventions": {
     "transcript_path": "relative transcript_path values in stdin.json resolve against the case directory",
     "stdin_cap_bytes": 1048576,
@@ -111,6 +111,18 @@
     ],
     "cycle::stop": [
       "cycle-stop"
+    ],
+    "cycle::tags": [
+      "cycle-start-tags"
+    ],
+    "cycle::tags_filtered": [
+      "cycle-start-tags-filtered"
+    ],
+    "cycle::tags_ignored_non_start": [
+      "cycle-stop"
+    ],
+    "cycle::tags_omitted_when_empty": [
+      "cycle-start-tags-empty"
     ],
     "extract_file_path::absent": [
       "ptu-bash-exit-zero"

--- a/packages/unimatrix/test/fixtures/parity/cycle-start-tags-empty/event.txt
+++ b/packages/unimatrix/test/fixtures/parity/cycle-start-tags-empty/event.txt
@@ -1,0 +1,1 @@
+PreToolUse

--- a/packages/unimatrix/test/fixtures/parity/cycle-start-tags-empty/expected-request.json
+++ b/packages/unimatrix/test/fixtures/parity/cycle-start-tags-empty/expected-request.json
@@ -1,0 +1,11 @@
+{
+  "type": "RecordEvent",
+  "event_type": "cycle_start",
+  "session_id": "sess-corpus",
+  "timestamp": 0,
+  "payload": {
+    "feature_cycle": "vnc-047"
+  },
+  "topic_signal": "vnc-047",
+  "provider": "claude-code"
+}

--- a/packages/unimatrix/test/fixtures/parity/cycle-start-tags-empty/stdin.json
+++ b/packages/unimatrix/test/fixtures/parity/cycle-start-tags-empty/stdin.json
@@ -1,0 +1,1 @@
+{"session_id":"sess-corpus","tool_name":"context_cycle","tool_input":{"type":"start","topic":"vnc-047","tags":["","   ","\t"]}}

--- a/packages/unimatrix/test/fixtures/parity/cycle-start-tags-filtered/event.txt
+++ b/packages/unimatrix/test/fixtures/parity/cycle-start-tags-filtered/event.txt
@@ -1,0 +1,1 @@
+PreToolUse

--- a/packages/unimatrix/test/fixtures/parity/cycle-start-tags-filtered/expected-request.json
+++ b/packages/unimatrix/test/fixtures/parity/cycle-start-tags-filtered/expected-request.json
@@ -1,0 +1,15 @@
+{
+  "type": "RecordEvent",
+  "event_type": "cycle_start",
+  "session_id": "sess-corpus",
+  "timestamp": 0,
+  "payload": {
+    "feature_cycle": "vnc-047",
+    "tags": [
+      "keep",
+      "also-keep"
+    ]
+  },
+  "topic_signal": "vnc-047",
+  "provider": "claude-code"
+}

--- a/packages/unimatrix/test/fixtures/parity/cycle-start-tags-filtered/stdin.json
+++ b/packages/unimatrix/test/fixtures/parity/cycle-start-tags-filtered/stdin.json
@@ -1,0 +1,1 @@
+{"session_id":"sess-corpus","tool_name":"context_cycle","tool_input":{"type":"start","topic":"vnc-047","tags":["keep",42,"","   ","also-keep",null,{"o":1},["nested"]]}}

--- a/packages/unimatrix/test/fixtures/parity/cycle-start-tags/event.txt
+++ b/packages/unimatrix/test/fixtures/parity/cycle-start-tags/event.txt
@@ -1,0 +1,1 @@
+PreToolUse

--- a/packages/unimatrix/test/fixtures/parity/cycle-start-tags/expected-request.json
+++ b/packages/unimatrix/test/fixtures/parity/cycle-start-tags/expected-request.json
@@ -1,0 +1,17 @@
+{
+  "type": "RecordEvent",
+  "event_type": "cycle_start",
+  "session_id": "sess-corpus",
+  "timestamp": 0,
+  "payload": {
+    "feature_cycle": "vnc-047",
+    "goal": "measure arm A reuse",
+    "tags": [
+      "arm:A",
+      "workflow:v1.3",
+      "region:us-east"
+    ]
+  },
+  "topic_signal": "vnc-047",
+  "provider": "claude-code"
+}

--- a/packages/unimatrix/test/fixtures/parity/cycle-start-tags/stdin.json
+++ b/packages/unimatrix/test/fixtures/parity/cycle-start-tags/stdin.json
@@ -1,0 +1,1 @@
+{"session_id":"sess-corpus","tool_name":"context_cycle","tool_input":{"type":"start","topic":"vnc-047","goal":"measure arm A reuse","tags":["arm:A","workflow:v1.3","region:us-east"]}}

--- a/packages/unimatrix/test/fixtures/parity/cycle-stop/stdin.json
+++ b/packages/unimatrix/test/fixtures/parity/cycle-stop/stdin.json
@@ -1,1 +1,1 @@
-{"session_id":"sess-corpus","tool_name":"context_cycle","tool_input":{"type":"stop","topic":"vnc-026","goal":"ignored for stop"}}
+{"session_id":"sess-corpus","tool_name":"context_cycle","tool_input":{"type":"stop","topic":"vnc-026","goal":"ignored for stop","tags":["arm:A","should-not-persist"]}}

--- a/packages/unimatrix/test/hook-client/build-request.test.js
+++ b/packages/unimatrix/test/hook-client/build-request.test.js
@@ -564,6 +564,108 @@ describe("buildRequest: PreToolUse context_cycle interception", () => {
     assert.ok(out.startsWith("x"));
   });
 
+  // vnc-047 / #944: tags ride the hook exactly like goal (Start-only, string
+  // filter, omit-when-empty). Parity oracle: hook.rs:860-917. Infallibility is
+  // load-bearing — a throw here would drop the whole cycle frame incl. goal.
+  it("test_cycle_tags_forwarded_on_start", () => {
+    const r = buildRequest(
+      "PreToolUse",
+      mkInput({
+        extra: {
+          tool_name: "context_cycle",
+          tool_input: { type: "start", topic: "x-1", tags: ["alpha", "beta"] },
+        },
+      })
+    );
+    assert.deepStrictEqual(r.payload.tags, ["alpha", "beta"]);
+  });
+
+  it("test_cycle_tags_non_string_members_filtered", () => {
+    const r = buildRequest(
+      "PreToolUse",
+      mkInput({
+        extra: {
+          tool_name: "context_cycle",
+          tool_input: {
+            type: "start",
+            topic: "x-1",
+            tags: ["keep", 42, null, { a: 1 }, "", "  ", "also-keep"],
+          },
+        },
+      })
+    );
+    // strings only, blank-after-trim dropped; opaque colon-prefixed kept as-is.
+    assert.deepStrictEqual(r.payload.tags, ["keep", "also-keep"]);
+  });
+
+  it("test_cycle_tags_omitted_when_empty_or_absent", () => {
+    const absent = buildRequest(
+      "PreToolUse",
+      mkInput({
+        extra: {
+          tool_name: "context_cycle",
+          tool_input: { type: "start", topic: "x-1" },
+        },
+      })
+    );
+    assert.ok(!("tags" in absent.payload), "tags omitted when absent");
+
+    const emptyArr = buildRequest(
+      "PreToolUse",
+      mkInput({
+        extra: {
+          tool_name: "context_cycle",
+          tool_input: { type: "start", topic: "x-1", tags: [] },
+        },
+      })
+    );
+    assert.ok(!("tags" in emptyArr.payload), "tags omitted when empty array");
+
+    const allBlank = buildRequest(
+      "PreToolUse",
+      mkInput({
+        extra: {
+          tool_name: "context_cycle",
+          tool_input: { type: "start", topic: "x-1", tags: ["", "   ", 7] },
+        },
+      })
+    );
+    assert.ok(!("tags" in allBlank.payload), "tags omitted when nothing survives");
+  });
+
+  it("test_cycle_tags_malformed_never_throws_and_keeps_goal", () => {
+    // Each malformed shape must omit tags, never throw, and still forward goal.
+    for (const bad of [null, "not-an-array", 42, { 0: "a" }, [{ x: 1 }], [[1]]]) {
+      const r = buildRequest(
+        "PreToolUse",
+        mkInput({
+          extra: {
+            tool_name: "context_cycle",
+            tool_input: { type: "start", topic: "x-1", goal: "ship it", tags: bad },
+          },
+        })
+      );
+      assert.ok(r !== null, "cycle frame survives malformed tags");
+      assert.ok(!("tags" in r.payload), "tags omitted for malformed input");
+      assert.strictEqual(r.payload.goal, "ship it", "goal survives bad tags");
+    }
+  });
+
+  it("test_cycle_tags_never_on_phase_end_or_stop", () => {
+    for (const type of ["phase-end", "stop"]) {
+      const ti =
+        type === "phase-end"
+          ? { type, topic: "x-1", phase: "design", next_phase: "delivery", tags: ["nope"] }
+          : { type, topic: "x-1", outcome: "success", tags: ["nope"] };
+      const r = buildRequest(
+        "PreToolUse",
+        mkInput({ extra: { tool_name: "context_cycle", tool_input: ti } })
+      );
+      assert.ok(r !== null, "non-start cycle frame builds");
+      assert.ok(!("tags" in r.payload), "tags never emitted on " + type);
+    }
+  });
+
   it("test_cycle_mcp_context_promotion_does_not_mutate_input", () => {
     const input = mkInput({
       session_id: "gem-1",

--- a/product/test/infra-001/suites/test_tools.py
+++ b/product/test/infra-001/suites/test_tools.py
@@ -5799,18 +5799,3 @@ def test_context_cycle_accepts_tags_param(server):
         {"type": "start", "topic": "vnc047-accepts-tags", "tags": ["arm:A", "mode:fast"], "agent_id": "human"},
     )
     assert_tool_success(resp)
-
-
-def test_context_cycle_ack_echoes_tags(server):
-    """T-VNC047-02 (AC-09, NON-GATING): best-effort ack echo — a start-with-tags call's
-    ack string contains the accept-for-recording note. Best-effort SHOULD; a miss here
-    does NOT fail delivery (R-16)."""
-    resp = server.call_tool(
-        "context_cycle",
-        {"type": "start", "topic": "vnc047-ack-echo", "tags": ["arm:A"], "agent_id": "human"},
-    )
-    assert_tool_success(resp)
-    text = get_result_text(resp)
-    assert "accepted for recording" in text, (
-        f"AC-09 best-effort ack echo missing accept-for-recording note (NON-GATING): {text!r}"
-    )


### PR DESCRIPTION
## Root cause (v3, authoritative)
vnc-047 added a \`tags\` field to \`context_cycle(start)\`, meant to ride the hook and persist server-side exactly like \`goal\`. Two defects shipped instead:

1. **Tags never reached the server.** The deployed **JS hook-client** (\`build-request-tools.js\`) is *field-selective* — it builds the outbound payload from a whitelist and was given a \`goal\` block but never a \`tags\` block. So \`insert_cycle_start_with_tags\` was never reached and \`cycle_tags\` stayed empty in **every live session**. (The Rust \`hook.rs\` tags code exists but is only the parity *oracle*, not on the live path.)
2. **The MCP handler lied.** \`cycle_tag_ack_phrase\` claimed tags were "accepted for recording" for input the handler dropped — a silent accept-and-drop.

The server write/read path and the whole-set-once freeze guard (keyed on \`cycle_tags\` rows) were already correct and are **untouched**.

## Fix
- **JS** (\`packages/unimatrix/lib/hook-client/build-request-tools.js\`): forward a \`tags\` key on cycle_start — start-only, strings-only, omit-when-empty, **infallible** (malformed tags degrade to no-key and can never drop the cycle event). Mirrors the \`hook.rs\` Step 4c oracle. +5 unit tests.
- **Rust** (\`crates/unimatrix-server/src/mcp/tools.rs\`): delete \`cycle_tag_ack_phrase\` + call site; keep the load-bearing \`CycleParams.tags\` field. Removed 4 obsolete ack tests, added a negative-ack test.
- **Parity gate** (\`parity_corpus_cases_b.rs\` + goldens): add \`cycle::tags\` cases — the guard whose absence let this ship. The start-with-tags golden now contains the \`tags\` key.
- **Test cleanup**: deleted obsolete Python \`test_context_cycle_ack_echoes_tags\`.

## Semantics (confirmed with owner)
Write-once-set per feature cycle: an empty first start does **not** lock; a later start carrying tags writes and locks; once a non-empty set exists it is frozen (no add/modify). ADR-002 unchanged — the fix just makes the already-shipped semantic *reachable*.

## Verification
Phase 3 PASS — Rust 4542, JS 779, parity 24/24, \`cargo test --workspace\` rc=0, clippy clean, smoke 35/35. Gate: Bug Fix Validation **PASS (7/7)**.

## Delivery follow-ups
- ADR-007 #5659 (ack-echo clause) to be \`context_correct\`'d — withdraw only the ack-echo part.
- Post-merge: rebuild server binary + refresh \`~/.unimatrix/dogfood-client\` (stale-binary rollout).
- Follow-up #945: retire the now-oracle-only Rust hook client.

Closes #944.

🤖 Generated with [Claude Code](https://claude.com/claude-code)