### PR TITLE
docs(platform): Unimatrix-as-platform vision + goal:platform + ass-102 scope

### DIFF
--- a/product/PRODUCT-VISION.md
+++ b/product/PRODUCT-VISION.md
@@ -14,6 +14,8 @@ The key mental model: workflow definitions, agent definitions, and skill definit
 
 Built for agentic software delivery. Configurable for any workflow-centric domain.
 
+**Unimatrix is a platform.** A self-learning knowledge engine with a stable, presented extension contract. Domain solutions — a delivery harness, a research harness, a monitoring stack — are built *on* it, not *into* it: they configure its domain layer, plug their own policy (identity, cost, gates) into its seams, and consume its memory over MCP. The engine is the platform; each solution is an extension along clean, delineated lines. The developer experience of that extension surface is a first-class concern — the seams are documented, versioned, and presented as a product, not left implicit.
+
 ---
 
 ## Story
@@ -37,6 +39,7 @@ Five strategic goals drive all roadmap decisions. Each is maintained as an enric
 | Proactive knowledge delivery | `proactive-delivery` | Knowledge arrives before agents search for it — phase-conditioned, session-aware |
 | Developer-friendly deployment | `personal-cloud` | One container, one bearer token, one command — full pipeline fidelity over HTTPS |
 | Domain-agnostic platform | `domain-agnostic` | Any domain, configured not rebuilt — validated on SDLC and research workflows |
+| Extensible platform surface | `platform` | The extension contract (domain config, policy/auth seams, memory+capability substrate over MCP/SDK) is presented, versioned, and DevX-first — solutions extend it, never reach into it |
 
 Query current goal content: `context_lookup(category="goal", tags=["goal", "{tag}"])`
 
@@ -46,6 +49,7 @@ Feature delivery is tracked via GitHub Issues with `goal:*` labels:
 - `goal:proactive-delivery` — injection, briefing, session context
 - `goal:personal-cloud` — container, HTTPS, auth, multi-LLM
 - `goal:domain-agnostic` — config externalization, domain packs, multi-retrieval
+- `goal:platform` — extension contract, policy/auth seams, plugin DevX, presented+versioned seams
 
 ---
 

