### PR TITLE
test(infra-001): bump tool-count assertion 14→15 for context_tag (#942)

### DIFF
--- a/product/test/infra-001/suites/test_tools.py
+++ b/product/test/infra-001/suites/test_tools.py
@@ -3322,20 +3322,21 @@ def _store_two_entries(server):
 # --- AC-19: context_edge tool registered as 13th tool -----------------
 
 
-@pytest.mark.xfail(reason="Pre-existing: GH#942 — hardcoded tool count 14 stale after vnc-045 added context_tag (15th tool); unrelated to vnc-047")
 def test_context_edge_tool_registered(server):
     """AC-19: context_edge is registered as an MCP tool with the correct parameter schema.
 
-    Updated from 13 to 14 tools (vnc-018 adds context_graph as the 14th tool).
-    The important assertion is context_edge presence and schema, not the exact count
-    (which is asserted separately in test_protocol.py::test_list_tools_returns_fourteen).
+    The tool count reached 15 with vnc-045 (#929) adding context_tag. The count
+    assertion is intentional: a new MCP tool must consciously bump it (and add its
+    own presence check), guarding against silent registry drift. The primary
+    assertions remain context_edge presence and schema.
     """
     resp = server.list_tools()
     result = resp.result
     tools = result.get("tools", [])
-    assert len(tools) == 14, f"Expected 14 tools (context_graph added in vnc-018), got {len(tools)}"
+    assert len(tools) == 15, f"Expected 15 tools (context_tag added in vnc-045), got {len(tools)}"
     names = [t["name"] for t in tools]
     assert "context_edge" in names, f"context_edge not in tools: {names}"
+    assert "context_tag" in names, f"context_tag not in tools: {names}"
     edge_tool = next(t for t in tools if t["name"] == "context_edge")
     schema = edge_tool.get("inputSchema", {})
     props = schema.get("properties", {})


### PR DESCRIPTION
Fixes #942.

## What

`test_context_edge_tool_registered` hardcoded `len(tools) == 14`, stale since vnc-045 (#929) added `context_tag` as the 15th MCP tool. It was marked `@pytest.mark.xfail` during vnc-047 so it wouldn't block that PR.

## Changes (single file, `product/test/infra-001/suites/test_tools.py`)

- Remove the `xfail` marker
- Bump the assertion `14 → 15` and its message
- Add a `context_tag` presence assertion
- Refresh the docstring (drops the dead `test_list_tools_returns_fourteen` reference)

The exact-count assertion is kept deliberately: a future tool must consciously bump it (and add its own presence check), guarding against silent registry drift.

## Verification

```
suites/test_tools.py::test_context_edge_tool_registered PASSED
```

Real green, not xfail. Swept the suite — this was the only hardcoded count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)