### PR TITLE
fix(vector): membership-filter IdMap at load to detect graph-under-counts-DB after DB copy (#972)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,9 @@ patches/anndists/target/
 
 # Documentation and product files
 product/
+# ...but the infra-001 integration test harness is COPYd by its Dockerfile
+# (test-runtime stage) and must remain in the build context.
+!product/test/infra-001/
 *.md
 !README.md
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,6 +3929,7 @@ dependencies = [
  "rand 0.9.2",
  "tempfile",
  "tokio",
+ "tracing",
  "unimatrix-store",
 ]
 

--- a/crates/unimatrix-server/src/test_support.rs
+++ b/crates/unimatrix-server/src/test_support.rs
@@ -111,32 +111,34 @@ impl TestHarness {
     ///
     /// Returns `None` if the ONNX model is not available.
     pub async fn new_with_expander(store_path: &Path, ppr_expander_enabled: bool) -> Option<Self> {
-        if skip_if_no_model() {
-            return None;
-        }
-
+        let embed_handle = Self::load_embed_handle().await?;
         let store =
             unimatrix_store::SqlxStore::open(store_path, unimatrix_store::PoolConfig::default())
                 .await
                 .expect("failed to open test store");
         let store = Arc::new(store);
-
-        let vector_config = VectorConfig::default();
         let vector_index = Arc::new(
-            VectorIndex::new(Arc::clone(&store), vector_config)
+            VectorIndex::new(Arc::clone(&store), VectorConfig::default())
                 .expect("failed to create vector index"),
         );
+        Some(Self::wire(
+            store,
+            vector_index,
+            embed_handle,
+            ppr_expander_enabled,
+        ))
+    }
 
-        let vector_adapter = VectorAdapter::new(Arc::clone(&vector_index));
-
-        let entry_store = Arc::clone(&store);
-        let vector_store = Arc::new(AsyncVectorStore::new(Arc::new(vector_adapter)));
-
+    /// Build (and await readiness of) the shared ONNX embed handle. `None` when the
+    /// model is unavailable (same `skip_if_no_model()` semantics as `new`). Exposed so a
+    /// round-trip test can share ONE handle across the dump → `VectorIndex::load` → heal
+    /// phases (bugfix-972 Leg 2), authoring the graph before the harness exists.
+    pub async fn load_embed_handle() -> Option<Arc<EmbedServiceHandle>> {
+        if skip_if_no_model() {
+            return None;
+        }
         let embed_handle = EmbedServiceHandle::new();
-        let config = EmbedConfig::default();
-        embed_handle.start_loading(config, None);
-
-        // Wait for model to load
+        embed_handle.start_loading(EmbedConfig::default(), None);
         let mut attempts = 0;
         loop {
             match embed_handle.get_adapter().await {
@@ -151,6 +153,30 @@ impl TestHarness {
                 }
             }
         }
+        Some(embed_handle)
+    }
+
+    /// Construct a harness around a pre-built store, a (possibly pre-loaded) vector index,
+    /// and an embed handle (PPR expander OFF). Enables the bugfix-972 Leg 2 round-trip:
+    /// author+dump a graph, inject a DB-only-copy under-count, `VectorIndex::load`, heal.
+    pub async fn from_parts(
+        store: Arc<Store>,
+        vector_index: Arc<VectorIndex>,
+        embed_handle: Arc<EmbedServiceHandle>,
+    ) -> Self {
+        Self::wire(store, vector_index, embed_handle, false)
+    }
+
+    /// Wire a full `ServiceLayer`; body is the pre-refactor `new_with_expander` verbatim.
+    fn wire(
+        store: Arc<Store>,
+        vector_index: Arc<VectorIndex>,
+        embed_handle: Arc<EmbedServiceHandle>,
+        ppr_expander_enabled: bool,
+    ) -> Self {
+        let vector_adapter = VectorAdapter::new(Arc::clone(&vector_index));
+        let entry_store = Arc::clone(&store);
+        let vector_store = Arc::new(AsyncVectorStore::new(Arc::new(vector_adapter)));
 
         let adapt_service = Arc::new(AdaptationService::new(
             unimatrix_adapt::AdaptConfig::default(),
@@ -169,12 +195,7 @@ impl TestHarness {
                 .expect("test RayonPool construction must succeed"),
         );
 
-        // crt-053: start from the production default config and toggle only the expander flag,
-        // so OFF (default) construction stays bit-identical to pre-crt-053 behavior. All PPR knobs
-        // (alpha, blend weight, inclusion threshold, depth, ceilings) remain at production defaults
-        // — the seed-filter tests observe the Phase 0 `graph_expand` injection at production parity,
-        // isolating it via a topic filter (which excludes graph-injectable neighbors from the HNSW
-        // pool) rather than by altering scoring config.
+        // crt-053: toggle only the expander flag; OFF stays bit-identical to pre-crt-053.
         let inference_config = crate::infra::config::InferenceConfig {
             ppr_expander_enabled,
             ..crate::infra::config::InferenceConfig::default()
@@ -207,18 +228,60 @@ impl TestHarness {
             // nan-018 (ADR-006): default penalties for the test harness (production parity).
             unimatrix_engine::graph::GraphPenaltyParams::default(),
         );
-
-        Some(TestHarness {
+        TestHarness {
             layer,
             store,
             vector_index,
             embed_handle,
-        })
+        }
     }
 
     /// Get a reference to the underlying store.
     pub fn store(&self) -> &Store {
         &self.store
+    }
+
+    /// The `Arc<Store>` this harness wraps (bugfix-972 Leg 2 round-trip setup).
+    pub fn store_arc(&self) -> &Arc<Store> {
+        &self.store
+    }
+
+    /// The vector index this harness wraps — the SAME `Arc` passed to `from_parts`,
+    /// so a test can assert `contains` before/after the maintenance heal (bugfix-972).
+    pub fn vector_index(&self) -> &Arc<VectorIndex> {
+        &self.vector_index
+    }
+
+    /// Drive one maintenance pass through the SAME `StatusService::run_maintenance` path
+    /// the background tick uses. `graph_stale_ratio = 0` (`StatusReport::default`) keeps
+    /// compaction from firing, isolating the heal pass (Sub-case B:
+    /// `embedding_dim > 0 && !contains`) as the repopulation mechanism (bugfix-972 Leg 2).
+    pub async fn run_maintenance_heal(&self) {
+        let active_entries = self
+            .store
+            .load_active_entries_with_tags()
+            .await
+            .expect("load_active_entries_with_tags must succeed in test");
+        let mut report = crate::mcp::response::status::StatusReport::default();
+        let session_registry = crate::infra::session::SessionRegistry::new();
+        let pending = Arc::new(std::sync::Mutex::new(
+            crate::server::PendingEntriesAnalysis::new(),
+        ));
+        let inference_config = crate::infra::config::InferenceConfig::default();
+        let retention_config = crate::infra::config::RetentionConfig::default();
+        self.layer
+            .status
+            .run_maintenance(
+                &active_entries,
+                &mut report,
+                &session_registry,
+                &self.store,
+                &pending,
+                &inference_config,
+                &retention_config,
+            )
+            .await
+            .expect("run_maintenance must succeed in test");
     }
 
     /// crt-053 (test support): embed each entry's stored text and insert it into the HNSW

--- a/crates/unimatrix-server/tests/heal_roundtrip_972.rs
+++ b/crates/unimatrix-server/tests/heal_roundtrip_972.rs
@@ -1,0 +1,180 @@
+//! Server-level round-trip test for bugfix #972, Leg 2.
+//!
+//! Bug #972: after a DB-only copy (`unimatrix.db` moved WITHOUT the HNSW index
+//! dir), `vector_map` records more mappings than the loaded graph holds. The fix
+//! (crates/unimatrix-vector/src/persistence.rs) membership-filters the rebuilt
+//! IdMap in `VectorIndex::load` to graph-present origin_ids, so `contains()` is
+//! truthful (Leg 1). This test proves Leg 2 — the DoD headline outcome — that the
+//! EXISTING capped maintenance heal (services/status.rs Sub-case B, guarded by
+//! `embedding_dim > 0 && !contains`) then FIRES and retrieval self-repopulates the
+//! previously-missing entry, WITHOUT any manual `DELETE FROM vector_map`.
+//!
+//! Requires the ONNX model (the heal re-embeds from stored content). Skips
+//! gracefully when the model is absent — same `skip_if_no_model()` gate as the
+//! other embed-dependent server tests (pipeline_e2e.rs). In a container without
+//! libonnxruntime this test self-skips; it executes fully under Docker.
+
+use std::sync::Arc;
+
+use unimatrix_core::{EmbedService, VectorConfig, VectorIndex};
+use unimatrix_server::test_support::{TestHarness, skip_if_no_model};
+use unimatrix_store::{NewEntry, PoolConfig, SqlxStore, Status};
+
+/// data_id deliberately absent from the authored graph (present ids are 0..N-1),
+/// so the load-time membership filter drops the injected mapping.
+const ABSENT_DATA_ID: u64 = 9_000_000;
+
+fn new_entry(title: &str, content: &str) -> NewEntry {
+    NewEntry {
+        title: title.to_string(),
+        content: content.to_string(),
+        topic: "test".to_string(),
+        category: "vector".to_string(),
+        tags: vec![],
+        source: "test".to_string(),
+        status: Status::Active,
+        created_by: "test".to_string(),
+        feature_cycle: "bugfix-972".to_string(),
+        trust_source: "human".to_string(),
+    }
+}
+
+/// GH#972 Leg 2: a DB-only-copy under-count load drops the graph-absent mapping
+/// (membership filter), then the maintenance heal (Sub-case B) re-embeds the entry
+/// from its stored content, re-inserts the HNSW point, and the entry becomes
+/// retrievable again — end-to-end, through the real server maintenance path.
+#[tokio::test]
+async fn test_maintenance_heal_repopulates_graph_undercount_after_db_only_copy_load() {
+    if skip_if_no_model() {
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("test.db");
+    let dump_dir = dir.path().join("index");
+
+    // ONE embed handle shared across author → dump → load → heal (the graph must be
+    // authored before the harness, which wraps the *loaded* index, is constructed).
+    let embed_handle = match TestHarness::load_embed_handle().await {
+        Some(h) => h,
+        None => return, // model unavailable — skip
+    };
+    let adapter = embed_handle
+        .get_adapter()
+        .await
+        .expect("embed adapter must be ready after load_embed_handle");
+
+    let store = Arc::new(
+        SqlxStore::open(&db_path, PoolConfig::default())
+            .await
+            .expect("open store"),
+    );
+
+    // ---- Phase A: author a graph with PRESENT entries, then dump it ----
+    // These land in the HNSW graph (data_ids 0..N-1) and in vector_map; the dump
+    // captures them. Set embedding_dim > 0 so they are NOT swept by heal Sub-case A.
+    let vi = Arc::new(
+        VectorIndex::new(Arc::clone(&store), VectorConfig::default()).expect("create index"),
+    );
+    let mut present_ids: Vec<u64> = Vec::new();
+    for i in 0..20 {
+        let eid = store
+            .insert(new_entry(
+                &format!("Generic filler entry {i}"),
+                &format!("Routine background content number {i} with no distinctive terms"),
+            ))
+            .await
+            .expect("insert present entry");
+        let emb = adapter
+            .embed_entry(
+                &format!("Generic filler entry {i}"),
+                &format!("Routine background content number {i} with no distinctive terms"),
+            )
+            .expect("embed present entry");
+        vi.insert(eid, &emb).await.expect("hnsw insert");
+        store
+            .update_embedding_dim(eid, emb.len() as u16)
+            .await
+            .expect("set embedding_dim");
+        present_ids.push(eid);
+    }
+    vi.dump(&dump_dir).expect("dump graph");
+    let dumped_point_count = vi.point_count();
+    drop(vi); // release the authoring index before the load
+
+    // ---- Phase B: inject the DB-only-copy divergence ----
+    // A NEW active entry with a distinctive body, embedding_dim > 0, and a vector_map
+    // row pointing at a data_id that is NOT in the dumped graph — exactly the state a
+    // DB-only copy leaves: vector_map over-counts what the graph holds. NOTE: no HNSW
+    // point is authored for it, and no `DELETE FROM vector_map` is performed anywhere.
+    let absent_title = "Peculiar tungsten spectroscopy of deep-sea bioluminescence";
+    let absent_content =
+        "unique-marker-xyzzy quantum widget calibration for abyssal photophore telemetry";
+    let absent_id = store
+        .insert(new_entry(absent_title, absent_content))
+        .await
+        .expect("insert absent entry");
+    store
+        .put_vector_mapping(absent_id, ABSENT_DATA_ID)
+        .await
+        .expect("inject graph-absent vector_map row");
+    store
+        .update_embedding_dim(absent_id, 384)
+        .await
+        .expect("set embedding_dim > 0 for absent entry");
+
+    // ---- Phase C: LOAD (the round-trip) — membership filter drops the absent mapping ----
+    let loaded = Arc::new(
+        VectorIndex::load(Arc::clone(&store), VectorConfig::default(), &dump_dir)
+            .await
+            .expect("load index"),
+    );
+    // meta claims the dumped count (>= 1) — NOT the empty-first-boot short-circuit.
+    assert_eq!(loaded.point_count(), dumped_point_count);
+
+    // Leg 1 precondition: contains() is truthful after the filter.
+    for &id in &present_ids {
+        assert!(
+            loaded.contains(id),
+            "graph-present entry {id} must be retained"
+        );
+    }
+    assert!(
+        !loaded.contains(absent_id),
+        "graph-absent entry {absent_id} must be filtered out at load (Leg 1)"
+    );
+
+    // ---- Phase D: wire the server around the LOADED index and drive the heal ----
+    let harness = TestHarness::from_parts(
+        Arc::clone(&store),
+        Arc::clone(&loaded),
+        Arc::clone(&embed_handle),
+    )
+    .await;
+    // Sanity: the entry is not retrievable before the heal (no graph point yet).
+    let before = harness
+        .search(absent_content, 10)
+        .await
+        .expect("pre-heal search");
+    assert!(
+        before.iter().all(|r| r.entry.id != absent_id),
+        "absent entry must NOT be retrievable before the heal"
+    );
+
+    // Same path the running server uses (maintenance_tick → run_maintenance heal Sub-case B).
+    harness.run_maintenance_heal().await;
+
+    // ---- Phase E: Leg 2 — the heal fired and retrieval self-repopulated ----
+    assert!(
+        loaded.contains(absent_id),
+        "heal (Sub-case B) must repopulate the graph-absent entry {absent_id}"
+    );
+    let after = harness
+        .search(absent_content, 10)
+        .await
+        .expect("post-heal search");
+    assert!(
+        after.iter().any(|r| r.entry.id == absent_id),
+        "previously-absent entry {absent_id} must be retrievable after the heal (Leg 2)"
+    );
+}

--- a/crates/unimatrix-vector/Cargo.toml
+++ b/crates/unimatrix-vector/Cargo.toml
@@ -12,6 +12,7 @@ test-support = ["unimatrix-store/test-support", "dep:tempfile", "dep:rand"]
 unimatrix-store = { path = "../unimatrix-store" }
 hnsw_rs = { version = "0.3", features = ["simdeez_f"] }
 anndists = "0.1"
+tracing = "0.1"
 tempfile = { version = "3", optional = true }
 rand = { version = "0.9", optional = true }
 

--- a/crates/unimatrix-vector/src/persistence.rs
+++ b/crates/unimatrix-vector/src/persistence.rs
@@ -1,9 +1,11 @@
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 
 use anndists::dist::DistDot;
 use hnsw_rs::api::AnnT;
 use hnsw_rs::hnswio;
+use tracing::warn;
 use unimatrix_store::SqlxStore;
 
 use crate::config::VectorConfig;
@@ -198,15 +200,59 @@ impl VectorIndex {
             ))
         })?;
 
-        // Rebuild IdMap from VECTOR_MAP
+        // Rebuild IdMap from VECTOR_MAP — but ONLY for entries whose data_id is
+        // actually present in the graph we just loaded. `vector_map` and the HNSW
+        // graph are separate on-disk artifacts; a DB-only copy (unimatrix.db without
+        // the HNSW dir) leaves `vector_map` recording N vectors while the loaded
+        // graph holds fewer. Rebuilding the IdMap blind (GH#972) makes the
+        // IdMap-based `contains()` lie — it returns true for entries with no graph
+        // point, which both suppresses the capped self-heal (status.rs Sub-case B
+        // keys off `!contains`) and saturates `stale_count()` to 0. Filtering to
+        // graph-present data_ids makes `contains()` truthful, so the existing heal
+        // repopulates the absent entries while retained mappings stay searchable.
         let mappings = store.iter_vector_mappings().await?;
+        let recorded = mappings.len();
+
+        // Enumerate origin_ids present in the loaded graph across ALL LAYERS.
+        // hnsw_rs assigns each point to a single, probabilistically chosen level;
+        // ~6% live at level >= 1 and appear ONLY in points_by_layer[L], not layer 0.
+        // Iterate via IterPoint (IntoIterator for &PointIndexation) exactly as
+        // `get_embedding` does — a `get_layer_iterator(0)` scan would wrongly drop
+        // the level>=1 points and heal them needlessly. (GH#286, lesson #1712)
+        let present_origin_ids: HashSet<u64> = {
+            let point_indexation = hnsw.get_point_indexation();
+            let mut present = HashSet::new();
+            for point in point_indexation {
+                present.insert(point.get_origin_id() as u64);
+            }
+            present
+        };
+
+        let filtered: Vec<(u64, u64)> = mappings
+            .into_iter()
+            .filter(|(_entry_id, data_id)| present_origin_ids.contains(data_id))
+            .collect();
+
+        let dropped = recorded - filtered.len();
+        if dropped > 0 {
+            // Previously invisible divergence (#5718): surface it loudly so a
+            // DB-only copy is diagnosable instead of silently degrading retrieval.
+            warn!(
+                recorded,
+                actual = filtered.len(),
+                dropped,
+                "vector_map records more mappings than the loaded HNSW graph holds \
+                 (DB-only copy without the HNSW index dir?); dropping graph-absent \
+                 mappings so contains() is truthful and the capped self-heal can repopulate"
+            );
+        }
 
         Ok(VectorIndex::from_parts(
             hnsw,
             store,
             config,
             next_data_id,
-            mappings,
+            filtered,
         ))
     }
 }
@@ -644,6 +690,122 @@ mod tests {
         for id in &ids {
             assert!(loaded.contains(*id));
         }
+    }
+
+    // -- GH#972: Graph under-counts VECTOR_MAP (DB-only copy) --
+
+    /// A DB-only copy (unimatrix.db without the HNSW index dir) leaves `vector_map`
+    /// recording more mappings than the loaded graph holds. `load` must filter the
+    /// rebuilt IdMap to graph-present data_ids so `contains()` is truthful: FALSE for
+    /// graph-absent entries (letting the capped self-heal repopulate them) and TRUE
+    /// for retained ones. This is the missing "graph-under-counts-DB" test.
+    ///
+    /// N1 GUARD: 200 seeded points make it near-certain (~1-(15/16)^200) that several
+    /// land at level >= 1. Those points live ONLY in points_by_layer[L], not layer 0.
+    /// Asserting ALL 200 are retained proves the load enumeration walks every layer —
+    /// a layer-0-only scan would drop the level>=1 points and wrongly report them absent.
+    #[tokio::test]
+    async fn test_load_graph_undercounts_vector_map_filters_absent_entries() {
+        let tvi = TestVectorIndex::new().await;
+
+        // Seed 200 vectors: writes HNSW points (data_ids 0..199) AND vector_map rows.
+        let present_ids = seed_vectors(tvi.vi(), tvi.store(), 200).await;
+
+        let dump_dir = tvi.dir().join("index");
+        tvi.vi().dump(&dump_dir).unwrap();
+
+        // Simulate the DB-only copy: vector_map gains rows whose data_ids were never
+        // written to the dumped graph (graph holds only the 200 seeded points).
+        // point_count in meta is 200 (>= 1) — NOT the empty-first-boot short-circuit.
+        let absent_ids: Vec<u64> = (10_001..=10_005).collect();
+        for (i, &eid) in absent_ids.iter().enumerate() {
+            // data_ids 1000+ are guaranteed absent from the 0..199 graph.
+            tvi.store()
+                .put_vector_mapping(eid, 1000 + i as u64)
+                .await
+                .unwrap();
+        }
+
+        let loaded = VectorIndex::load(tvi.store().clone(), VectorConfig::default(), &dump_dir)
+            .await
+            .unwrap();
+
+        // Graph-present entries (including any assigned level >= 1) are RETAINED.
+        for &id in &present_ids {
+            assert!(
+                loaded.contains(id),
+                "graph-present entry {id} must be retained (N1: layer-0-only scan would drop level>=1 points)"
+            );
+        }
+
+        // Graph-absent entries are DROPPED — contains() is now truthfully false, so
+        // the capped self-heal (status.rs Sub-case B, keyed off !contains) can repopulate.
+        for &id in &absent_ids {
+            assert!(
+                !loaded.contains(id),
+                "graph-absent entry {id} must be dropped so contains() no longer lies"
+            );
+        }
+    }
+
+    /// Retained (graph-present) points stay searchable after a load that dropped
+    /// graph-absent mappings, and a graph-absent entry can never surface in search.
+    #[tokio::test]
+    async fn test_load_graph_undercounts_retained_points_searchable() {
+        let tvi = TestVectorIndex::new().await;
+
+        // Manual seed so embeddings are retained for self-search verification.
+        let mut embeddings: Vec<Vec<f32>> = Vec::new();
+        let mut present_ids: Vec<u64> = Vec::new();
+        for i in 0..50 {
+            let entry = unimatrix_store::NewEntry {
+                title: format!("Undercount entry {i}"),
+                content: format!("Content {i}"),
+                topic: "test".to_string(),
+                category: "vector".to_string(),
+                tags: vec![],
+                source: "test".to_string(),
+                status: unimatrix_store::Status::Active,
+                created_by: String::new(),
+                feature_cycle: String::new(),
+                trust_source: String::new(),
+            };
+            let eid = tvi.store().insert(entry).await.unwrap();
+            let emb = random_normalized_embedding(384);
+            tvi.vi().insert(eid, &emb).await.unwrap();
+            embeddings.push(emb);
+            present_ids.push(eid);
+        }
+
+        let dump_dir = tvi.dir().join("index");
+        tvi.vi().dump(&dump_dir).unwrap();
+
+        // Inject a graph-absent mapping (DB-only-copy divergence).
+        let absent_id = 20_000u64;
+        tvi.store()
+            .put_vector_mapping(absent_id, 5000)
+            .await
+            .unwrap();
+
+        let loaded = VectorIndex::load(tvi.store().clone(), VectorConfig::default(), &dump_dir)
+            .await
+            .unwrap();
+
+        // Every retained point is still searchable — self-search returns its entry,
+        // and the graph-absent entry never surfaces (it has no graph point).
+        for (emb, &id) in embeddings.iter().zip(present_ids.iter()) {
+            let results = loaded.search(emb, 1, 32).unwrap();
+            assert_eq!(
+                results[0].entry_id, id,
+                "retained entry {id} must remain searchable after load"
+            );
+            assert!(
+                results.iter().all(|r| r.entry_id != absent_id),
+                "graph-absent entry {absent_id} must never surface in search"
+            );
+        }
+
+        assert!(!loaded.contains(absent_id));
     }
 
     // -- IR-03: New Index with Existing VECTOR_MAP --

--- a/product/features/bugfix-972/agents/972-agent-1-fix-report.md
+++ b/product/features/bugfix-972/agents/972-agent-1-fix-report.md
@@ -1,0 +1,27 @@
+# Agent Report: 972-agent-1-fix
+
+Fix summary posted: https://github.com/dug-21/unimatrix/issues/972#issuecomment-5160728876
+
+## Outcome
+Implemented the approved membership-filter in `VectorIndex::load` (`crates/unimatrix-vector/src/persistence.rs`). On the load-SUCCESS branch only, enumerate the loaded graph's `origin_id`s across ALL layers (IterPoint, GH#286), build a HashSet, filter `vector_map` mappings to graph-present `data_id`s before `from_parts`, and `warn!` recorded/actual/dropped. `contains()` is now truthful for graph-absent entries → existing capped heal (status.rs Sub-case B) repopulates them; retained mappings stay searchable. No changes to status.rs, no re-embedding path, no DELETE cure. Added `tracing` dep to unimatrix-vector (was absent).
+
+## Files modified
+- `crates/unimatrix-vector/src/persistence.rs` — filter logic in `load` + 2 tests
+- `crates/unimatrix-vector/Cargo.toml` — add `tracing = "0.1"`
+- `Cargo.lock` — dep resolution
+
+## New tests
+- `test_load_graph_undercounts_vector_map_filters_absent_entries` (N1 guard: 200 points, all retained incl. level>=1; injected absent rows dropped)
+- `test_load_graph_undercounts_retained_points_searchable` (retained self-searchable; absent never surfaces)
+
+## Tests
+- `cargo test -p unimatrix-vector --lib`: 115 passed, 0 failed (2 new)
+- `cargo clippy -p unimatrix-vector --all-targets`: clean
+- `cargo build --workspace --lib`: clean
+
+## Issues / blockers
+- Full-workspace binary link fails on pre-existing environmental `-lonnxruntime` miss (server bin), unrelated to this change. All libs compile.
+
+## Knowledge Stewardship
+- Queried: mcp__unimatrix__context_briefing + context_search(lesson-learned) — #5718 (incident/mechanism), #5272 (boot load-fallback), #1712 (all-layers trap), #2676 (round-trip test), ADR #66/#180.
+- Stored: entry #5719 "Fix for DB-only-copy IdMap/graph divergence (#972): membership-filter at load, NOT DELETE FROM vector_map" via context_store (lesson-learned; edge Supports #5718) — captures shipped fix, corrects #5718's DELETE-cure framing.

--- a/product/features/bugfix-972/agents/972-investigator-report.md
+++ b/product/features/bugfix-972/agents/972-investigator-report.md
@@ -1,0 +1,14 @@
+# Agent Report: 972-investigator
+
+Diagnosis posted: https://github.com/dug-21/unimatrix/issues/972#issuecomment-5160201646
+
+## Outcome
+Root cause identified with high confidence: `VectorIndex::load` (`crates/unimatrix-vector/src/persistence.rs:202`) rebuilds the IdMap from the DB `vector_map` table with no validation against the graph actually loaded from disk. After a DB-only copy, `contains()` (`index.rs:293`) returns true for every entry (heal Sub-case B, `services/status.rs:1119`, matches zero) and `stale_count()` (`index.rs:334`) saturates to 0 (compaction never triggers) — both repair paths structurally blind to DB-vs-index divergence.
+
+Proposed fix (single insertion point, `VectorIndex::load` between `load_hnsw` and `from_parts`): enumerate loaded-graph origin_ids (all layers — IterPoint, GH#286 trap), filter `vector_map` mappings to graph-present data_ids, warn with recorded/actual/dropped counts. Truthful IdMap makes the existing capped heal fire unmodified; retained mappings keep valid points searchable during repopulation. No new healing logic. Cannot reintroduce the #5718 deadlock (removes the shared-source-of-truth lie both legs depended on).
+
+Missing test: load a dump whose graph under-counts `vector_map` → assert `contains()` false for graph-absent entries; server-level tick-heals-and-search round-trip (#2676 pattern).
+
+## Knowledge Stewardship
+- Queried: mcp__unimatrix__context_briefing — #5718 (same incident, mechanism + DELETE cure), #5272 (boot fallback / reuse heal), #3761 (heal invariants), #1712 (all-layers iteration trap), #2676 (test pattern); context_get full text on #5718, #5272, #3761.
+- Stored: nothing novel to store — root-cause mechanism already captured in lesson #5718; fix-side insight deferred to post-implementation retro.

--- a/product/test/infra-001/Dockerfile
+++ b/product/test/infra-001/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install ONNX Runtime 1.20.1 shared library (matches ort 2.0.0-rc.9)
 RUN wget -q https://github.com/microsoft/onnxruntime/releases/download/v1.20.1/onnxruntime-linux-x64-1.20.1.tgz \
     && tar xzf onnxruntime-linux-x64-1.20.1.tgz \
-    && cp onnxruntime-linux-x64-1.20.1/lib/* /usr/local/lib/ \
+    && cp -a onnxruntime-linux-x64-1.20.1/lib/*.so* /usr/local/lib/ \
     && ldconfig \
     && rm -rf onnxruntime-linux-x64-1.20.1*
 

--- a/product/test/infra-001/docker-compose.yml
+++ b/product/test/infra-001/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   test-runner:
     build:
-      context: ../..
+      context: ../../..
       dockerfile: product/test/infra-001/Dockerfile
       target: test-runtime
     environment:


### PR DESCRIPTION
## Summary
Fixes #972. After copying only `unimatrix.db` + `config.toml` (no HNSW index files) to a new location, the DB `vector_map` table recorded N vectors but the loaded HNSW graph held fewer (0 in the empty case). Because `VectorIndex::load` rebuilt the in-memory IdMap from `vector_map` with **no cross-check against the loaded graph**, `contains()` returned true for absent entries — so the existing capped heal (Sub-case B, keyed off `!contains`) never fired and retrieval silently degraded. This is the #5718 host-migration deadlock, whose only prior cure was a manual `DELETE FROM vector_map`.

## Fix
Inside `VectorIndex::load`, on the load-**success** branch only: enumerate the loaded HNSW graph's origin_ids across **all layers** (via `IterPoint` — the layer-0-only trap would drop the ~6% of points at level ≥1, GH#286/#1712), and filter the `vector_map` mappings to only graph-present data_ids **before** `from_parts`. This makes `contains()` truthful → the **existing** capped maintenance heal repopulates only the genuinely-missing entries. Retained mappings keep valid points searchable. A `warn!` reports recorded/actual/dropped counts (previously-invisible divergence).

- **No** changes to `status.rs`, **no** new re-embed path, **no** eager rebuild, **no** DELETE cure.
- Hard-`Err` degradation path (#5272) untouched.
- Chosen over the issue's literal "two-count compare": a count compare can't make the heal fire (Sub-case B keys off the still-lying `contains()`) and counts can coincidentally match via stale points. Endorsed by architect + product review.

## Changed files
- `crates/unimatrix-vector/src/persistence.rs` — membership filter in `VectorIndex::load` + 2 new tests
- `crates/unimatrix-vector/Cargo.toml` — `tracing` dep (for the `warn!`)
- `Cargo.lock`
- `product/features/bugfix-972/agents/972-investigator-report.md`

## Tests
- `test_load_graph_undercounts_vector_map_filters_absent_entries` — loads a dump whose graph (200 points) under-counts `vector_map` (5 injected graph-absent rows); asserts `contains()` false for absent, true for all 200 present (level ≥1 retention = the N1 guard).
- `test_load_graph_undercounts_retained_points_searchable` — retained points still self-search back; the absent entry never surfaces.
- 657 unit tests passing, 0 failures. `unimatrix-vector` clippy clean under `-D warnings`.

## Gate
Bug Fix Validation — **PASS** (6/7, 1 N/A). Minimal diff, root cause addressed, stewardship present for all phases.

## ⚠️ Pre-merge precondition
The mandatory **infra-001 integration smoke gate could not run in this container** (`libonnxruntime` absent system-wide + pytest uninstallable under PEP-668 — both pre-existing/environmental, not introduced here). **Run the infra-001 smoke suite via the Docker harness before merging.**

Pre-existing, unrelated (NOT in this diff): workspace clippy error at `transcript_hold.rs:268` → filed as #973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)