--- a/product/research/ass-102/SCOPE.md
+++ b/product/research/ass-102/SCOPE.md
@@ -1,0 +1,47 @@
+# SCOPE: ass-102 — Extensible-platform assessment + capability breakdown for `goal:platform`
+
+**Goal advanced**: `goal:platform` — Extensible platform surface (Unimatrix #5689)
+**Type**: assessment / design-research (read-only; no build)
+**Grounding**: platform/plugin reframe (uni-zero, 2026-07-18); ass-100/101 (identity seam); domain-agnostic goal + capabilities; packaging conclusions (dug-21/jurati#12)
+
+---
+
+## The question
+
+Unimatrix has adopted a **platform** framing (PRODUCT-VISION.md): a self-learning knowledge engine with a *presented, versioned, DevX-first extension contract*, on which domain solutions are built rather than baked in. The goal entry `#5689` is thin and emerging. This spike produces the **assessment and candidate capability breakdown** that turns it actionable.
+
+**Primary question**: What is the current state of Unimatrix's extension surface (across the L1/L2/L3 layers below), and what **objectives + behaviorally-proven capability decomposition** would deliver a presented, versioned, DevX-first extension contract?
+
+The three layers to assess:
+- **L1 — domain config**: categories, confidence weights, server instructions, observation domain packs.
+- **L2 — policy/auth seams**: the relying-party identity verifier (swappable trusted issuer), BearerValidator, observation ingestion sources — the seams where a solution supplies the policy Unimatrix declined (identity, cost, gates).
+- **L3 — solution contract**: the memory + capability-map substrate over the MCP wire + client SDK; the two hard co-evolution seams (wire stability + SDK semver).
+
+## Why it matters
+
+- `goal:platform` cannot be sequenced or claimed without a capability breakdown — "what's proven vs what's left" is undefined today.
+- The platform framing consolidates currently-**loose threads** (scattered seams: domain packs, BearerValidator, trusted-issuer verifier, observation ingestion, capability substrate, client SDK) into one contract — this spike is where that consolidation gets its evidence.
+- The **enterprise extension story** (internal enterprise devs extend Unimatrix along clean lines) depends on this contract being real and presented, not implicit.
+- DevX has no home in the current goals; this spike establishes the baseline it must improve against.
+
+## What to explore (bounded)
+
+1. **Seam inventory + state.** Enumerate the existing extension points across L1/L2/L3 (code + config + docs). For each: is it *presented* (documented, discoverable) or *implicit*? *Versioned* or not? What's its stability contract today?
+2. **DevX baseline.** What does it actually take, today, to (a) add a domain pack (L1), (b) add a policy/auth seam consumer (L2), (c) stand up a new domain solution (L3)? Where are the sharp edges, undocumented steps, internals-reaching requirements?
+3. **The identity seam as the reference L2.** Assess the ass-100/101 relying-party verifier + client-SDK identity plugin: is it *generic* (any issuer) or Jurati-shaped? What would make it a clean, presented L2 seam?
+4. **Real L3 evidence.** Cross-reference the domain solutions that already exercise the engine — SDLC (Jurati), research (ASS-057, `uni-research-*`), environmental/data (`ndp-*` roster). Which seams do they actually use? Which are exercised vs assumed?
+5. **Candidate capability decomposition.** Propose a candidate objectives list and capability breakdown (functional + nfr), with draft `done_when` phrasing, and a first-pass status read (proven / partial / missing / asserted) for each against today's codebase. Distinguish **claim-floor** (minimum to claim the goal) from **north-star** (curve).
+
+## Expected output (FINDINGS.md)
+
+- **(a) Seam inventory + state table** — every L1/L2/L3 extension point, presented-vs-implicit, versioned-vs-not, current stability contract.
+- **(b) DevX gap assessment** — the concrete friction to extend at each layer today; the sharpest edges.
+- **(c) Candidate capability decomposition** — proposed objectives + capabilities (functional + nfr) with draft `done_when` and first-pass status. Framed as *input for uni-zero to author* into the capability map (research synthesizes; uni-zero authors — the uni-capability firewall).
+- **(d) Prove-core-seam-rest recommendation** — which capabilities are claim-floor (proven on the real domains: SDLC + research) vs which are seams to promote only on evidence. Explicitly hold the "no speculative plugin SDK" line.
+
+## Constraints / prior art
+
+- **No build.** Options + assessment + candidate decomposition that feed a uni-zero authoring pass; does not amend ADRs or ship code.
+- **Do not author the capability nodes.** The spike *proposes* the breakdown; uni-zero authors the outcome-phrased capabilities (firewall discipline).
+- **Prior art to build on**: goal `#5689`; the domain-agnostic goal + its capabilities (DA1–DA9, NX-*); ass-100/101 FINDINGS (identity/root-of-trust); the packaging thread (dug-21/jurati#12); jurati #1/#2 (what the Unimatrix package ships vs doesn't). Use the `uni-capability` skill for the decomposition format.
+- **Out of scope**: designing a general plugin SDK; Jurati-internal shape; any single solution's roster/spine.


### PR DESCRIPTION
## Summary
Evolves Unimatrix's vision to a **platform** framing — domain solutions are built *on* it (configuring the domain layer, plugging policy into seams, consuming memory over MCP), never baked in. Keeps a clean "what it IS vs what it BECOMES" boundary and makes the extension surface + DevX a first-class concern.

## Changes
- **`PRODUCT-VISION.md`**: platform paragraph in the Vision section; new **Extensible platform surface** goal row + `goal:platform` label.
- **`product/research/ass-102/SCOPE.md`**: scopes the capability-breakdown assessment for `goal:platform`.

## Already applied (Unimatrix records)
- Goal **#5689 "Extensible platform surface"** authored (`Advances` vision root).
- Vision root corrected **#4671 → #5690** to carry the platform framing (6 incoming goal edges redirected).
- `goal:platform` GitHub label created; issue **#956** (ass-102) filed.

## Notes
Vision/goal docs only — no code. ass-102 is scoped, not executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)